### PR TITLE
Customizing frontend page title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>cal.io</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,19 @@ import { AuthProvider } from './context/AuthContext.tsx'
 
 const queryClient = new QueryClient()
 
+/**
+ * Build the browser tab title, adding the dev worktree name when available.
+ */
+function getBrowserTitle() {
+  const baseTitle = 'cal.io'
+  if (!import.meta.env.DEV) return baseTitle
+  const worktreeName = __WORKTREE_NAME__?.trim()
+  if (!worktreeName) return baseTitle
+  return `${worktreeName}.cal.io`
+}
+
+document.title = getBrowserTitle()
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __WORKTREE_NAME__: string | null

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -16,6 +18,22 @@ function isRunningInContainer() {
   }
 }
 
+/**
+ * Derive the worktree name from the repo root directory for dev-only labeling.
+ */
+function getWorktreeNameFromRepoRoot(repoRootName: string) {
+  if (repoRootName === 'cal-io') return null
+  if (repoRootName.startsWith('cal-io-')) {
+    const suffix = repoRootName.slice('cal-io-'.length)
+    return suffix.length > 0 ? suffix : null
+  }
+  return repoRootName.length > 0 ? repoRootName : null
+}
+
+const frontendDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRootName = path.basename(path.resolve(frontendDir, '..'))
+const worktreeName = getWorktreeNameFromRepoRoot(repoRootName)
+
 const usePolling =
   process.env.VITE_USE_POLLING === 'true' ||
   process.env.VITE_USE_POLLING === '1' ||
@@ -28,6 +46,9 @@ const devServerPort =
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __WORKTREE_NAME__: JSON.stringify(worktreeName),
+  },
   server: {
     host: true,
     port: devServerPort,


### PR DESCRIPTION
Setting frontend page title (appearing in tab) from 'frontend' to 'cal.io'. When working in a non-main worktree, instead uses <branch>.cal.io (like alpha.cal.io).