### PR TITLE
Log summary: friendly date titles + holiday emojis

### DIFF
--- a/frontend/src/components/LogSummaryCard.tsx
+++ b/frontend/src/components/LogSummaryCard.tsx
@@ -3,7 +3,7 @@ import { Box, Card, CardActionArea, CardContent, Skeleton, Typography } from '@m
 import { Gauge } from '@mui/x-charts/Gauge';
 import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
-import { formatDateToLocalDateString } from '../utils/date';
+import { formatDateToLocalDateString, formatIsoDateForDisplay, getHolidayEmojiForIsoDate } from '../utils/date';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 import { useTweenedNumber } from '../hooks/useTweenedNumber';
 import { useUserProfileQuery } from '../queries/userProfile';
@@ -73,7 +73,10 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
     const today = formatDateToLocalDateString(new Date(), timeZone);
     const activeDate = date ?? today;
     const isActiveDateToday = activeDate === today;
-    const title = isActiveDateToday ? "Today's Log" : `Log for ${activeDate}`;
+    const holidayEmoji = getHolidayEmojiForIsoDate(activeDate);
+    const title = isActiveDateToday
+        ? `Today's Log${holidayEmoji ? ` ${holidayEmoji}` : ''}`
+        : `Log for ${formatIsoDateForDisplay(activeDate)}${holidayEmoji ? ` ${holidayEmoji}` : ''}`;
 
     const foodQuery = useFoodLogQuery(activeDate);
 


### PR DESCRIPTION
## Why
Past-day log summary titles currently render as an ISO date (`YYYY-MM-DD`), which is harder to scan than a weekday + long date label.

## What
- Past-day log summary titles now render as a locale-friendly long date (weekday + month + day + year).
- Titles are optionally decorated on a few major holidays with a small emoji (Christmas/Halloween/Valentine's/New Year's Eve/New Year's Day/US Thanksgiving).

## Design / Implementation Notes
- `formatIsoDateForDisplay()` in `frontend/src/utils/date.ts` treats the input as a *calendar date* (not a moment in time) and formats using `timeZone: "UTC"` to avoid off-by-one day shifts when the browser's timezone differs from the user's log timezone.
- `getHolidayEmojiForIsoDate()` in `frontend/src/utils/date.ts` matches fixed month/day holidays and computes US Thanksgiving as the 4th Thursday in November via `isUsThanksgivingDate()`.
- `frontend/src/components/LogSummaryCard.tsx` uses both helpers and appends the emoji to the title when present.

## Verification
- `npm --prefix frontend run lint`
- `cd frontend && npm exec -- tsc -b`
