### PR TITLE
Log: Add bottom padding so entries clear FAB

### DIFF
--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -39,6 +39,15 @@ type FoodLogEntry = {
     calories: number;
 };
 
+const LOG_FAB_DIAMETER_SPACING = 7; // Default MUI "large" Fab is 56px (7 * 8).
+const LOG_FAB_CONTENT_CLEARANCE_SPACING = 2; // Extra room so bottom-row actions aren't tight against the FAB.
+const LOG_FAB_BOTTOM_NAV_GAP_SPACING = 1; // Our FAB sits 8px above the reserved bottom-nav space on mobile.
+
+const LOG_PAGE_BOTTOM_PADDING = {
+    xs: LOG_FAB_DIAMETER_SPACING + LOG_FAB_CONTENT_CLEARANCE_SPACING + LOG_FAB_BOTTOM_NAV_GAP_SPACING,
+    md: LOG_FAB_DIAMETER_SPACING + LOG_FAB_CONTENT_CLEARANCE_SPACING
+} as const;
+
 const Log: React.FC = () => {
     const queryClient = useQueryClient();
     const { user } = useAuth();
@@ -63,7 +72,7 @@ const Log: React.FC = () => {
     const handleCloseWeightDialog = () => setIsWeightDialogOpen(false);
 
     return (
-        <Box>
+        <Box sx={{ pb: LOG_PAGE_BOTTOM_PADDING }}>
             <Box
                 sx={{
                     display: 'flex',


### PR DESCRIPTION
Problem
- The /log page uses a fixed SpeedDial FAB in the bottom-right.
- With minimal bottom spacing, the last items in the food log can end up behind the FAB (e.g., Evening Snack delete is hard to tap).

Solution
- Add responsive bottom padding to the /log page container sized to clear the FAB, with a small extra clearance for tap targets (and a mobile offset for the bottom-nav gap).

Testing
- On a small viewport, scroll to the bottom of the log and confirm the final meal row actions (Delete) are fully visible above the FAB.