### PR TITLE
Improve /log weight entry UX

### DIFF
--- a/frontend/src/components/WeightEntryForm.tsx
+++ b/frontend/src/components/WeightEntryForm.tsx
@@ -1,34 +1,65 @@
-import React, { useState } from 'react';
-import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack, TextField, Typography } from '@mui/material';
+import React, { useId, useMemo, useState } from 'react';
+import {
+    Alert,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    InputAdornment,
+    Link,
+    Stack,
+    TextField,
+    Typography
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/AddRounded';
+import RemoveIcon from '@mui/icons-material/RemoveRounded';
 import axios from 'axios';
+import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getTodayIsoDate } from '../utils/date';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { formatIsoDateForDisplay, getTodayIsoDate } from '../utils/date';
 import { getApiErrorMessage } from '../utils/apiError';
+import {
+    findMetricOnOrBeforeDate,
+    type MetricEntry,
+    metricsQueryKey,
+    toDatePart,
+    useMetricsQuery
+} from '../queries/metrics';
 
 type Props = {
     onSuccess?: () => void;
     date?: string;
 };
 
-type MetricEntry = {
-    id: number;
-    date: string;
-    weight: number;
-};
+const WEIGHT_ENTRY_STEP = 0.1; // Weight logs are captured at 0.1 resolution (matches backend rounding).
+const WEIGHT_ENTRY_MIN = 0.1; // Prevents obviously-invalid non-positive weights.
 
 /**
- * Fetch the current user's metric entry for a single day, if it exists.
+ * Parse a weight input string into a finite number.
+ *
+ * Returns `null` for empty/invalid values so callers can distinguish "unset" from "0".
  */
-async function fetchMetricForDate(date: string): Promise<MetricEntry | null> {
-    const res = await axios.get('/api/metrics', { params: { start: date, end: date } });
-    const metrics = Array.isArray(res.data) ? (res.data as MetricEntry[]) : [];
-    return metrics[0] ?? null;
+function parseWeightInput(value: string): number | null {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Round a numeric weight to tenths to prevent floating point drift when stepping.
+ */
+function roundWeightToTenth(value: number): number {
+    return Math.round(value * 10) / 10;
 }
 
 type WeightEntryFormContentProps = {
     entryDate: string;
     existingMetric: MetricEntry | null;
+    prefillMetric: MetricEntry | null;
     isLoadingExistingMetric: boolean;
     isExistingMetricError: boolean;
     weightUnitLabel: string;
@@ -44,22 +75,37 @@ type WeightEntryFormContentProps = {
 const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
     entryDate,
     existingMetric,
+    prefillMetric,
     isLoadingExistingMetric,
     isExistingMetricError,
     weightUnitLabel,
     onSuccess
 }) => {
     const queryClient = useQueryClient();
-    const [weight, setWeight] = useState(() => (existingMetric ? String(existingMetric.weight) : ''));
+    const [weight, setWeight] = useState(() => (prefillMetric ? String(prefillMetric.weight) : ''));
     const [error, setError] = useState<string | null>(null);
     const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+
+    const parsedWeight = useMemo(() => parseWeightInput(weight), [weight]);
+    const entryDateLabel = useMemo(() => formatIsoDateForDisplay(entryDate), [entryDate]);
+    const prefillDateLabel = useMemo(() => {
+        if (!prefillMetric) return null;
+        return formatIsoDateForDisplay(toDatePart(prefillMetric.date));
+    }, [prefillMetric]);
+    const weightFieldError = useMemo(() => {
+        if (!weight.trim()) return null;
+        if (parsedWeight === null) return 'Enter a valid number.';
+        if (parsedWeight <= 0) return 'Weight must be positive.';
+        if (parsedWeight < WEIGHT_ENTRY_MIN) return `Weight must be at least ${WEIGHT_ENTRY_MIN} ${weightUnitLabel}.`;
+        return null;
+    }, [parsedWeight, weight, weightUnitLabel]);
 
     const saveMutation = useMutation({
         mutationFn: async () => {
             await axios.post('/api/metrics', { weight, date: entryDate });
         },
         onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: ['metrics'] });
+            await queryClient.invalidateQueries({ queryKey: metricsQueryKey() });
             await queryClient.invalidateQueries({ queryKey: ['user-profile'] });
             await queryClient.invalidateQueries({ queryKey: ['profile'] });
         }
@@ -70,7 +116,7 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
             await axios.delete(`/api/metrics/${encodeURIComponent(String(id))}`);
         },
         onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: ['metrics'] });
