### PR TITLE
Log: make date picker a single focusable control

### DIFF
--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
     Alert,
     Box,
@@ -33,6 +33,8 @@ import AppCard from '../ui/AppCard';
 const LOG_FAB_DIAMETER_SPACING = 7; // Default MUI "large" Fab is 56px (7 * 8).
 const LOG_FAB_CONTENT_CLEARANCE_SPACING = 2; // Extra room so bottom-row actions aren't tight against the FAB.
 const LOG_FAB_BOTTOM_NAV_GAP_SPACING = 1; // Our FAB sits 8px above the reserved bottom-nav space on mobile.
+const LOG_DATE_PICKER_OVERLAY_FOCUS_OUTLINE_PX = 2; // Thickness of the keyboard focus ring on the date control overlay.
+const LOG_DATE_PICKER_OVERLAY_FOCUS_OUTLINE_OFFSET_PX = 2; // Gap between the overlay outline and the field chrome.
 
 const LOG_PAGE_BOTTOM_PADDING = {
     xs: LOG_FAB_DIAMETER_SPACING + LOG_FAB_CONTENT_CLEARANCE_SPACING + LOG_FAB_BOTTOM_NAV_GAP_SPACING,
@@ -61,6 +63,30 @@ function getLogDateBounds(args: { todayIso: string; createdAtIso?: string; timeZ
     return { min, max };
 }
 
+/**
+ * Open a native browser date picker for an `<input type="date">` when supported.
+ *
+ * Chrome/Edge expose `HTMLInputElement.showPicker()` which lets us make the entire control open the picker (not just
+ * the calendar icon), avoiding the fiddly "edit month/day/year segments" interaction.
+ */
+function showNativeDatePicker(input: HTMLInputElement | null) {
+    if (!input) return;
+
+    try {
+        const maybeShowPicker = (input as HTMLInputElement & { showPicker?: () => void }).showPicker;
+        if (typeof maybeShowPicker === 'function') {
+            maybeShowPicker.call(input);
+            return;
+        }
+    } catch {
+        // Ignore - some browsers throw when attempting to show a picker programmatically.
+    }
+
+    // Fallbacks: try click() first (often opens the picker); if that fails, focus the hidden input.
+    input.click();
+    input.focus();
+}
+
 const Log: React.FC = () => {
     const queryClient = useQueryClient();
     const { user } = useAuth();
@@ -77,6 +103,8 @@ const Log: React.FC = () => {
     const [selectedDate, setSelectedDate] = useState(() => today);
     const [isFoodDialogOpen, setIsFoodDialogOpen] = useState(false);
     const [isWeightDialogOpen, setIsWeightDialogOpen] = useState(false);
+    const dateOverlayButtonRef = useRef<HTMLButtonElement | null>(null);
+    const datePickerInputRef = useRef<HTMLInputElement | null>(null);
 
     // Clamp selection when the bounds change (e.g. user profile loads, timezone changes).
     useEffect(() => {
@@ -146,31 +174,87 @@ const Log: React.FC = () => {
                         </span>
                     </Tooltip>
 
-                    <TextField
-                        label="Date"
-                        type="date"
-                        value={effectiveDate}
-                        onChange={(e) => {
-                            const nextDate = e.target.value;
-                            if (!nextDate) return;
-                            setSelectedDate(clampIsoDate(nextDate, dateBounds));
-                        }}
-                        InputLabelProps={{ shrink: true }}
-                        inputProps={{ min: dateBounds.min, max: dateBounds.max }}
-                        sx={{
-                            flexGrow: 1,
-                            minWidth: 0,
-                            '& input': { textAlign: 'center' },
-                            // Native `type="date"` inputs render differently per-browser; these help keep the value visually centered
-                            // in Chrome/Safari without affecting the calendar icon alignment.
-                            '& input::-webkit-datetime-edit': { textAlign: 'center' },
-                            '& input::-webkit-date-and-time-value': { textAlign: 'center' },
-                            '& input::-webkit-datetime-edit-fields-wrapper': {
-                                display: 'flex',
-                                justifyContent: 'center'
-                            }
-                        }}
-                    />
+                    <Box sx={{ position: 'relative', flexGrow: 1, minWidth: 0 }}>
+                        <TextField
+                            label="Date"
+                            type="date"
+                            value={effectiveDate}
+                            InputLabelProps={{ shrink: true }}
+                            inputProps={{
+                                min: dateBounds.min,
+                                max: dateBounds.max,
+                                readOnly: true,
+                                tabIndex: -1
+                            }}
+                            sx={{
+                                width: '100%',
+                                '& input': { textAlign: 'center' },
+                                // Native `type="date"` inputs render differently per-browser; these help keep the value visually centered
+                                // in Chrome/Safari without affecting the calendar icon alignment.
+                                '& input::-webkit-datetime-edit': { textAlign: 'center' },
+                                '& input::-webkit-date-and-time-value': { textAlign: 'center' },
+                                '& input::-webkit-datetime-edit-fields-wrapper': {
+                                    display: 'flex',
+                                    justifyContent: 'center'
+                                }
+                            }}
+                        />
+
+                        {/* Hidden input used solely for the browser's native date picker UI. */}
+                        <Box
+                            component="input"
+                            type="date"
+                            ref={datePickerInputRef}
+                            value={effectiveDate}
+                            min={dateBounds.min}
+                            max={dateBounds.max}
+                            tabIndex={-1}
+                            aria-hidden="true"
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                const nextDate = e.target.value;
+                                if (!nextDate) return;
+                                setSelectedDate(clampIsoDate(nextDate, dateBounds));
+                                dateOverlayButtonRef.current?.focus({ preventScroll: true });
+                            }}
+                            sx={{
+                                position: 'absolute',
+                                inset: 0,
+                                opacity: 0,
+                                pointerEvents: 'none'
+                            }}
+                        />
+
+                        {/*
+                            Overlay button: makes the whole field open the date picker without focusing the visible
+                            input's "month/day/year" segments (which feels fiddly on mobile).
+                            The overlay itself is the focus target for keyboard navigation.
+                        */}
+                        <Box
+                            component="button"
+                            type="button"
+                            ref={dateOverlayButtonRef}
+                            aria-label={`Date: ${effectiveDate}. Activate to choose a different day.`}
+                            onClick={() => showNativeDatePicker(datePickerInputRef.current)}
+                            sx={(theme) => ({
+                                position: 'absolute',
+                                inset: 0,
+                                zIndex: 1,
+                                cursor: 'pointer',
+                                borderRadius: theme.shape.borderRadius,
+                                WebkitTapHighlightColor: 'transparent',
+                                background: 'transparent',
+                                border: 0,
+                                padding: 0,
+                                margin: 0,
+                                outline: 'none',
+                                '&:active': { backgroundColor: theme.palette.action.hover },
+                                '&:focus-visible': {
+                                    outline: `${LOG_DATE_PICKER_OVERLAY_FOCUS_OUTLINE_PX}px solid ${theme.palette.primary.main}`,
+                                    outlineOffset: `${LOG_DATE_PICKER_OVERLAY_FOCUS_OUTLINE_OFFSET_PX}px`
+                                }
+                            })}
+                        />
+                    </Box>
 
                     <Tooltip title="Next day">
                         <span>


### PR DESCRIPTION
## Intent

The `/log` page used a native `type="date"` input (MUI `TextField`) that allows direct month/day/year segment editing when the field is tapped/clicked. On mobile this feels fiddly; the goal is for the control to behave like a single action (open the native picker) while keeping keyboard navigation accessible.

## What changed

- Made the `/log` date control behave like a picker button for pointer/touch: clicking/tapping anywhere opens the native date picker instead of focusing individual date segments.
- Kept keyboard navigation: Tab lands on one focusable element (the overlay button), and Enter/Space triggers the picker.

## Technical design

`frontend/src/pages/Log.tsx`

- Added `showNativeDatePicker(...)` helper:
  - Uses `HTMLInputElement.showPicker()` when available.
  - Falls back to `click()`/`focus()` to trigger the browser picker in other engines.
- Kept the visible date field as a MUI `TextField type="date"` for consistent layout and label rendering, but made it non-focusable:
  - `tabIndex={-1}` prevents the month/day/year segments from receiving keyboard focus.
  - `readOnly` documents the intent and avoids React controlled-input warnings.
- Introduced a hidden `<input type="date">` that actually drives the native picker UI:
  - `tabIndex={-1}` + `aria-hidden` keep it out of the tab order/accessibility tree.
  - `onChange` updates `selectedDate` (still clamped to `[min,max]`) and restores focus back to the overlay button.
- Added a full-size overlay `button`:
  - Captures pointer interaction without focusing the visible segmented date input.
  - Provides a `:focus-visible` outline so keyboard users get a single, clear focus target.

## Testing

- `npm --prefix frontend run lint`
- `cd frontend && npm exec -- tsc -b`
