### PR TITLE
Make Calorie Target actionable + auto-save profile inputs

### DIFF
--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -157,11 +157,15 @@ router.patch('/profile', async (req, res) => {
   }
 
   if (date_of_birth !== undefined) {
-    const parsedDate = new Date(date_of_birth);
-    if (Number.isNaN(parsedDate.getTime())) {
-      return res.status(400).json({ message: 'Invalid date_of_birth' });
+    if (date_of_birth === null || date_of_birth === '') {
+      updateData.date_of_birth = null;
+    } else {
+      const parsedDate = new Date(date_of_birth);
+      if (Number.isNaN(parsedDate.getTime())) {
+        return res.status(400).json({ message: 'Invalid date_of_birth' });
+      }
+      updateData.date_of_birth = parsedDate;
     }
-    updateData.date_of_birth = parsedDate;
   }
 
   if (sex !== undefined) {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ const Dashboard: React.FC = () => {
 
     return (
         <Box>
-            <CalorieTargetBanner />
+            <CalorieTargetBanner isDashboard />
 
             <Grid container spacing={3} alignItems="stretch">
                 <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex' }}>

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '../context/useAuth';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { activityLevelOptions } from '../constants/activityLevels';
-import { useQuery } from '@tanstack/react-query';
+import { useUserProfileQuery } from '../queries/userProfile';
 import { validateGoalWeights } from '../utils/goalValidation';
 import { formatDateToLocalDateString } from '../utils/date';
 import TimeZonePicker from '../components/TimeZonePicker';
@@ -77,14 +77,7 @@ const Onboarding: React.FC = () => {
         height_inches?: string | null;
     };
 
-    const profileQuery = useQuery({
-        queryKey: ['profile'],
-        queryFn: async () => {
-            const res = await axios.get('/api/user/profile');
-            return res.data;
-        },
-        enabled: !!user
-    });
+    const profileQuery = useUserProfileQuery({ enabled: !!user });
 
     useEffect(() => {
         if (profileQuery.isSuccess) {

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,8 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     Alert,
     Box,
-    Button,
     FormControl,
     Link,
     InputLabel,
@@ -13,41 +12,17 @@ import {
     Typography
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { Link as RouterLink } from 'react-router-dom';
+import CalorieTargetBanner from '../components/CalorieTargetBanner';
 import { activityLevelOptions } from '../constants/activityLevels';
-import TimeZonePicker from '../components/TimeZonePicker';
+import type { UserProfilePatchPayload } from '../context/authContext';
 import { useAuth } from '../context/useAuth';
+import { useUserProfileQuery } from '../queries/userProfile';
 import AppPage from '../ui/AppPage';
 import AppCard from '../ui/AppCard';
 import { getDefaultHeightUnitForWeightUnit } from '../utils/unitPreferences';
 
-type ProfileResponse = {
-    profile: {
-        timezone: string | null;
-        date_of_birth: string | null;
-        sex: 'MALE' | 'FEMALE' | null;
-        height_mm: number | null;
-        activity_level: 'SEDENTARY' | 'LIGHT' | 'MODERATE' | 'ACTIVE' | 'VERY_ACTIVE' | null;
-        weight_unit: 'KG' | 'LB';
-    };
-    calorieSummary: {
-        dailyCalorieTarget?: number;
-        tdee?: number;
-        missing: string[];
-    };
-};
-
-type ProfileUpdatePayload = {
-    timezone: string | null;
-    date_of_birth: string | null;
-    sex: string | null;
-    activity_level: string | null;
-    height_cm?: string | null;
-    height_feet?: string | null;
-    height_inches?: string | null;
-};
+const AUTOSAVE_DELAY_MS = 450;
 
 type ParsedHeight = {
     cm: number;
@@ -67,15 +42,50 @@ function parseHeightFromMillimeters(mm: number): ParsedHeight {
 }
 
 /**
+ * Convert a draft input string to a patch-friendly nullable string.
+ *
+ * Notes:
+ * - Empty strings are sent as null so the backend can clear optional fields.
+ * - Whitespace is trimmed to avoid accidental invalid values.
+ */
+function normalizePatchString(value: string): string | null {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Build a height patch from ft/in inputs.
+ *
+ * When both fields are empty, this explicitly clears the stored height via `height_mm: null`
+ * (the backend interprets blank ft/in as 0 which would otherwise be invalid).
+ */
+function buildFeetInchesHeightPatch(feet: string, inches: string): UserProfilePatchPayload {
+    const normalizedFeet = normalizePatchString(feet);
+    const normalizedInches = normalizePatchString(inches);
+
+    if (normalizedFeet === null && normalizedInches === null) {
+        return { height_mm: null };
+    }
+
+    return { height_feet: normalizedFeet, height_inches: normalizedInches };
+}
+
+/**
  * Profile is the dedicated page for editing user-specific profile fields used for calorie math.
  */
 const Profile: React.FC = () => {
     const theme = useTheme();
     const { user, updateProfile } = useAuth();
     const sectionGap = theme.custom.layout.page.sectionGap;
-    const [profileMessage, setProfileMessage] = useState('');
 
-    const [timezone, setTimezone] = useState<string | null>(null);
+    const autosaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const savedMessageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pendingPatchRef = useRef<UserProfilePatchPayload>({});
+    const isSavingRef = useRef(false);
+
+    const [autosaveStatus, setAutosaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+    const [autosaveError, setAutosaveError] = useState<string | null>(null);
+
     const [dateOfBirth, setDateOfBirth] = useState<string | null>(null);
     const [sex, setSex] = useState<string | null>(null);
     const [heightCm, setHeightCm] = useState<string | null>(null);
@@ -83,20 +93,20 @@ const Profile: React.FC = () => {
     const [heightInches, setHeightInches] = useState<string | null>(null);
     const [activityLevel, setActivityLevel] = useState<string | null>(null);
 
-    const profileQuery = useQuery({
-        queryKey: ['profile'],
-        queryFn: async (): Promise<ProfileResponse> => {
-            const res = await axios.get('/api/user/profile');
-            return res.data;
-        }
-    });
+    const profileQuery = useUserProfileQuery();
 
-    const timezoneValue = useMemo(() => {
-        if (timezone !== null) return timezone;
-        const value = profileQuery.data?.profile.timezone;
-        if (value) return value;
-        return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-    }, [profileQuery.data?.profile.timezone, timezone]);
+    useEffect(() => {
+        return () => {
+            if (autosaveTimeoutRef.current) {
+                clearTimeout(autosaveTimeoutRef.current);
+                autosaveTimeoutRef.current = null;
+            }
+            if (savedMessageTimeoutRef.current) {
+                clearTimeout(savedMessageTimeoutRef.current);
+                savedMessageTimeoutRef.current = null;
+            }
+        };
+    }, []);
 
     const dobValue = useMemo(() => {
         if (dateOfBirth !== null) return dateOfBirth;
@@ -143,71 +153,129 @@ const Profile: React.FC = () => {
         return value ?? '';
     }, [activityLevel, profileQuery.data?.profile.activity_level]);
 
-    const handleProfileSave = async () => {
-        try {
-            const payload: ProfileUpdatePayload = {
-                timezone: timezoneValue || null,
-                date_of_birth: dobValue || null,
-                sex: sexValue || null,
-                activity_level: activityValue || null
-            };
+    /**
+     * Flush any queued changes to the backend.
+     *
+     * Uses a ref-backed patch buffer so rapid edits across multiple inputs are saved together.
+     */
+    const flushAutosave = useCallback(async () => {
+        if (isSavingRef.current) return;
 
-            if (heightUnit === 'CM') {
-                payload.height_cm = heightCmValue || null;
-            } else {
-                payload.height_feet = heightFeetValue || null;
-                payload.height_inches = heightInchesValue || null;
+        const patch = pendingPatchRef.current;
+        if (Object.keys(patch).length === 0) return;
+
+        pendingPatchRef.current = {};
+        isSavingRef.current = true;
+        setAutosaveStatus('saving');
+        setAutosaveError(null);
+
+        try {
+            await updateProfile(patch);
+            setAutosaveStatus('saved');
+
+            if (savedMessageTimeoutRef.current) {
+                clearTimeout(savedMessageTimeoutRef.current);
+            }
+            savedMessageTimeoutRef.current = setTimeout(() => setAutosaveStatus('idle'), 1500);
+        } catch {
+            // Merge the failed patch back so a subsequent edit retries with the latest values.
+            pendingPatchRef.current = { ...patch, ...pendingPatchRef.current };
+            setAutosaveStatus('error');
+            setAutosaveError('Failed to save profile changes.');
+        } finally {
+            isSavingRef.current = false;
+            if (Object.keys(pendingPatchRef.current).length > 0) {
+                // If edits happened while saving, flush immediately after this request finishes.
+                if (autosaveTimeoutRef.current) clearTimeout(autosaveTimeoutRef.current);
+                autosaveTimeoutRef.current = setTimeout(() => void flushAutosave(), 0);
+            }
+        }
+    }, [updateProfile]);
+
+    /**
+     * Queue a profile patch and debounce writes so typing doesn't spam the API.
+     */
+    const queueAutosave = useCallback(
+        (patch: UserProfilePatchPayload) => {
+            // Height keys must be mutually exclusive depending on the active unit mode.
+            if ('height_cm' in patch || 'height_feet' in patch || 'height_inches' in patch || 'height_mm' in patch) {
+                delete pendingPatchRef.current.height_cm;
+                delete pendingPatchRef.current.height_feet;
+                delete pendingPatchRef.current.height_inches;
+                delete pendingPatchRef.current.height_mm;
             }
 
-            await updateProfile(payload);
+            pendingPatchRef.current = { ...pendingPatchRef.current, ...patch };
 
-            setProfileMessage('Profile updated');
-            setTimezone(null);
-            setDateOfBirth(null);
-            setSex(null);
-            setHeightCm(null);
-            setHeightFeet(null);
-            setHeightInches(null);
-            setActivityLevel(null);
-            void profileQuery.refetch();
-        } catch {
-            setProfileMessage('Failed to update profile');
-        }
-    };
+            if (autosaveTimeoutRef.current) clearTimeout(autosaveTimeoutRef.current);
+            if (savedMessageTimeoutRef.current) {
+                clearTimeout(savedMessageTimeoutRef.current);
+                savedMessageTimeoutRef.current = null;
+            }
+
+            setAutosaveStatus('saving');
+            setAutosaveError(null);
+
+            autosaveTimeoutRef.current = setTimeout(() => void flushAutosave(), AUTOSAVE_DELAY_MS);
+        },
+        [flushAutosave]
+    );
 
     return (
         <AppPage maxWidth="content">
             <Stack spacing={sectionGap} useFlexGap>
+                <CalorieTargetBanner />
+
                 <Typography color="text.secondary">
-                    Edit the info used to estimate your daily calorie burn (TDEE) and calorie math inputs.
+                    Changes save automatically. Update the inputs below to recalculate your calorie target (TDEE +/- goal deficit).
                 </Typography>
 
                 <AppCard>
-                    {profileMessage && (
-                        <Alert severity="info" sx={{ mb: 2 }}>
-                            {profileMessage}
+                    {autosaveError && (
+                        <Alert severity="error" sx={{ mb: 2 }}>
+                            {autosaveError}
                         </Alert>
                     )}
 
-                    <Stack spacing={2}>
-                        <TimeZonePicker
-                            value={timezoneValue}
-                            onChange={(next) => setTimezone(next)}
-                            helperText="Used to define your day boundaries for food and weight logs."
-                        />
+                    {autosaveStatus === 'saving' && !autosaveError && (
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                            Saving…
+                        </Typography>
+                    )}
+                    {autosaveStatus === 'saved' && !autosaveError && (
+                        <Typography
+                            variant="caption"
+                            sx={{ display: 'block', mb: 1, color: (theme) => theme.palette.success.main }}
+                        >
+                            Saved
+                        </Typography>
+                    )}
 
+                    <Stack spacing={2}>
                         <TextField
                             label="Date of Birth"
                             type="date"
                             InputLabelProps={{ shrink: true }}
                             value={dobValue}
-                            onChange={(e) => setDateOfBirth(e.target.value)}
+                            onChange={(e) => {
+                                const next = e.target.value;
+                                setDateOfBirth(next);
+                                queueAutosave({ date_of_birth: normalizePatchString(next) });
+                            }}
                             fullWidth
                         />
 
                         <FormControl fullWidth>
                             <InputLabel>Sex</InputLabel>
-                            <Select value={sexValue} label="Sex" onChange={(e) => setSex(e.target.value)}>
+                            <Select
+                                value={sexValue}
+                                label="Sex"
+                                onChange={(e) => {
+                                    const next = String(e.target.value);
+                                    setSex(next);
+                                    queueAutosave({ sex: normalizePatchString(next) });
+                                }}
+                            >
                                 <MenuItem value="MALE">Male</MenuItem>
                                 <MenuItem value="FEMALE">Female</MenuItem>
                             </Select>
@@ -218,7 +286,11 @@ const Profile: React.FC = () => {
                                 label="Height (cm)"
                                 type="number"
                                 value={heightCmValue}
-                                onChange={(e) => setHeightCm(e.target.value)}
+                                onChange={(e) => {
+                                    const next = e.target.value;
+                                    setHeightCm(next);
+                                    queueAutosave({ height_cm: normalizePatchString(next) });
+                                }}
                                 inputProps={{ min: 50, max: 272, step: 0.1 }}
                                 fullWidth
                             />
@@ -228,7 +300,11 @@ const Profile: React.FC = () => {
                                     label="Feet"
                                     type="number"
                                     value={heightFeetValue}
-                                    onChange={(e) => setHeightFeet(e.target.value)}
+                                    onChange={(e) => {
+                                        const next = e.target.value;
+                                        setHeightFeet(next);
+                                        queueAutosave(buildFeetInchesHeightPatch(next, heightInchesValue));
+                                    }}
                                     inputProps={{ min: 1, max: 8, step: 1 }}
                                     fullWidth
                                 />
@@ -236,7 +312,11 @@ const Profile: React.FC = () => {
                                     label="Inches"
                                     type="number"
                                     value={heightInchesValue}
-                                    onChange={(e) => setHeightInches(e.target.value)}
+                                    onChange={(e) => {
+                                        const next = e.target.value;
+                                        setHeightInches(next);
+                                        queueAutosave(buildFeetInchesHeightPatch(heightFeetValue, next));
+                                    }}
                                     inputProps={{ min: 0, max: 11.9, step: 0.1 }}
                                     fullWidth
                                 />
@@ -244,16 +324,20 @@ const Profile: React.FC = () => {
                         )}
 
                         <Typography variant="caption" color="text.secondary">
-                            Units are configured in{' '}
-                            <Link component={RouterLink} to="/settings">
-                                Settings
-                            </Link>
-                            .
+                            Units and timezone are configured in <Link component={RouterLink} to="/settings">Settings</Link>.
                         </Typography>
 
                         <FormControl fullWidth>
                             <InputLabel>Activity Level</InputLabel>
-                            <Select value={activityValue} label="Activity Level" onChange={(e) => setActivityLevel(e.target.value)}>
+                            <Select
+                                value={activityValue}
+                                label="Activity Level"
+                                onChange={(e) => {
+                                    const next = String(e.target.value);
+                                    setActivityLevel(next);
+                                    queueAutosave({ activity_level: normalizePatchString(next) });
+                                }}
+                            >
                                 {activityLevelOptions.map((option) => (
                                     <MenuItem key={option.value} value={option.value}>
                                         {option.label}
@@ -261,10 +345,6 @@ const Profile: React.FC = () => {
                                 ))}
                             </Select>
                         </FormControl>
-
-                        <Button variant="contained" onClick={() => void handleProfileSave()} disabled={profileQuery.isLoading}>
-                            Save Profile
-                        </Button>
                     </Stack>
                 </AppCard>
             </Stack>


### PR DESCRIPTION
  ## Intent

  Make the dashboard’s primary “Calorie Target” summary behave like the other dashboard cards (actionable +
  navigates to a deeper view), and make `/profile` more instructive by showing the “inputs -> outputs” calorie math
  with immediate feedback.

  ## User-facing changes

  - Dashboard:
    - Rename “Daily Target” -> “Calorie Target”
    - Card is clickable and routes to `/profile`
    - Adds CTA hint text (“View / edit profile inputs”) to match other dashboard cards
    - Keeps the calculation tooltip available on the dashboard variant
  - Profile:
    - Renders the same Calorie Target card at the top of `/profile`
    - Inlines the prior tooltip breakdown as an accordion (“Calculation details”)
    - Adds a link to `/goals` for changing deficit (deficit is not editable on `/profile`)
    - Removes timezone from `/profile` (timezone remains configurable in `/settings`)
    - Profile fields now auto-save (debounced) and the Save Profile button is removed, so Calorie Target updates
  immediately after edits

  ## Technical design notes

  - `CalorieTargetBanner` now supports a `isDashboard` prop:
    - Dashboard variant wraps in a `CardActionArea` linking to `/profile`
    - Nested controls (info tooltip icon, retry button) stop propagation to avoid accidental navigation
    - Profile variant renders inline + adds an accordion for the detailed breakdown
    - Accordion styling is hardened to avoid vertical “jumping” on expand/collapse (MUI expanded margins/min-
  heights)
  - Profile auto-save:
    - Uses a ref-backed patch buffer + debounce (~450ms) to coalesce rapid edits into fewer PATCHes
    - Failed patches are merged back into the pending buffer so the next edit retries with the latest values
    - Relies on `updateProfile()` cache invalidation to refresh `useUserProfileQuery()` so the Calorie Target re-
  renders quickly
  - Data fetching consistency:
    - `/profile` and `/onboarding` now use the shared `useUserProfileQuery()` hook (query key `['user-profile']`)
  - Backend robustness:
    - `PATCH /api/user/profile` now supports clearing `date_of_birth` via `null` / `""` (previous behavior could
  parse to epoch)

  ## Code pointers

  - Dashboard wiring: `frontend/src/pages/Dashboard.tsx`
  - Calorie Target card, dashboard link behavior, tooltip/accordion breakdown: `frontend/src/components/
  CalorieTargetBanner.tsx`
  - Profile auto-save + timezone removal: `frontend/src/pages/Profile.tsx`
  - Onboarding query alignment: `frontend/src/pages/Onboarding.tsx`
  - Backend profile patch (date_of_birth clearing): `backend/src/routes/user.ts`

  ## Testing

  - `npm --prefix frontend run lint`
  - `cd frontend && ./node_modules/.bin/tsc -b`
  - `npm --prefix backend test`
  EOF