+            await queryClient.invalidateQueries({ queryKey: metricsQueryKey() });
             await queryClient.invalidateQueries({ queryKey: ['user-profile'] });
             await queryClient.invalidateQueries({ queryKey: ['profile'] });
         }
@@ -93,6 +139,7 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
     const handleSubmit = (event: React.FormEvent) => {
         event.preventDefault();
         if (saveMutation.isPending || deleteMutation.isPending || isLoadingExistingMetric) return;
+        if (!weight.trim() || weightFieldError) return;
         void handleSave();
     };
 
@@ -109,28 +156,94 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
         }
     };
 
+    /**
+     * Adjust the weight input up/down by a single step, clamped to the minimum.
+     *
+     * Uses the current input when valid, otherwise falls back to the best available prior value.
+     */
+    const stepperBase = (parsedWeight !== null && parsedWeight > 0 ? parsedWeight : prefillMetric?.weight) ?? null;
+
+    const rawFormId = useId();
+    const formId = `weight-entry-form-${rawFormId.replace(/:/g, '')}`;
+
+    const handleStepWeight = (delta: number) => {
+        if (stepperBase === null) return;
+        const next = Math.max(WEIGHT_ENTRY_MIN, roundWeightToTenth(stepperBase + delta));
+        setWeight(next.toFixed(1));
+    };
+
+    const isBusy = isLoadingExistingMetric || saveMutation.isPending || deleteMutation.isPending;
+    const canSubmit = !isBusy && !!weight.trim() && !weightFieldError;
+    const submitLabel = existingMetric ? 'Save Weight' : 'Add Weight';
+
     return (
-        <Stack spacing={2} component="form" onSubmit={handleSubmit}>
-            {error && <Alert severity="error">{error}</Alert>}
-            {isExistingMetricError && !error && (
-                <Alert severity="warning">Unable to load the existing weight entry for this day.</Alert>
-            )}
-            {existingMetric && (
-                <Typography variant="body2" color="text.secondary">
-                    Existing entry found for {entryDate}. Saving will overwrite it.
-                </Typography>
-            )}
-            <TextField
-                label={`Weight (${weightUnitLabel})`}
-                type="number"
-                fullWidth
-                value={weight}
-                onChange={(e) => setWeight(e.target.value)}
-                inputProps={{ step: 0.1 }}
-                disabled={isLoadingExistingMetric || saveMutation.isPending || deleteMutation.isPending}
-                required={!existingMetric}
-            />
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
+        <>
+            <DialogContent>
+                <Stack spacing={2} component="form" id={formId} onSubmit={handleSubmit} sx={{ mt: 1 }}>
+                    {error && <Alert severity="error">{error}</Alert>}
+                    {isExistingMetricError && !error && (
+                        <Alert severity="warning">Unable to load the existing weight entry for this day.</Alert>
+                    )}
+                    {existingMetric && (
+                        <Typography variant="body2" color="text.secondary">
+                            Existing entry found for {entryDateLabel}. Saving will overwrite it.
+                        </Typography>
+                    )}
+
+                    {!existingMetric && prefillMetric && (
+                        <Typography variant="body2" color="text.secondary">
+                            Prefilled from your last weigh-in ({prefillDateLabel ?? toDatePart(prefillMetric.date)}).
+                        </Typography>
+                    )}
+                    <TextField
+                        label={`Weight (${weightUnitLabel})`}
+                        type="number"
+                        fullWidth
+                        value={weight}
+                        onChange={(e) => setWeight(e.target.value)}
+                        autoFocus
+                        inputProps={{ min: WEIGHT_ENTRY_MIN, step: WEIGHT_ENTRY_STEP, inputMode: 'decimal' }}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        aria-label={`Decrease weight by ${WEIGHT_ENTRY_STEP} ${weightUnitLabel}`}
+                                        size="small"
+                                        edge="end"
+                                        onClick={() => handleStepWeight(-WEIGHT_ENTRY_STEP)}
+                                        disabled={isBusy || stepperBase === null}
+                                    >
+                                        <RemoveIcon fontSize="small" />
+                                    </IconButton>
+                                    <IconButton
+                                        aria-label={`Increase weight by ${WEIGHT_ENTRY_STEP} ${weightUnitLabel}`}
+                                        size="small"
+                                        edge="end"
+                                        onClick={() => handleStepWeight(WEIGHT_ENTRY_STEP)}
+                                        disabled={isBusy || stepperBase === null}
+                                    >
+                                        <AddIcon fontSize="small" />
+                                    </IconButton>
+                                </InputAdornment>
+                            )
+                        }}
+                        error={Boolean(weightFieldError)}
+                        helperText={weightFieldError ?? ' '}
+                        disabled={isBusy}
+                        required
+                    />
+
+                    <Typography variant="caption" color="text.secondary">
+                        Want to change units? Update them in{' '}
+                        <Link component={RouterLink} to="/settings">
+                            Settings
+                        </Link>
+                        .
+                    </Typography>
+                </Stack>
+            </DialogContent>
+
+            <DialogActions>
                 {existingMetric && (
                     <Button
                         type="button"
@@ -144,17 +257,20 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
                 )}
                 <Button
                     type="submit"
