### PR TITLE
Clamp Mifflin-St Jeor age input to 19-79

### DIFF
--- a/backend/src/utils/profile.ts
+++ b/backend/src/utils/profile.ts
@@ -39,8 +39,23 @@ export const calculateAge = (dateOfBirth: Date, now: Date = new Date()): number 
     return age;
 };
 
+const MIFFLIN_ST_JEOR_VALID_AGE_YEARS = {
+    min: 19,
+    max: 79
+} as const;
+
+/**
+ * Clamp an age (in years) to the validation range for the Mifflin-St Jeor equation.
+ *
+ * The equation is intended for adults; extrapolating outside 19-79 years quickly
+ * yields unrealistic BMR/TDEE outputs, so we cap to the nearest bound.
+ */
+const clampAgeForMifflinStJeor = (ageYears: number): number =>
+    Math.min(MIFFLIN_ST_JEOR_VALID_AGE_YEARS.max, Math.max(MIFFLIN_ST_JEOR_VALID_AGE_YEARS.min, ageYears));
+
 export const calculateBmr = (sex: Sex, weightKg: number, heightCm: number, ageYears: number): number => {
-    const base = 10 * weightKg + 6.25 * heightCm - 5 * ageYears;
+    const clampedAgeYears = clampAgeForMifflinStJeor(ageYears);
+    const base = 10 * weightKg + 6.25 * heightCm - 5 * clampedAgeYears;
     return Math.round((sex === 'MALE' ? base + 5 : base - 161) * 10) / 10;
 };
 

--- a/backend/test/profile-utils.test.js
+++ b/backend/test/profile-utils.test.js
@@ -46,6 +46,14 @@ test('profile utils: calculateBmr matches Mifflin-St Jeor and rounds to 0.1', ()
   assert.equal(calculateBmr('FEMALE', 82, 175, 35), 1577.8);
 });
 
+test('profile utils: calculateBmr clamps ages outside 19-79 to avoid unrealistic extrapolation', () => {
+  assert.equal(calculateBmr('MALE', 82, 175, 18), calculateBmr('MALE', 82, 175, 19));
+  assert.equal(calculateBmr('MALE', 82, 175, -5), calculateBmr('MALE', 82, 175, 19));
+
+  assert.equal(calculateBmr('FEMALE', 82, 175, 80), calculateBmr('FEMALE', 82, 175, 79));
+  assert.equal(calculateBmr('FEMALE', 82, 175, 150), calculateBmr('FEMALE', 82, 175, 79));
+});
+
 test('profile utils: activityMultiplier matches the configured mapping', () => {
   assert.equal(activityMultiplier('SEDENTARY'), 1.2);
   assert.equal(activityMultiplier('LIGHT'), 1.375);


### PR DESCRIPTION
## Intent

Mifflin-St Jeor is validated for ages 19-79. Today we feed it the raw age computed from `date_of_birth`, which can be <19 or >79 (including bad DOB entries), producing increasingly unrealistic BMR/TDEE outputs.

## Approach

Clamp the age-years input to the nearest valid bound (19 or 79) before applying the equation. This keeps `calculateAge()` semantics unchanged for any other consumers; only the Mifflin-St Jeor input is constrained.

## Implementation

- Add `MIFFLIN_ST_JEOR_VALID_AGE_YEARS` and `clampAgeForMifflinStJeor()` and apply it inside `calculateBmr()`: `backend/src/utils/profile.ts`
- The `/user/profile` calorie summary (BMR/TDEE) now uses the clamped age when out of range: `backend/src/routes/user.ts` -> `buildCalorieSummary()`

## Tests

- Add coverage to assert ages <19 behave like 19, and ages >79 behave like 79: `backend/test/profile-utils.test.js`

## Notes

This is still an approximation for out-of-range users, but avoids extreme/absurd values from extrapolation without changing persisted data or API shapes.