### PR TITLE
Split body profile from account settings

### DIFF
--- a/frontend/src/components/AccountSecurityCard.tsx
+++ b/frontend/src/components/AccountSecurityCard.tsx
@@ -1,0 +1,266 @@
+import React, { useState } from 'react';
+import {
+    Alert,
+    Box,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Stack,
+    TextField,
+    Typography
+} from '@mui/material';
+import LogoutIcon from '@mui/icons-material/LogoutRounded';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/useAuth';
+import { useTransientStatus } from '../hooks/useTransientStatus';
+import AppCard from '../ui/AppCard';
+import InlineStatusLine from '../ui/InlineStatusLine';
+import SectionHeader from '../ui/SectionHeader';
+import { getApiErrorMessage } from '../utils/apiError';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+type Props = {
+    /** Optional supporting copy shown under the "Account" header. */
+    subtitle?: React.ReactNode;
+};
+
+/**
+ * AccountSecurityCard
+ *
+ * A single surface for account-scoped actions (email display, password changes, and logout).
+ * This keeps "account" concerns colocated on Settings, separate from the body/TDEE profile page.
+ */
+const AccountSecurityCard: React.FC<Props> = ({
+    subtitle = 'View your email address, update your password, or log out.'
+}) => {
+    const navigate = useNavigate();
+    const { user, logout, changePassword } = useAuth();
+    const { status, showStatus, clearStatus } = useTransientStatus();
+
+    const [passwordError, setPasswordError] = useState('');
+    const [isChangingPassword, setIsChangingPassword] = useState(false);
+    const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
+
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+
+    /**
+     * Clear sensitive input values used by the password dialog.
+     */
+    const resetPasswordDialogFields = () => {
+        setPasswordError('');
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+    };
+
+    /**
+     * Open the change-password dialog and clear any prior error/status.
+     */
+    const handlePasswordDialogOpen = () => {
+        clearStatus();
+        resetPasswordDialogFields();
+        setIsPasswordDialogOpen(true);
+    };
+
+    /**
+     * Close the change-password dialog and clear sensitive input values.
+     */
+    const closePasswordDialog = () => {
+        setIsPasswordDialogOpen(false);
+        resetPasswordDialogFields();
+    };
+
+    /**
+     * Close the change-password dialog (unless a request is in-flight).
+     */
+    const handlePasswordDialogClose = () => {
+        if (isChangingPassword) return;
+        closePasswordDialog();
+    };
+
+    /**
+     * Change the current user's password after validating basic client-side constraints.
+     */
+    const handlePasswordChange = async () => {
+        clearStatus();
+        setPasswordError('');
+
+        if (!currentPassword) {
+            setPasswordError('Please enter your current password.');
+            return;
+        }
+
+        if (newPassword.length < MIN_PASSWORD_LENGTH) {
+            setPasswordError(`New password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+            return;
+        }
+
+        if (newPassword !== confirmPassword) {
+            setPasswordError('New passwords do not match.');
+            return;
+        }
+
+        if (currentPassword === newPassword) {
+            setPasswordError('New password must be different from your current password.');
+            return;
+        }
+
+        setIsChangingPassword(true);
+        try {
+            await changePassword(currentPassword, newPassword);
+            showStatus('Password updated.', 'success');
+            closePasswordDialog();
+        } catch (err) {
+            setPasswordError(getApiErrorMessage(err) ?? 'Failed to update password.');
+        } finally {
+            setIsChangingPassword(false);
+        }
+    };
+
+    /**
+     * Keep the password form accessible by handling Enter-to-submit and preventing full-page reloads.
+     */
+    const handlePasswordSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        void handlePasswordChange();
+    };
+
+    /**
+     * Clear the current session and return the user to the login screen.
+     */
+    const handleLogout = async () => {
+        clearStatus();
+        try {
+            await logout();
+            navigate('/login');
+        } catch {
+            showStatus('Failed to log out', 'error');
+        }
+    };
+
+    return (
+        <>
+            <AppCard>
+                <SectionHeader
+                    title="Account"
+                    subtitle={subtitle}
+                    actions={
+                        <Button variant="outlined" onClick={handlePasswordDialogOpen}>
+                            Change Password
+                        </Button>
+                    }
+                    sx={{ mb: 0.5 }}
+                />
+
+                <InlineStatusLine status={status} sx={{ mb: 1 }} />
+
+                <Stack spacing={2}>
+                    <Stack spacing={1.5}>
+                        <Typography variant="body2" color="text.secondary">
+                            Email
+                        </Typography>
+                        <Box
+                            sx={{
+                                px: 2,
+                                py: 1.5,
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderRadius: 1,
+                                backgroundColor: 'action.hover'
+                            }}
+                        >
+                            <Typography sx={{ wordBreak: 'break-word' }}>{user?.email ?? ''}</Typography>
+                        </Box>
+                    </Stack>
+
+                    <Button
+                        variant="outlined"
+                        color="error"
+                        startIcon={<LogoutIcon />}
+                        onClick={() => void handleLogout()}
+                        fullWidth
+                    >
+                        Log out
+                    </Button>
+                </Stack>
+            </AppCard>
+
+            <Dialog
+                open={isPasswordDialogOpen}
+                onClose={handlePasswordDialogClose}
+                fullWidth
+                maxWidth="xs"
+            >
+                <DialogTitle>Change password</DialogTitle>
+                <DialogContent>
+                    <Stack
+                        spacing={2}
+                        component="form"
+                        id="change-password-form"
+                        onSubmit={handlePasswordSubmit}
+                        sx={{ pt: 1 }}
+                    >
+                        {passwordError && <Alert severity="error">{passwordError}</Alert>}
+
+                        <TextField
+                            label="Current Password"
+                            type="password"
+                            autoComplete="current-password"
+                            value={currentPassword}
+                            onChange={(e) => setCurrentPassword(e.target.value)}
+                            disabled={isChangingPassword}
+                            required
+                            fullWidth
+                        />
+
+                        <TextField
+                            label="New Password"
+                            type="password"
+                            autoComplete="new-password"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            helperText={`At least ${MIN_PASSWORD_LENGTH} characters.`}
+                            disabled={isChangingPassword}
+                            inputProps={{ minLength: MIN_PASSWORD_LENGTH }}
+                            required
+                            fullWidth
+                        />
+
+                        <TextField
+                            label="Confirm New Password"
+                            type="password"
+                            autoComplete="new-password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            disabled={isChangingPassword}
+                            inputProps={{ minLength: MIN_PASSWORD_LENGTH }}
+                            required
+                            fullWidth
+                        />
+                    </Stack>
+                </DialogContent>
+                <DialogActions sx={{ px: 3, pb: 2 }}>
+                    <Button onClick={handlePasswordDialogClose} disabled={isChangingPassword}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        form="change-password-form"
+                        variant="contained"
+                        disabled={isChangingPassword}
+                    >
+                        {isChangingPassword ? 'Updating...' : 'Update Password'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};
+
+export default AccountSecurityCard;
+

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -21,6 +21,7 @@ import { Outlet, Link as RouterLink, useLocation, useNavigate } from 'react-rout
 import DashboardIcon from '@mui/icons-material/DashboardRounded';
 import ListAltIcon from '@mui/icons-material/ListAltRounded';
 import ShowChartIcon from '@mui/icons-material/ShowChartRounded';
+import PersonIcon from '@mui/icons-material/PersonRounded';
 import SettingsIcon from '@mui/icons-material/SettingsRounded';
 import LogoutIcon from '@mui/icons-material/LogoutRounded';
 import { alpha, useTheme } from '@mui/material/styles';
@@ -37,7 +38,7 @@ function getActiveNavigationValue(pathname: string): string | null {
     if (pathname.startsWith('/dashboard')) return '/dashboard';
     if (pathname.startsWith('/log')) return '/log';
     if (pathname.startsWith('/goals')) return '/goals';
-    if (pathname.startsWith('/settings')) return '/settings';
+    if (pathname.startsWith('/profile')) return '/profile';
     return null;
 }
 
@@ -53,7 +54,7 @@ const Layout: React.FC = () => {
 
     const hideNav = location.pathname.startsWith('/onboarding');
     const showAppNav = Boolean(user) && !isLoading && !hideNav;
-    const showProfileShortcut = Boolean(user) && !isLoading && !hideNav;
+    const showSettingsShortcut = Boolean(user) && !isLoading && !hideNav;
     const showDrawer = showAppNav && isDesktop;
     const showBottomNav = showAppNav && !isDesktop;
 
@@ -91,6 +92,17 @@ const Layout: React.FC = () => {
                             <ShowChartIcon />
                         </ListItemIcon>
                         <ListItemText primary="Goals" />
+                    </ListItemButton>
+
+                    <ListItemButton
+                        selected={location.pathname.startsWith('/profile')}
+                        component={RouterLink}
+                        to="/profile"
+                    >
+                        <ListItemIcon>
+                            <PersonIcon />
+                        </ListItemIcon>
+                        <ListItemText primary="Profile" />
                     </ListItemButton>
                 </List>
             </Box>
@@ -157,12 +169,12 @@ const Layout: React.FC = () => {
 
                     <Box sx={{ flexGrow: 1 }} />
 
-                    {showProfileShortcut && (
-                        <Tooltip title="Profile">
+                    {showSettingsShortcut && (
+                        <Tooltip title="Settings">
                             <IconButton
                                 color="inherit"
-                                onClick={() => navigate('/profile')}
-                                aria-label="Open profile"
+                                onClick={() => navigate('/settings')}
+                                aria-label="Open settings"
                                 sx={{ ml: 1 }}
                             >
                                 <Avatar
@@ -228,7 +240,7 @@ const Layout: React.FC = () => {
                         <BottomNavigationAction value="/dashboard" label="Dashboard" icon={<DashboardIcon />} />
                         <BottomNavigationAction value="/log" label="Log" icon={<ListAltIcon />} />
                         <BottomNavigationAction value="/goals" label="Goals" icon={<ShowChartIcon />} />
-                        <BottomNavigationAction value="/settings" label="Settings" icon={<SettingsIcon />} />
+                        <BottomNavigationAction value="/profile" label="Profile" icon={<PersonIcon />} />
                     </BottomNavigation>
                 </Box>
             )}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -199,7 +199,7 @@ const Onboarding: React.FC = () => {
 
                 <ProfilePhotoCard
                     title="Profile photo (optional)"
-                    description="Shown in the app bar and on your profile."
+                    description="Shown in the app bar and in your settings."
                 />
 
                 <AppCard>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,12 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-    Alert,
     Box,
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
     FormControl,
     Link,
     InputLabel,
@@ -20,8 +14,6 @@ import { useTheme } from '@mui/material/styles';
 import { Link as RouterLink } from 'react-router-dom';
 import CalorieTargetBanner from '../components/CalorieTargetBanner';
 import { activityLevelOptions } from '../constants/activityLevels';
-import ProfilePhotoCard from '../components/ProfilePhotoCard';
-import { useTransientStatus } from '../hooks/useTransientStatus';
 import type { UserProfilePatchPayload } from '../context/authContext';
 import { useAuth } from '../context/useAuth';
 import { useUserProfileQuery } from '../queries/userProfile';
@@ -29,11 +21,9 @@ import AppPage from '../ui/AppPage';
 import AppCard from '../ui/AppCard';
 import InlineStatusLine from '../ui/InlineStatusLine';
 import SectionHeader from '../ui/SectionHeader';
-import { getApiErrorMessage } from '../utils/apiError';
 import { getDefaultHeightUnitForWeightUnit } from '../utils/unitPreferences';
 
 const AUTOSAVE_DELAY_MS = 450;
-const MIN_PASSWORD_LENGTH = 8;
 
 type ParsedHeight = {
     cm: number;
@@ -82,20 +72,13 @@ function buildFeetInchesHeightPatch(feet: string, inches: string): UserProfilePa
 }
 
 /**
- * Profile is the dedicated page for editing user-specific profile fields used for calorie math.
+ * Profile is focused on body-profile inputs used for calorie math (BMR/TDEE).
+ * Account settings (photo/password) live in Settings.
  */
 const Profile: React.FC = () => {
     const theme = useTheme();
-    const { user, updateProfile, changePassword } = useAuth();
+    const { user, updateProfile } = useAuth();
     const sectionGap = theme.custom.layout.page.sectionGap;
-    const { status: accountStatus, showStatus: showAccountStatus, clearStatus: clearAccountStatus } = useTransientStatus();
-    const [passwordError, setPasswordError] = useState('');
-    const [isChangingPassword, setIsChangingPassword] = useState(false);
-    const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
-
-    const [currentPassword, setCurrentPassword] = useState('');
-    const [newPassword, setNewPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
 
     const autosaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const savedMessageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -247,100 +230,18 @@ const Profile: React.FC = () => {
         [flushAutosave]
     );
 
-    /**
-     * Open the change-password dialog and clear any prior error state.
-     */
-    const handlePasswordDialogOpen = () => {
-        clearAccountStatus();
-        resetPasswordDialogFields();
-        setIsPasswordDialogOpen(true);
-    };
-
-    /**
-     * Clear sensitive input values used by the password dialog.
-     */
-    const resetPasswordDialogFields = () => {
-        setPasswordError('');
-        setCurrentPassword('');
-        setNewPassword('');
-        setConfirmPassword('');
-    };
-
-    /**
-     * Close the change-password dialog and clear sensitive input values.
-     */
-    const closePasswordDialog = () => {
-        setIsPasswordDialogOpen(false);
-        resetPasswordDialogFields();
-    };
-
-    /**
-     * Close the change-password dialog (unless a request is in-flight).
-     */
-    const handlePasswordDialogClose = () => {
-        if (isChangingPassword) return;
-        closePasswordDialog();
-    };
-
-    /**
-     * Change the current user's password after validating basic client-side constraints.
-     */
-    const handlePasswordChange = async () => {
-        clearAccountStatus();
-        setPasswordError('');
-
-        if (!currentPassword) {
-            setPasswordError('Please enter your current password.');
-            return;
-        }
-
-        if (newPassword.length < MIN_PASSWORD_LENGTH) {
-            setPasswordError(`New password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
-            return;
-        }
-
-        if (newPassword !== confirmPassword) {
-            setPasswordError('New passwords do not match.');
-            return;
-        }
-
-        if (currentPassword === newPassword) {
-            setPasswordError('New password must be different from your current password.');
-            return;
-        }
-
-        setIsChangingPassword(true);
-        try {
-            await changePassword(currentPassword, newPassword);
-            showAccountStatus('Password updated.', 'success');
-            closePasswordDialog();
-        } catch (err) {
-            setPasswordError(getApiErrorMessage(err) ?? 'Failed to update password.');
-        } finally {
-            setIsChangingPassword(false);
-        }
-    };
-
-    /**
-     * Keep the password form accessible by handling Enter-to-submit and preventing full-page reloads.
-     */
-    const handlePasswordSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-        void handlePasswordChange();
-    };
-
     return (
         <AppPage maxWidth="content">
             <Stack spacing={sectionGap} useFlexGap>
                 <CalorieTargetBanner />
 
-                <Typography color="text.secondary">
-                    Changes save automatically. Update the inputs below to recalculate your calorie target (TDEE +/- goal deficit).
-                </Typography>
-
-                <ProfilePhotoCard description="Used for your avatar in the app bar." />
-
                 <AppCard>
+                    <SectionHeader
+                        title="Body profile"
+                        subtitle="Changes save automatically. Update these inputs to recalculate your estimated baseline burn (TDEE)."
+                        sx={{ mb: 0.5 }}
+                    />
+
                     <InlineStatusLine status={autosaveStatusLine} sx={{ mb: 1 }} ariaLive="off" />
 
                     <Stack spacing={2}>
@@ -439,108 +340,6 @@ const Profile: React.FC = () => {
                         </FormControl>
                     </Stack>
                 </AppCard>
-
-                <AppCard>
-                    <SectionHeader
-                        title="Account"
-                        subtitle="View your email address and update your password."
-                        actions={
-                            <Button variant="outlined" onClick={handlePasswordDialogOpen}>
-                                Change Password
-                            </Button>
-                        }
-                        sx={{ mb: 0.5 }}
-                    />
-
-                    <InlineStatusLine status={accountStatus} sx={{ mb: 1 }} />
-
-                    <Stack spacing={1.5}>
-                        <Typography variant="body2" color="text.secondary">
-                            Email
-                        </Typography>
-                        <Box
-                            sx={{
-                                px: 2,
-                                py: 1.5,
-                                border: '1px solid',
-                                borderColor: 'divider',
-                                borderRadius: 1,
-                                backgroundColor: 'action.hover'
-                            }}
-                        >
-                            <Typography sx={{ wordBreak: 'break-word' }}>{user?.email ?? ''}</Typography>
-                        </Box>
-                    </Stack>
-                </AppCard>
-
-                <Dialog
-                    open={isPasswordDialogOpen}
-                    onClose={handlePasswordDialogClose}
-                    fullWidth
-                    maxWidth="xs"
-                >
-                    <DialogTitle>Change password</DialogTitle>
-                    <DialogContent>
-                        <Stack
-                            spacing={2}
-                            component="form"
-                            id="change-password-form"
-                            onSubmit={handlePasswordSubmit}
-                            sx={{ pt: 1 }}
-                        >
-                            {passwordError && <Alert severity="error">{passwordError}</Alert>}
-
-                            <TextField
-                                label="Current Password"
-                                type="password"
-                                autoComplete="current-password"
-                                value={currentPassword}
-                                onChange={(e) => setCurrentPassword(e.target.value)}
-                                disabled={isChangingPassword}
-                                required
-                                fullWidth
-                            />
-
-                            <TextField
-                                label="New Password"
-                                type="password"
-                                autoComplete="new-password"
-                                value={newPassword}
-                                onChange={(e) => setNewPassword(e.target.value)}
-                                helperText={`At least ${MIN_PASSWORD_LENGTH} characters.`}
-                                disabled={isChangingPassword}
-                                inputProps={{ minLength: MIN_PASSWORD_LENGTH }}
-                                required
-                                fullWidth
-                            />
-
-                            <TextField
-                                label="Confirm New Password"
-                                type="password"
-                                autoComplete="new-password"
-                                value={confirmPassword}
-                                onChange={(e) => setConfirmPassword(e.target.value)}
-                                disabled={isChangingPassword}
-                                inputProps={{ minLength: MIN_PASSWORD_LENGTH }}
-                                required
-                                fullWidth
-                            />
-                        </Stack>
-                    </DialogContent>
-                    <DialogActions sx={{ px: 3, pb: 2 }}>
-                        <Button onClick={handlePasswordDialogClose} disabled={isChangingPassword}>
-                            Cancel
-                        </Button>
-                        <Button
-                            type="submit"
-                            form="change-password-form"
-                            variant="contained"
-                            disabled={isChangingPassword}
-                        >
-                            {isChangingPassword ? 'Updating...' : 'Update Password'}
-                        </Button>
-                    </DialogActions>
-                </Dialog>
             </Stack>
         </AppPage>
     );

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
     Box,
-    Button,
     FormControl,
     FormHelperText,
     InputLabel,
@@ -9,14 +8,14 @@ import {
     Select,
     Stack
 } from '@mui/material';
-import LogoutIcon from '@mui/icons-material/LogoutRounded';
 import { useTheme } from '@mui/material/styles';
-import { useNavigate } from 'react-router-dom';
 import { useTransientStatus } from '../hooks/useTransientStatus';
 import { useAuth } from '../context/useAuth';
 import type { HeightUnit, WeightUnit } from '../context/authContext';
 import { useThemeMode } from '../context/useThemeMode';
 import type { ThemePreference } from '../context/themeModeContext';
+import AccountSecurityCard from '../components/AccountSecurityCard';
+import ProfilePhotoCard from '../components/ProfilePhotoCard';
 import TimeZonePicker from '../components/TimeZonePicker';
 import UnitPreferenceToggles from '../components/UnitPreferenceToggles';
 import AppPage from '../ui/AppPage';
@@ -25,17 +24,15 @@ import InlineStatusLine from '../ui/InlineStatusLine';
 import SectionHeader from '../ui/SectionHeader';
 
 /**
- * Settings is focused on device preferences (theme) and app preferences (units).
+ * Settings is focused on account management (photo/password) and app preferences (units/theme).
  */
 const Settings: React.FC = () => {
     const theme = useTheme();
     const sectionGap = theme.custom.layout.page.sectionGap;
-    const { user, logout, updateUnitPreferences, updateTimezone } = useAuth();
+    const { user, updateUnitPreferences, updateTimezone } = useAuth();
     const { preference: themePreference, mode: resolvedThemeMode, setPreference: setThemePreference } = useThemeMode();
-    const navigate = useNavigate();
 
     const { status: unitsStatus, showStatus: showUnitsStatus } = useTransientStatus();
-    const { status: accountStatus, showStatus: showAccountStatus } = useTransientStatus();
 
     const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
     const [timezoneValue, setTimezoneValue] = useState(() => user?.timezone ?? detectedTimezone);
@@ -94,21 +91,13 @@ const Settings: React.FC = () => {
         }
     };
 
-    /**
-     * Clear the current session and return the user to the login screen.
-     */
-    const handleLogout = async () => {
-        try {
-            await logout();
-            navigate('/login');
-        } catch {
-            showAccountStatus('Failed to log out', 'error');
-        }
-    };
-
     return (
         <AppPage maxWidth="content">
             <Stack spacing={sectionGap} useFlexGap>
+                <ProfilePhotoCard description="Used for your avatar in the app bar." />
+
+                <AccountSecurityCard />
+
                 <AppCard>
                     <SectionHeader title="Units & Localization" sx={{ mb: 0.5 }} />
 
@@ -152,21 +141,6 @@ const Settings: React.FC = () => {
                                 : 'Persisted on this device.'}
                         </FormHelperText>
                     </FormControl>
-                </AppCard>
-
-                <AppCard>
-                    <SectionHeader title="Account" sx={{ mb: 0.5 }} />
-                    <InlineStatusLine status={accountStatus} sx={{ mb: 1 }} />
-
-                    <Button
-                        variant="outlined"
-                        color="error"
-                        startIcon={<LogoutIcon />}
-                        onClick={() => void handleLogout()}
-                        fullWidth
-                    >
-                        Log out
-                    </Button>
                 </AppCard>
             </Stack>
         </AppPage>


### PR DESCRIPTION
## Intent
The `/profile` page was mixing two concerns (body inputs used for calorie math vs. account/security settings). This change splits those responsibilities so each destination is cohesive and the Dashboard "Calorie Target" CTA lands on the correct page.

## UX / Navigation
- `/profile` is now **body-profile + TDEE inputs only** (Calorie Target breakdown + autosaving DOB/sex/height/activity).
- `/settings` is now the home for **account management + preferences**, and starts with account content:
  - profile photo
  - email + change password
  - logout
- App bar avatar now navigates to `/settings`.
- Mobile bottom nav swaps the "Settings" tab for a "Profile" tab that navigates to `/profile`.
- Desktop drawer adds "Profile" in the primary nav list; "Settings" remains in the lower (secondary) section.

## Implementation Notes
- `frontend/src/pages/Profile.tsx`
  - Removed account/photo/password UI.
  - Added a labeled "Body profile" card wrapping the autosaving TDEE inputs.
- `frontend/src/components/AccountSecurityCard.tsx`
  - New component extracted from the old Profile "Account" section.
  - Owns the change-password dialog + logout action while keeping Settings cohesive.
- `frontend/src/pages/Settings.tsx`
  - Reordered sections so Account content comes first.
  - Uses `ProfilePhotoCard` + `AccountSecurityCard`, then Units/Localization, then Appearance.
- `frontend/src/components/Layout.tsx`
  - Updated avatar shortcut to open Settings.
  - Updated drawer + bottom nav destinations and active-tab mapping.
- `frontend/src/pages/Onboarding.tsx`
  - Updated profile-photo copy to point users to Settings (not Profile).

## Reviewer Notes
- Dashboard `CalorieTargetBanner` already links to `/profile`; after this split it now lands on the body-profile page as intended.
- Settings no longer appears as a bottom-nav tab; it is reachable via the app-bar avatar and from the desktop drawer.

## Test Plan
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
