### PR TITLE
Dev seed: vary food logs across the week

### DIFF
--- a/backend/src/services/devTestData.ts
+++ b/backend/src/services/devTestData.ts
@@ -24,15 +24,104 @@ type MealTemplate = {
   name: string;
   calories: number;
   hour: number;
+  minute?: number;
 };
 
-const MEAL_TEMPLATES: MealTemplate[] = [
-  { mealPeriod: MealPeriod.BREAKFAST, name: 'Spinach omelet', calories: 320, hour: 7 },
-  { mealPeriod: MealPeriod.MORNING_SNACK, name: 'Apple with peanut butter', calories: 180, hour: 10 },
-  { mealPeriod: MealPeriod.LUNCH, name: 'Turkey sandwich', calories: 520, hour: 13 },
-  { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Protein shake', calories: 210, hour: 16 },
-  { mealPeriod: MealPeriod.DINNER, name: 'Chicken stir-fry', calories: 650, hour: 19 },
-  { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Dark chocolate square', calories: 120, hour: 21 },
+const SEED_MEAL_ITEMS = {
+  spinachOmelet: { mealPeriod: MealPeriod.BREAKFAST, name: 'Spinach omelet', calories: 320, hour: 7 },
+  sourdoughToast: { mealPeriod: MealPeriod.BREAKFAST, name: 'Sourdough toast', calories: 150, hour: 7, minute: 20 },
+  latte: { mealPeriod: MealPeriod.BREAKFAST, name: 'Latte', calories: 120, hour: 8, minute: 10 },
+
+  appleWithPeanutButter: {
+    mealPeriod: MealPeriod.MORNING_SNACK,
+    name: 'Apple with peanut butter',
+    calories: 180,
+    hour: 10,
+  },
+  greekYogurt: { mealPeriod: MealPeriod.MORNING_SNACK, name: 'Greek yogurt', calories: 190, hour: 10 },
+
+  turkeySandwich: { mealPeriod: MealPeriod.LUNCH, name: 'Turkey sandwich', calories: 520, hour: 13 },
+  sideSalad: { mealPeriod: MealPeriod.LUNCH, name: 'Side salad', calories: 180, hour: 13, minute: 15 },
+  chickenBurritoBowl: { mealPeriod: MealPeriod.LUNCH, name: 'Chicken burrito bowl', calories: 680, hour: 13 },
+
+  proteinShake: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Protein shake', calories: 210, hour: 16 },
+  trailMix: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Trail mix', calories: 160, hour: 16, minute: 25 },
+  granolaBar: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Granola bar', calories: 140, hour: 16, minute: 20 },
+
+  chickenStirFry: { mealPeriod: MealPeriod.DINNER, name: 'Chicken stir-fry', calories: 650, hour: 19 },
+  steamedRice: { mealPeriod: MealPeriod.DINNER, name: 'Steamed rice', calories: 200, hour: 19, minute: 15 },
+  roastedVeggies: { mealPeriod: MealPeriod.DINNER, name: 'Roasted veggies', calories: 110, hour: 19, minute: 20 },
+
+  darkChocolateSquare: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Dark chocolate square', calories: 120, hour: 21 },
+  popcorn: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Popcorn', calories: 150, hour: 21, minute: 5 },
+  iceCreamScoop: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Ice cream scoop', calories: 220, hour: 21, minute: 10 },
+} satisfies Record<string, MealTemplate>;
+
+const WEEK_MEAL_PLANS: MealTemplate[][] = [
+  // 2160 kcal: full day + extra afternoon snack item (multi-item meal).
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.trailMix,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 1900 kcal: no morning snack / evening snack, dinner has multiple items.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.steamedRice,
+  ],
+  // 1740 kcal: lunch empty, breakfast + afternoon snack have multiple items.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.latte,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.granolaBar,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 1870 kcal: breakfast empty, lunch has multiple items.
+  [
+    SEED_MEAL_ITEMS.greekYogurt,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.sideSalad,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 1540 kcal: dinner empty, swapped lunch + swapped evening snack.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.chickenBurritoBowl,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.popcorn,
+  ],
+  // 2050 kcal: afternoon snack empty, breakfast + dinner have multiple items.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.sourdoughToast,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.roastedVeggies,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 2040 kcal: morning snack empty, breakfast swapped in extra item + higher-cal evening snack.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.latte,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.iceCreamScoop,
+  ],
 ];
 
 type SeedProfileImage = {
@@ -83,9 +172,43 @@ const getPastWeekDates = (timeZone: string, now: Date = new Date()): Date[] => {
 };
 
 /**
+ * Choose a deterministic created_at timestamp that won't hide seeded history in the /log date picker.
+ *
+ * The /log page clamps its minimum selectable day to the user's account creation local day.
+ * We set created_at to land on the earliest seeded local_date (when formatted in the user's
+ * timezone), so all generated seed days remain selectable without widening bounds globally.
+ */
+const getSeedUserCreatedAt = (seedDays: Date[], timeZone: string): Date => {
+  const earliestSeedDay = seedDays[0];
+  if (!earliestSeedDay) {
+    return new Date();
+  }
+
+  const seedDateIso = earliestSeedDay.toISOString().slice(0, 10);
+  const candidateHoursUtc = [12, 0, 6, 18];
+
+  for (const hour of candidateHoursUtc) {
+    const candidate = new Date(earliestSeedDay);
+    candidate.setUTCHours(hour, 0, 0, 0);
+
+    try {
+      if (formatDateToLocalDateString(candidate, timeZone) === seedDateIso) {
+        return candidate;
+      }
+    } catch {
+      // Ignore invalid timezone inputs (we'll fall back to a best-effort value below).
+    }
+  }
+
+  const fallback = new Date(earliestSeedDay);
+  fallback.setUTCHours(12, 0, 0, 0);
+  return fallback;
+};
+
+/**
  * Ensure a deterministic test user exists (and always has the expected password).
  */
-const ensureTestUser = async (): Promise<{ id: number }> => {
+const ensureTestUser = async (createdAt: Date): Promise<{ id: number }> => {
   const passwordHash = await bcrypt.hash(TEST_USER_PASSWORD, 10);
   const placeholderImage = await loadProfilePlaceholderImage();
   const placeholderImageData = placeholderImage
@@ -97,6 +220,7 @@ const ensureTestUser = async (): Promise<{ id: number }> => {
     create: {
       email: TEST_USER_EMAIL,
       password_hash: passwordHash,
+      created_at: createdAt,
       timezone: TEST_USER_TIMEZONE,
       weight_unit: WeightUnit.KG,
       height_unit: HeightUnit.CM,
@@ -110,6 +234,7 @@ const ensureTestUser = async (): Promise<{ id: number }> => {
       // Keep the dev user deterministic so "invalid credentials" doesn't happen
       // if the account already existed with a different password.
       password_hash: passwordHash,
+      created_at: createdAt,
       timezone: TEST_USER_TIMEZONE,
       weight_unit: WeightUnit.KG,
       height_unit: HeightUnit.CM,
@@ -129,7 +254,7 @@ const ensureTestUser = async (): Promise<{ id: number }> => {
  * This account is intentionally kept incomplete so developers can repeatedly test
  * the onboarding flow without needing a full DB reset.
  */
-const ensureOnboardingTestUser = async (): Promise<{ id: number }> => {
+const ensureOnboardingTestUser = async (createdAt: Date): Promise<{ id: number }> => {
   const passwordHash = await bcrypt.hash(TEST_USER_PASSWORD, 10);
 
   return prisma.user.upsert({
@@ -137,6 +262,7 @@ const ensureOnboardingTestUser = async (): Promise<{ id: number }> => {
     create: {
       email: TEST_ONBOARDING_USER_EMAIL,
       password_hash: passwordHash,
+      created_at: createdAt,
       timezone: TEST_USER_TIMEZONE,
       weight_unit: WeightUnit.KG,
       height_unit: HeightUnit.CM,
@@ -150,6 +276,7 @@ const ensureOnboardingTestUser = async (): Promise<{ id: number }> => {
     update: {
       // Keep this user perpetually in a pre-onboarding state.
       password_hash: passwordHash,
+      created_at: createdAt,
       timezone: TEST_USER_TIMEZONE,
       weight_unit: WeightUnit.KG,
       height_unit: HeightUnit.CM,
@@ -213,11 +340,25 @@ const ensureBodyMetrics = async (userId: number, days: Date[]): Promise<void> =>
 };
 
 /**
- * Build meal logs for a given day using fixed templates.
+ * Return a deterministic-but-varied meal plan for the provided seed day index.
+ *
+ * This keeps local dev data reproducible while exercising UI states like:
+ * - different day totals
+ * - empty meals (no items for a meal period)
+ * - multi-item meals (multiple food logs in one meal period)
+ */
+const getMealTemplatesForSeedDayIndex = (dayIndex: number): MealTemplate[] => {
+  const plan = WEEK_MEAL_PLANS[dayIndex % WEEK_MEAL_PLANS.length];
+  return plan ?? [];
+};
+
+/**
+ * Build meal logs for a given day using the varied seed templates.
  */
 const buildMealLogsForDay = (
   userId: number,
-  day: Date
+  day: Date,
+  dayIndex: number
 ): Array<{
   user_id: number;
   date: Date;
@@ -226,9 +367,11 @@ const buildMealLogsForDay = (
   name: string;
   calories: number;
 }> => {
-  return MEAL_TEMPLATES.map((template) => {
+  const templates = getMealTemplatesForSeedDayIndex(dayIndex);
+
+  return templates.map((template) => {
     const mealDate = new Date(day);
-    mealDate.setUTCHours(template.hour, 0, 0, 0);
+    mealDate.setUTCHours(template.hour, template.minute ?? 0, 0, 0);
     return {
       user_id: userId,
       date: mealDate,
@@ -244,7 +387,7 @@ const buildMealLogsForDay = (
  * Create daily food logs for the past week without duplicating existing entries.
  */
 const ensureFoodLogs = async (userId: number, days: Date[]): Promise<void> => {
-  for (const day of days) {
+  for (const [dayIndex, day] of days.entries()) {
     const existingCount = await prisma.foodLog.count({
       where: {
         user_id: userId,
@@ -254,7 +397,7 @@ const ensureFoodLogs = async (userId: number, days: Date[]): Promise<void> => {
     if (existingCount > 0) continue;
 
     await prisma.foodLog.createMany({
-      data: buildMealLogsForDay(userId, day),
+      data: buildMealLogsForDay(userId, day, dayIndex),
     });
   }
 };
@@ -263,9 +406,11 @@ const ensureFoodLogs = async (userId: number, days: Date[]): Promise<void> => {
  * Seed the local database with a test user and a week of sample data.
  */
 export const seedDevTestData = async (): Promise<void> => {
-  const user = await ensureTestUser();
-  const onboardingUser = await ensureOnboardingTestUser();
   const days = getPastWeekDates(TEST_USER_TIMEZONE);
+  const createdAt = getSeedUserCreatedAt(days, TEST_USER_TIMEZONE);
+
+  const user = await ensureTestUser(createdAt);
+  const onboardingUser = await ensureOnboardingTestUser(createdAt);
 
   await ensureTestGoal(user.id);
   await ensureBodyMetrics(user.id, days);


### PR DESCRIPTION
## Intent

Dev seed data was uniform day-to-day (same meal periods, same totals), which made it hard to exercise UI behaviors like empty states, per-meal animation transitions, and varying totals.

This PR keeps the seed deterministic but introduces a small amount of intentional variety across the past week.

## What Changed

- Seeded food logs now vary by day:
  - different total calories per day
  - some meal periods have no entries
  - some meal periods have multiple entries
- Seeded dev users (test + onboarding) now get a deterministic `created_at` that backdates to the earliest seeded day.
  - The /log page clamps its minimum selectable date to `user.created_at`.

## Technical Design Notes

- Deterministic variety:
  - `ensureFoodLogs()` passes the seeded day index into `buildMealLogsForDay()`.
  - `getMealTemplatesForSeedDayIndex()` selects from `WEEK_MEAL_PLANS` via modulo.
- Idempotency is preserved:
  - food logs are only inserted for a `local_date` when no rows exist for that day.
  - metrics/goals are still only backfilled when missing.
- `getSeedUserCreatedAt()` selects a UTC timestamp that formats into the earliest seeded local day in `TEST_USER_TIMEZONE` (to avoid off-by-one issues).

## Code Pointers

- `backend/src/services/devTestData.ts`
  - Meal variety: `SEED_MEAL_ITEMS`, `WEEK_MEAL_PLANS`, `getMealTemplatesForSeedDayIndex()`, `buildMealLogsForDay()`
  - Date-picker fix: `getSeedUserCreatedAt()`, `ensureTestUser()`, `ensureOnboardingTestUser()`

## Testing

- `npm --prefix backend test`
- Manual:
  - `npm run db:reset && npm run db:seed`
  - Navigate /log across the seeded week; confirm some meals are empty and totals differ per day.