+                    form={formId}
                     variant="contained"
-                    disabled={!weight || deleteMutation.isPending || saveMutation.isPending || isLoadingExistingMetric}
+                    disabled={!canSubmit}
                 >
-                    {existingMetric ? 'Save Weight' : 'Add Weight'}
+                    {submitLabel}
                 </Button>
-            </Stack>
+            </DialogActions>
 
             <Dialog open={isDeleteConfirmOpen} onClose={() => setIsDeleteConfirmOpen(false)} fullWidth maxWidth="xs">
                 <DialogTitle>Delete weight entry?</DialogTitle>
                 <DialogContent>
-                    <Typography sx={{ mt: 1 }}>Delete the weight entry for {entryDate}? This cannot be undone.</Typography>
+                    <Typography sx={{ mt: 1 }}>
+                        Delete the weight entry for {entryDateLabel}? This cannot be undone.
+                    </Typography>
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={() => setIsDeleteConfirmOpen(false)} disabled={deleteMutation.isPending}>
@@ -170,7 +286,7 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
                     </Button>
                 </DialogActions>
             </Dialog>
-        </Stack>
+        </>
     );
 };
 
@@ -180,21 +296,28 @@ const WeightEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
 
     const entryDate = date ?? getTodayIsoDate(user?.timezone);
 
-    const metricQuery = useQuery({
-        queryKey: ['metrics', entryDate],
-        queryFn: async () => fetchMetricForDate(entryDate)
-    });
+    const metricsQuery = useMetricsQuery();
+    const metrics = useMemo(() => metricsQuery.data ?? [], [metricsQuery.data]);
 
