### PR TITLE
Improvements for git worktrees

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,9 @@
   "name": "cal-io",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/workspaces/cal-io",
-
-  "forwardPorts": [3000, 5173],
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "initializeCommand": "bash .devcontainer/init-devcontainer-env.sh",
 
   "onCreateCommand": "npm install -g @openai/codex",
-  "postCreateCommand": "npm run setup:devcontainer"
+  "postCreateCommand": "npm run setup:devcontainer && node .devcontainer/update-peacock-settings.mjs"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,12 +4,22 @@ services:
   app:
     image: mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
     volumes:
-      - ..:/workspaces/cal-io:cached
+      - ..:/workspaces/${WORKSPACE_FOLDER_NAME}:cached
+    ports:
+      - "${BACKEND_PORT}:3000"
+      - "${FRONTEND_PORT}:${FRONTEND_PORT}"
     command: sleep infinity
     environment:
       DATABASE_URL: postgresql://user:password@postgres:5432/fitness_app?schema=public
       PORT: 3000
       SESSION_SECRET: development_secret_key
+      WORKTREE_COLOR: ${WORKTREE_COLOR}
+      WORKTREE_IS_MAIN: ${WORKTREE_IS_MAIN}
+      WORKTREE_NAME: ${WORKTREE_NAME}
+      VITE_DEV_SERVER_PORT: ${VITE_DEV_SERVER_PORT}
+      VITE_WORKTREE_COLOR: ${VITE_WORKTREE_COLOR}
+      VITE_WORKTREE_NAME: ${VITE_WORKTREE_NAME}
+      VITE_WORKTREE_IS_MAIN: ${VITE_WORKTREE_IS_MAIN}
     depends_on:
       - postgres
 

--- a/.devcontainer/init-devcontainer-env.sh
+++ b/.devcontainer/init-devcontainer-env.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace_root="$(pwd)"
+workspace_name="$(basename "$workspace_root")"
+project_slug="$(printf '%s' "$workspace_name" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed -e 's/^-*//' -e 's/-*$//')"
+is_main_worktree="false"
+
+if [ -d "${workspace_root}/.git" ]; then
+  is_main_worktree="true"
+fi
+
+if [ -z "$project_slug" ]; then
+  project_slug="cal-io"
+fi
+
+hash="$(printf '%s' "$workspace_name" | cksum | awk '{print $1}')"
+offset="$((hash % 1000))"
+
+backend_port="$((3000 + offset))"
+frontend_port="$((5173 + offset))"
+base_peacock_color="#007fff"
+worktree_colors=(
+  "#0f766e"
+  "#0e7490"
+  "#2f855a"
+  "#4d7c0f"
+  "#b45309"
+  "#c2410c"
+  "#b91c1c"
+  "#a21caf"
+  "#6d28d9"
+  "#4b5563"
+)
+color_index="$((hash % ${#worktree_colors[@]}))"
+derived_color="${worktree_colors[$color_index]}"
+
+worktree_color="$derived_color"
+vite_worktree_color="$derived_color"
+
+if [ "$is_main_worktree" = "true" ]; then
+  worktree_color="$base_peacock_color"
+  vite_worktree_color=""
+fi
+
+env_path=".devcontainer/.env"
+tmp_path="${env_path}.tmp"
+
+cat > "$tmp_path" <<EOF
+COMPOSE_PROJECT_NAME=${project_slug}
+WORKSPACE_FOLDER_NAME=${workspace_name}
+BACKEND_PORT=${backend_port}
+FRONTEND_PORT=${frontend_port}
+VITE_DEV_SERVER_PORT=${frontend_port}
+WORKTREE_NAME=${workspace_name}
+WORKTREE_IS_MAIN=${is_main_worktree}
+WORKTREE_COLOR=${worktree_color}
+VITE_WORKTREE_COLOR=${vite_worktree_color}
+VITE_WORKTREE_NAME=${workspace_name}
+VITE_WORKTREE_IS_MAIN=${is_main_worktree}
+EOF
+
+if [ -f "$env_path" ] && cmp -s "$tmp_path" "$env_path"; then
+  rm "$tmp_path"
+else
+  mv "$tmp_path" "$env_path"
+fi

