### PR TITLE
Settings: Fix timezone selector overflow + unify styling

### DIFF
--- a/frontend/src/components/TimeZonePicker.tsx
+++ b/frontend/src/components/TimeZonePicker.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box, FormHelperText, Typography } from '@mui/material';
-import { alpha, useTheme } from '@mui/material/styles';
-import TimezoneSelect, { type ITimezoneOption } from 'react-timezone-select';
+import { Autocomplete, TextField } from '@mui/material';
+import { useTimezoneSelect, type ITimezoneOption } from 'react-timezone-select';
 
 type Props = {
     /** Current IANA timezone identifier (e.g. "America/Los_Angeles"). */
@@ -14,92 +13,78 @@ type Props = {
 };
 
 /**
+ * Format the current time in the supplied time zone. Returns null when the time zone is missing/invalid.
+ */
+function getCurrentTimeLabel(timeZone: string, now: Date): string | null {
+    const trimmed = timeZone.trim();
+    if (!trimmed) return null;
+
+    try {
+        return new Intl.DateTimeFormat(undefined, {
+            timeZone: trimmed,
+            hour: '2-digit',
+            minute: '2-digit'
+        }).format(now);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Concatenate a user-provided helper message with a "current time there" suffix.
+ */
+function buildHelperLine(helperText: string | undefined, currentTimeLabel: string | null): string | undefined {
+    const parts = [];
+    if (helperText) parts.push(helperText);
+    if (currentTimeLabel) parts.push(`Current time there: ${currentTimeLabel}`);
+    return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+/**
  * TimeZonePicker
  *
- * Uses `react-timezone-select` to avoid maintaining our own timezone list/labels.
- * Shows the current time for the selected zone so users can sanity-check the choice.
+ * Uses `react-timezone-select` for a sane timezone list + labels, but renders with MUI so it
+ * looks/behaves like the rest of our form controls (portal dropdown, consistent theming).
  */
 const TimeZonePicker: React.FC<Props> = ({ value, onChange, label = 'Timezone', helperText, disabled }) => {
-    const theme = useTheme();
     const [now, setNow] = useState<Date>(() => new Date());
+    const { options } = useTimezoneSelect({ labelStyle: 'original', displayValue: 'UTC' });
 
     useEffect(() => {
         const interval = setInterval(() => setNow(new Date()), 60_000);
         return () => clearInterval(interval);
     }, []);
 
-    const currentTimeLabel = useMemo(() => {
+    const currentTimeLabel = useMemo(() => getCurrentTimeLabel(value, now), [now, value]);
+    const helperLine = useMemo(() => buildHelperLine(helperText, currentTimeLabel), [currentTimeLabel, helperText]);
+
+    const selectedOption = useMemo<ITimezoneOption | undefined>(() => {
         const trimmed = value.trim();
-        if (!trimmed) return null;
-
-        try {
-            return new Intl.DateTimeFormat(undefined, {
-                timeZone: trimmed,
-                hour: '2-digit',
-                minute: '2-digit'
-            }).format(now);
-        } catch {
-            return null;
-        }
-    }, [now, value]);
-
-    const helperLine = useMemo(() => {
-        const parts = [];
-        if (helperText) parts.push(helperText);
-        if (currentTimeLabel) parts.push(`Current time there: ${currentTimeLabel}`);
-        return parts.join(' ');
-    }, [currentTimeLabel, helperText]);
+        if (!trimmed) return undefined;
+        return options.find((option) => option.value === trimmed) ?? { value: trimmed, label: trimmed };
+    }, [options, value]);
 
     return (
-        <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
-                {label}
-            </Typography>
-
-            <TimezoneSelect
-                value={value}
-                onChange={(option: ITimezoneOption) => onChange(option.value)}
-                displayValue="UTC"
-                labelStyle="original"
-                isDisabled={disabled}
-                styles={{
-                    container: (base) => ({ ...base, width: '100%' }),
-                    control: (base, state) => ({
-                        ...base,
-                        minHeight: 56,
-                        backgroundColor: theme.palette.background.paper,
-                        borderColor: state.isFocused ? theme.palette.primary.main : theme.palette.divider,
-                        boxShadow: state.isFocused ? `0 0 0 2px ${alpha(theme.palette.primary.main, 0.2)}` : 'none',
-                        ':hover': {
-                            borderColor: state.isFocused ? theme.palette.primary.main : theme.palette.text.primary
-                        }
-                    }),
-                    menu: (base) => ({
-                        ...base,
-                        zIndex: 1300,
-                        backgroundColor: theme.palette.background.paper
-                    }),
-                    menuList: (base) => ({
-                        ...base,
-                        backgroundColor: theme.palette.background.paper
-                    }),
-                    option: (base, state) => ({
-                        ...base,
-                        color: theme.palette.text.primary,
-                        backgroundColor: state.isSelected
-                            ? theme.palette.action.selected
-                            : state.isFocused
-                                ? theme.palette.action.hover
-                                : theme.palette.background.paper
-                    }),
-                    singleValue: (base) => ({ ...base, color: theme.palette.text.primary }),
-                    placeholder: (base) => ({ ...base, color: theme.palette.text.secondary }),
-                    input: (base) => ({ ...base, color: theme.palette.text.primary })
-                }}
-            />
-
-            {helperLine && <FormHelperText sx={{ mt: 0.75 }}>{helperLine}</FormHelperText>}
-        </Box>
+        <Autocomplete
+            options={options}
+            value={selectedOption}
+            onChange={(_, next) => {
+                if (next) onChange(next.value);
+            }}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, selected) => option.value === selected.value}
+            disableClearable
+            disabled={disabled}
+            fullWidth
+            disablePortal={false}
+            sx={{
+                // Match MUI <Select /> cursor affordance on desktop (avoid I-beam text cursor).
+                '& .MuiInputBase-root': { cursor: 'pointer' },
+                '& .MuiInputBase-root input': { cursor: 'pointer' },
+                '& .MuiAutocomplete-endAdornment': { cursor: 'pointer' }
+            }}
+            renderInput={(params) => <TextField {...params} label={label} helperText={helperLine} />}
+        />
     );
 };
 


### PR DESCRIPTION
## Problem
On `/settings` -> "Units & Localization", the timezone selector (react-timezone-select / react-select):
- Rendered its menu inside the parent Card (which uses `overflow: hidden` via MUI `Card`), so the dropdown was clipped/truncated.
- Looked noticeably different from the rest of our MUI form controls (radius, floating label behavior, colors).

## Approach
Keep `react-timezone-select` for the timezone list + label formatting, but render the actual control using MUI components:
- Use `useTimezoneSelect()` to generate the timezone `options`.
- Render with MUI `Autocomplete` + `TextField` for consistent theming and a portaled dropdown menu.
- Force a pointer cursor on hover to match MUI `<Select />` (Autocomplete defaults to the I-beam cursor).

## Code Pointers
- `frontend/src/components/TimeZonePicker.tsx`
  - Replace `TimezoneSelect` (react-select) with MUI `Autocomplete`.
  - Ensure the dropdown renders outside cards via Popper portal (`disablePortal={false}`).
  - Preserve the existing "Current time there" helper UX via `getCurrentTimeLabel()` and `buildHelperLine()`.

## Verification
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