-    const existingMetric = metricQuery.data ?? null;
-    const contentKey = `${entryDate}:${existingMetric?.id ?? 'new'}`;
+    const existingMetric = useMemo(() => {
+        return metrics.find((metric) => toDatePart(metric.date) === entryDate) ?? null;
+    }, [entryDate, metrics]);
+
+    const prefillMetric = useMemo(() => {
+        if (existingMetric) return existingMetric;
+        return findMetricOnOrBeforeDate(metrics, entryDate);
+    }, [entryDate, existingMetric, metrics]);
+
+    const contentKey = `${entryDate}:${existingMetric?.id ?? 'new'}:${prefillMetric?.id ?? 'none'}`;
 
     return (
         <WeightEntryFormContent
             key={contentKey}
             entryDate={entryDate}
             existingMetric={existingMetric}
-            isLoadingExistingMetric={metricQuery.isLoading}
-            isExistingMetricError={metricQuery.isError}
+            prefillMetric={prefillMetric}
+            isLoadingExistingMetric={metricsQuery.isLoading}
+            isExistingMetricError={metricsQuery.isError}
             weightUnitLabel={weightUnitLabel}
             onSuccess={onSuccess}
         />

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -10,12 +10,14 @@ import {
     IconButton,
     TextField,
     Tooltip,
+    Typography,
 } from '@mui/material';
 import SpeedDial from '@mui/material/SpeedDial';
 import SpeedDialAction from '@mui/material/SpeedDialAction';
 import AddIcon from '@mui/icons-material/AddRounded';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeftRounded';
 import ChevronRightIcon from '@mui/icons-material/ChevronRightRounded';
+import CloseIcon from '@mui/icons-material/CloseRounded';
 import TodayIcon from '@mui/icons-material/TodayRounded';
 import RestaurantIcon from '@mui/icons-material/RestaurantRounded';
 import MonitorWeightIcon from '@mui/icons-material/MonitorWeightRounded';
@@ -26,7 +28,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import LogSummaryCard from '../components/LogSummaryCard';
 import WeightSummaryCard from '../components/WeightSummaryCard';
 import { useAuth } from '../context/useAuth';
-import { addDaysToIsoDate, clampIsoDate, formatDateToLocalDateString, getTodayIsoDate } from '../utils/date';
+import {
+    addDaysToIsoDate,
+    clampIsoDate,
+    formatDateToLocalDateString,
+    formatIsoDateForDisplay,
+    getTodayIsoDate
+} from '../utils/date';
 import { fetchFoodLog, foodLogQueryKey, useFoodLogQuery } from '../queries/foodLog';
 import AppCard from '../ui/AppCard';
 
@@ -115,6 +123,7 @@ const Log: React.FC = () => {
     }, [dateBounds]);
 
     const effectiveDate = clampIsoDate(selectedDate, dateBounds);
+    const effectiveDateLabel = useMemo(() => formatIsoDateForDisplay(effectiveDate), [effectiveDate]);
 
     const foodQuery = useFoodLogQuery(effectiveDate);
 
@@ -354,23 +363,33 @@ const Log: React.FC = () => {
             </Dialog>
 
             <Dialog open={isWeightDialogOpen} onClose={handleCloseWeightDialog} fullWidth maxWidth="sm">
-                <DialogTitle>Track Weight</DialogTitle>
-                <DialogContent>
-                    <Box sx={{ mt: 1 }}>
-                        <WeightEntryForm
-                            date={effectiveDate}
-                            onSuccess={() => {
-                                void queryClient.invalidateQueries({ queryKey: ['metrics'] });
-                                void queryClient.invalidateQueries({ queryKey: ['user-profile'] });
-                                void queryClient.invalidateQueries({ queryKey: ['profile'] });
-                                handleCloseWeightDialog();
-                            }}
-                        />
+                <DialogTitle sx={{ position: 'relative', pr: 6 }}>
+                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                        <Box component="span">Track Weight</Box>
+                        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                            For {effectiveDateLabel} (the day you're viewing)
+                        </Typography>
                     </Box>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleCloseWeightDialog}>Close</Button>
-                </DialogActions>
+
+                    <Tooltip title="Close">
+                        <IconButton
+                            aria-label="Close"
+                            onClick={handleCloseWeightDialog}
+                            sx={{ position: 'absolute', right: 8, top: 8 }}
+                        >
+                            <CloseIcon />
+                        </IconButton>
+                    </Tooltip>
+                </DialogTitle>
+                <WeightEntryForm
+                    date={effectiveDate}
+                    onSuccess={() => {
+                        void queryClient.invalidateQueries({ queryKey: ['metrics'] });
+                        void queryClient.invalidateQueries({ queryKey: ['user-profile'] });
+                        void queryClient.invalidateQueries({ queryKey: ['profile'] });
+                        handleCloseWeightDialog();
+                    }}
+                />
             </Dialog>
         </Box>
     );