--- a/.devcontainer/update-peacock-settings.mjs
+++ b/.devcontainer/update-peacock-settings.mjs
@@ -1,0 +1,163 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Normalize a hex color string to #RRGGBB or return null when invalid.
+ */
+function normalizeHexColor(value) {
+    const trimmed = value.trim();
+    const hex = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed;
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) return null;
+    return `#${hex.toLowerCase()}`;
+}
+
+/**
+ * Parse a #RRGGBB hex color into RGB components.
+ */
+function parseHexColor(hex) {
+    const normalized = normalizeHexColor(hex);
+    if (!normalized) return null;
+    const raw = normalized.slice(1);
+    return {
+        r: Number.parseInt(raw.slice(0, 2), 16),
+        g: Number.parseInt(raw.slice(2, 4), 16),
+        b: Number.parseInt(raw.slice(4, 6), 16)
+    };
+}
+
+/**
+ * Format an RGB color as #RRGGBB.
+ */
+function formatHexColor({ r, g, b }) {
+    return `#${toHexByte(r)}${toHexByte(g)}${toHexByte(b)}`;
+}
+
+/**
+ * Lighten a #RRGGBB color by the given ratio (0-1).
+ */
+function lightenHexColor(hex, ratio) {
+    const color = parseHexColor(hex);
+    if (!color) return null;
+    return formatHexColor({
+        r: Math.round(color.r + (255 - color.r) * ratio),
+        g: Math.round(color.g + (255 - color.g) * ratio),
+        b: Math.round(color.b + (255 - color.b) * ratio)
+    });
+}
+
+/**
+ * Apply an alpha channel to a #RRGGBB color and return #RRGGBBAA.
+ */
+function applyAlpha(hex, alpha) {
+    const color = parseHexColor(hex);
+    if (!color) return null;
+    const alphaByte = clampByte(Math.round(alpha * 255));
+    return `${formatHexColor(color)}${toHexByte(alphaByte)}`;
+}
+
+/**
+ * Estimate relative luminance for an RGB color in 0-1.
+ */
+function relativeLuminance({ r, g, b }) {
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+/**
+ * Pick a readable foreground color for a background.
+ */
+function pickForegroundColor(hex) {
+    const color = parseHexColor(hex);
+    if (!color) return '#e7e7e7';
+    return relativeLuminance(color) > 0.6 ? '#15202b' : '#e7e7e7';
+}
+
+/**
+ * Clamp a number to the 0-255 byte range.
+ */
+function clampByte(value) {
+    return Math.max(0, Math.min(255, value));
+}
+
+/**
+ * Convert a number in the 0-255 range to a two-digit hex byte.
+ */
+function toHexByte(value) {
+    return clampByte(value).toString(16).padStart(2, '0');
+}
+
+/**
+ * Read VS Code settings JSON, returning an empty object if missing.
+ */
+async function readSettings(filePath) {
+    try {
+        const raw = await fs.readFile(filePath, 'utf8');
+        return JSON.parse(raw);
+    } catch (error) {
+        if (error && error.code === 'ENOENT') {
+            return {};
+        }
+        throw error;
+    }
+}
+
+/**
+ * Write VS Code settings JSON with stable formatting.
+ */
+async function writeSettings(filePath, data) {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const content = `${JSON.stringify(data, null, 4)}\n`;
+    await fs.writeFile(filePath, content, 'utf8');
+}
+
+const workspaceRoot = process.cwd();
+const settingsPath = path.join(workspaceRoot, '.vscode', 'settings.json');
+
+const rawColor = process.env.WORKTREE_COLOR ?? '';
+const baseColor = normalizeHexColor(rawColor);
+
+if (!baseColor) {
+    process.exit(0);
+}
+
+const activeBackground = lightenHexColor(baseColor, 0.2) ?? baseColor;
+const activeForeground = pickForegroundColor(activeBackground);
+const inactiveForeground = applyAlpha(activeForeground, 0.6) ?? activeForeground;
+const baseForeground = pickForegroundColor(baseColor);
+const baseInactiveForeground = applyAlpha(baseForeground, 0.6) ?? baseForeground;
+const baseInactiveBackground = applyAlpha(baseColor, 0.6) ?? baseColor;
+
+const colorCustomizations = {
+    'activityBar.activeBackground': activeBackground,
+    'activityBar.background': activeBackground,
+    'activityBar.foreground': activeForeground,
+    'activityBar.inactiveForeground': inactiveForeground,
+    'activityBarBadge.background': '#bf0060',
+    'activityBarBadge.foreground': '#e7e7e7',
+    'commandCenter.border': applyAlpha(baseForeground, 0.6) ?? baseForeground,
+    'sash.hoverBorder': activeBackground,
+    'statusBar.background': baseColor,
+    'statusBar.foreground': baseForeground,
+    'statusBarItem.hoverBackground': activeBackground,
+    'statusBarItem.remoteBackground': baseColor,
+    'statusBarItem.remoteForeground': baseForeground,
+    'titleBar.activeBackground': baseColor,
+    'titleBar.activeForeground': baseForeground,
+    'titleBar.inactiveBackground': baseInactiveBackground,
+    'titleBar.inactiveForeground': baseInactiveForeground
+};
+
+const settings = await readSettings(settingsPath);
+const existingCustomizations = settings['workbench.colorCustomizations'];
+const mergedCustomizations = {
+    ...(existingCustomizations && typeof existingCustomizations === 'object' ? existingCustomizations : {}),
+    ...colorCustomizations
+};
+
+const nextSettings = {
+    ...settings,
+    'peacock.color': baseColor,
+    'peacock.remoteColor': baseColor,
+    'workbench.colorCustomizations': mergedCustomizations
+};
+
+await writeSettings(settingsPath, nextSettings);

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 backend/.env
 .DS_Store
 coverage
+.devcontainer/.env
+.vscode/settings.json

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -32,6 +32,9 @@ const Layout: React.FC = () => {
     const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
     const navigate = useNavigate();
     const location = useLocation();
+    const worktreeName = import.meta.env.VITE_WORKTREE_NAME?.trim();
+    const isMainWorktree = import.meta.env.VITE_WORKTREE_IS_MAIN === 'true';
+    const worktreeBadgeLabel = worktreeName && !isMainWorktree ? worktreeName : null;
 
     const hideNav = location.pathname.startsWith('/onboarding');
     const showDrawer = Boolean(user) && !isLoading && !hideNav;
@@ -125,14 +128,34 @@ const Layout: React.FC = () => {
                         </IconButton>
                     )}
 
-                    <Typography
-                        variant="h6"
-                        component={RouterLink}
-                        to="/dashboard"
-                        sx={{ color: 'inherit', textDecoration: 'none' }}
-                    >
-                        cal-io
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography
+                            variant="h6"
+                            component={RouterLink}
+                            to="/dashboard"
+                            sx={{ color: 'inherit', textDecoration: 'none' }}
+                        >
+                            cal-io
+                        </Typography>
+                        {worktreeBadgeLabel && (
+                            <Box
+                                component="span"
+                                sx={{
+                                    border: '1px solid rgba(255, 255, 255, 0.5)',
+                                    borderRadius: 1,
+                                    px: 1,
+                                    py: 0.25,
+                                    fontSize: '0.7rem',
+                                    fontWeight: 600,
+                                    lineHeight: 1,
+                                    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+                                    letterSpacing: '0.04em'
+                                }}
+                            >
+                                {worktreeBadgeLabel}
+                            </Box>
+                        )}
+                    </Box>
                 </Toolbar>
             </AppBar>
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,5 +1,20 @@
 import { createTheme } from '@mui/material/styles';
 
+const worktreeColor = import.meta.env.VITE_WORKTREE_COLOR?.trim();
+const isMainWorktree = import.meta.env.VITE_WORKTREE_IS_MAIN === 'true';
+const appBarColor = !isMainWorktree && worktreeColor ? worktreeColor : undefined;
+const appBarOverrides = appBarColor
+    ? {
+          MuiAppBar: {
+              styleOverrides: {
+                  root: {
+                      backgroundColor: appBarColor
+                  }
+              }
+          }
+      }
+    : {};
+
 const theme = createTheme({
     palette: {
         mode: 'light',
@@ -18,6 +33,7 @@ const theme = createTheme({
         borderRadius: 10
     },
     components: {
+        ...appBarOverrides,
         MuiPaper: {
             defaultProps: {
                 elevation: 2

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,12 +20,18 @@ const usePolling =
   process.env.VITE_USE_POLLING === 'true' ||
   process.env.VITE_USE_POLLING === '1' ||
   isRunningInContainer()
+const devServerPortEnv = process.env.VITE_DEV_SERVER_PORT
+const devServerPortValue = devServerPortEnv ? Number.parseInt(devServerPortEnv, 10) : undefined
+const devServerPort =
+  Number.isFinite(devServerPortValue) && devServerPortValue > 0 ? devServerPortValue : undefined
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
+    port: devServerPort,
+    strictPort: devServerPort !== undefined,
     watch: usePolling ? { usePolling: true, interval: 100 } : undefined,
     proxy: {
       '/auth': 'http://localhost:3000',


### PR DESCRIPTION
Adding robust support for worktree development, with hashed port offsets and customized colors for Peacock in VS Code and in the frontend appbar for easy recognition.

  - /.devcontainer/devcontainer.json: worktree‑specific workspaceFolder,
    initializeCommand to generate env, and postCreateCommand now runs the
    Peacock updater.
  - /.devcontainer/docker-compose.yml: worktree‑specific bind mount and port
    mapping; passes VITE_DEV_SERVER_PORT, worktree metadata, and color envs into
    the container.
  - /.devcontainer/init-devcontainer-env.sh: new script that derives
    COMPOSE_PROJECT_NAME, port offsets, worktree name/main flag, and a
    deterministic color; writes .devcontainer/.env.
  - /.devcontainer/update-peacock-settings.mjs: new script that updates Peacock
    keys and merges workbench.colorCustomizations based on the worktree color.
  - /.gitignore: ignores .devcontainer/.env and .vscode/settings.json (both now
    generated per worktree).
  - frontend/vite.config.ts: Vite server reads VITE_DEV_SERVER_PORT and uses
    strictPort so the log shows the real host port.
  - frontend/src/components/Layout.tsx: conditional worktree badge next to the
    app title for non‑main worktrees.
  - frontend/src/theme.ts: overrides MuiAppBar background with
    VITE_WORKTREE_COLOR for non‑main worktrees only.