--- a/frontend/src/queries/metrics.ts
+++ b/frontend/src/queries/metrics.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export type MetricEntry = {
+    id: number;
+    date: string;
+    weight: number;
+};
+
+/**
+ * Build the canonical React Query key for the current user's weight history.
+ */
+export function metricsQueryKey() {
+    return ['metrics'] as const;
+}
+
+/**
+ * Fetch the current user's weight entries (descending by date).
+ */
+export async function fetchMetrics(): Promise<MetricEntry[]> {
+    const res = await axios.get('/api/metrics');
+    return Array.isArray(res.data) ? (res.data as MetricEntry[]) : [];
+}
+
+/**
+ * Shared hook for loading the current user's weight history.
+ *
+ * Centralizing this ensures /log widgets and dialogs share caching behavior.
+ */
+export function useMetricsQuery(options?: { enabled?: boolean }) {
+    return useQuery({
+        queryKey: metricsQueryKey(),
+        queryFn: fetchMetrics,
+        enabled: options?.enabled
+    });
+}
+
+/**
+ * Extract the date-only portion of a timestamp-like string (e.g. "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SSZ").
+ */
+export function toDatePart(value: string): string {
+    return value.split('T')[0] ?? value;
+}
+
+/**
+ * Return the most recent metric on-or-before a given local date string (`YYYY-MM-DD`).
+ *
+ * Metrics are expected to be in descending date order.
+ */
+export function findMetricOnOrBeforeDate(metrics: MetricEntry[], targetDate: string): MetricEntry | null {
+    for (const metric of metrics) {
+        const metricDate = toDatePart(metric.date);
+        if (metricDate <= targetDate) return metric;
+    }
+    return null;
+}
+


### PR DESCRIPTION
## Intent

Improve the weigh-in logging UX on `/log` by preventing invalid inputs, making it faster to enter a realistic value, and clarifying which day the entry will be saved against (selected log day vs. "today").

## UX / Behavior Changes

- Weight input now enforces positive values at the UI level (server already rejects <= 0).
- Adds a Settings link for changing unit preferences.
- When there isn't already an entry for the selected day, pre-fills from the most recent prior weigh-in.
- Adds +/- controls to step weight by 0.1 for quick adjustments (in addition to numeric `step`).
- Makes the weight dialog explicit about the target day in the title.
- Moves primary actions into the dialog footer; closes via top-right X (removes redundant bottom Close).

## Implementation Notes

- `frontend/src/queries/metrics.ts`
  - Introduces `useMetricsQuery()` + `metricsQueryKey()` for shared weight history fetching/caching.
  - Adds `toDatePart()` + `findMetricOnOrBeforeDate()` helpers for date-only comparisons.
- `frontend/src/components/WeightSummaryCard.tsx`
  - Switched to `useMetricsQuery()` to share cache with the form.
- `frontend/src/components/WeightEntryForm.tsx`
  - Uses cached metrics to resolve `existingMetric` for `entryDate` and `prefillMetric` (on-or-before).
  - Adds local validation + disables submit on invalid values; adds stepper buttons; keeps rounding stable at tenths.
  - Refactors layout to render `DialogContent` + `DialogActions` inside the form component so actions sit below the divider.
- `frontend/src/pages/Log.tsx`
  - Enhances the weight dialog title with the formatted selected date and adds a top-right close icon.

## Verification

- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
