### PR TITLE
Rebrand: cal.io -> calibrate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# cal-io — Intent, Goals, and Design Requirements
+# calibrate — Intent, Goals, and Design Requirements
 
 ## Product Intent
-cal-io is a responsive calorie tracker (desktop + mobile web) for users who want to lose (or manage) weight by monitoring calorie intake vs. expected calorie expenditure.
+calibrate is a responsive calorie tracker (desktop + mobile web) for users who want to lose (or manage) weight by monitoring calorie intake vs. expected calorie expenditure.
 
 ## Target Stack
 - Frontend: React + TypeScript + Vite (UI via MUI)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# cal-io
+# calibrate
 
 Responsive calorie tracker (React + Vite frontend, Node/Express backend, Postgres + Prisma).
+
+Official domain: calibratehealth.app
 
 ## Quickstart (devcontainer)
 

--- a/backend/src/services/devTestData.ts
+++ b/backend/src/services/devTestData.ts
@@ -5,7 +5,7 @@ import prisma from '../config/database';
 import { ActivityLevel, HeightUnit, MealPeriod, Sex, WeightUnit } from '@prisma/client';
 import { formatDateToLocalDateString, normalizeToUtcDateOnly } from '../utils/date';
 
-const TEST_USER_EMAIL = 'test@cal.io';
+const TEST_USER_EMAIL = 'test@calibratehealth.app';
 const TEST_USER_PASSWORD = 'password123';
 const TEST_USER_TIMEZONE = 'America/Los_Angeles';
 

--- a/backend/src/services/foodData/openFoodFactsProvider.ts
+++ b/backend/src/services/foodData/openFoodFactsProvider.ts
@@ -206,7 +206,7 @@ class OpenFoodFactsProvider implements FoodDataProvider {
         page: number,
         languageCode?: string
     ): Promise<Response> {
-        const headers = { 'User-Agent': 'cal-io/food-search' };
+        const headers = { 'User-Agent': 'calibrate/food-search' };
         const v2Params = new URLSearchParams({
             search_terms: query,
             page_size: String(pageSize),
@@ -230,7 +230,7 @@ class OpenFoodFactsProvider implements FoodDataProvider {
         page: number,
         languageCode?: string
     ): Promise<Response> {
-        const headers = { 'User-Agent': 'cal-io/food-search' };
+        const headers = { 'User-Agent': 'calibrate/food-search' };
         const legacyParams = new URLSearchParams({
             search_terms: query,
             search_simple: '1',
@@ -255,7 +255,7 @@ class OpenFoodFactsProvider implements FoodDataProvider {
         if (languageCode) {
             params.set('lc', languageCode);
         }
-        const headers = { 'User-Agent': 'cal-io/food-search' };
+        const headers = { 'User-Agent': 'calibrate/food-search' };
         const response = await this.fetchWithTimeout(
             `${this.baseUrl}/api/v2/product/${encodeURIComponent(barcode)}?${params.toString()}`,
             headers

--- a/backend/src/utils/devAuth.ts
+++ b/backend/src/utils/devAuth.ts
@@ -2,7 +2,7 @@ import type { NextFunction, Request, Response } from 'express';
 import prisma from '../config/database';
 import { ensureDevTestData } from '../services/devTestData';
 
-const TEST_USER_EMAIL = 'test@cal.io';
+const TEST_USER_EMAIL = 'test@calibratehealth.app';
 
 /**
  * Decide whether the current request should auto-login the local test user.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,11 +6,11 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="theme-color" content="#111827" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-title" content="cal.io" />
+    <meta name="apple-mobile-web-app-title" content="calibrate" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>cal.io</title>
+    <title>calibrate</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/icon.svg
+++ b/frontend/public/icon.svg
@@ -4,7 +4,7 @@
   height="512"
   viewBox="0 0 512 512"
   role="img"
-  aria-label="cal.io"
+  aria-label="calibrate"
 >
   <defs>
     <linearGradient id="ring" x1="96" y1="416" x2="416" y2="96" gradientUnits="userSpaceOnUse">
@@ -24,4 +24,3 @@
   />
   <circle cx="365" cy="165" r="18" fill="#22c55e" />
 </svg>
-

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -154,7 +154,7 @@ const Layout: React.FC = () => {
                             to={user ? '/dashboard' : '/'}
                             sx={{ color: 'inherit', textDecoration: 'none' }}
                         >
-                            cal.io
+                            calibrate
                         </Typography>
                         {worktreeBadgeLabel && (
                             <Box
@@ -186,7 +186,7 @@ const Layout: React.FC = () => {
                             target="_blank"
                             rel="noreferrer"
                             color="inherit"
-                            aria-label="Open the cal.io GitHub repository"
+                            aria-label="Open the source repository on GitHub"
                         >
                             <GitHubIcon />
                         </IconButton>

--- a/frontend/src/context/ThemeModeContext.tsx
+++ b/frontend/src/context/ThemeModeContext.tsx
@@ -4,7 +4,8 @@ import { CssBaseline, ThemeProvider, useMediaQuery } from '@mui/material';
 import { createAppTheme } from '../theme';
 import { ThemeModeContext, type ThemeModeContextValue, type ThemePreference } from './themeModeContext';
 
-const THEME_PREFERENCE_STORAGE_KEY = 'calio.themePreference';
+const THEME_PREFERENCE_STORAGE_KEY = 'calibrate.themePreference';
+const LEGACY_THEME_PREFERENCE_STORAGE_KEY = 'calio.themePreference';
 
 /**
  * Type guard for values we allow to be stored/used as theme preferences.
@@ -19,7 +20,17 @@ function isThemePreference(value: unknown): value is ThemePreference {
 function readStoredThemePreference(): ThemePreference | null {
     try {
         const stored = window.localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY);
-        return isThemePreference(stored) ? stored : null;
+        if (isThemePreference(stored)) return stored;
+
+        const legacyStored = window.localStorage.getItem(LEGACY_THEME_PREFERENCE_STORAGE_KEY);
+        if (isThemePreference(legacyStored)) {
+            // Best-effort migrate legacy cal-io branding to calibrate without losing user preference.
+            window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, legacyStored);
+            window.localStorage.removeItem(LEGACY_THEME_PREFERENCE_STORAGE_KEY);
+            return legacyStored;
+        }
+
+        return null;
     } catch {
         return null;
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,11 +13,11 @@ const queryClient = new QueryClient()
  * Build the browser tab title, adding the dev worktree name when available.
  */
 function getBrowserTitle() {
-  const baseTitle = 'cal.io'
+  const baseTitle = 'calibrate'
   if (!import.meta.env.DEV) return baseTitle
   const worktreeName = __WORKTREE_NAME__?.trim()
   if (!worktreeName) return baseTitle
-  return `${worktreeName}.cal.io`
+  return `${worktreeName}.calibrate`
 }
 
 /**

--- a/frontend/src/pages/DevDashboard.tsx
+++ b/frontend/src/pages/DevDashboard.tsx
@@ -149,7 +149,7 @@ const DevDashboard: React.FC = () => {
 
         try {
             const response = await axios.post<ResetTestUserOnboardingResponse>('/dev/test/reset-test-user-onboarding');
-            const email = response.data?.user?.email ?? 'test@cal.io';
+            const email = response.data?.user?.email ?? 'test@calibratehealth.app';
             setResetSuccess(`Reset complete for ${email}. Navigate to /onboarding (or refresh a protected page) to re-test onboarding.`);
         } catch (err) {
             console.error(err);

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -180,7 +180,7 @@ const Landing: React.FC = () => {
                                     </Typography>
 
                                     <Typography variant="h6" color="text.secondary" sx={{ maxWidth: '56ch' }}>
-                                        cal.io is the free, self-hostable health and fitness tracker. No subscription, no ads, no nonsense.
+                                        calibrate is the free, self-hostable health and fitness tracker. No subscription, no ads, no nonsense.
                                     </Typography>
                                 </Stack>
 
@@ -252,7 +252,7 @@ const Landing: React.FC = () => {
                             Losing weight shouldn&apos;t cost an arm and a leg
                         </Typography>
                         <Typography variant="body1" color="text.secondary" sx={{ maxWidth: '80ch' }}>
-                            cal.io is built to be available to everybody - free to use, clean and ad-free, and self-hostable so
+                            calibrate is built to be available to everybody - free to use, clean and ad-free, and self-hostable so
                             you can run it on your own terms. No catch.
                         </Typography>
                     </Stack>

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -763,7 +763,7 @@ const Onboarding: React.FC = () => {
         cardBodyContent = (
             <Box>
                 <Typography variant="h4" gutterBottom>
-                    Welcome to cal.io
+                    Welcome to calibrate
                 </Typography>
                 <Typography color="text.secondary">
                     Let&apos;s set a daily calorie target that helps you reach your weight goal.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -45,8 +45,8 @@ function getPwaOptions(): Partial<VitePWAOptions> {
       'pwa-512x512.png',
     ],
     manifest: {
-      name: 'cal.io',
-      short_name: 'cal.io',
+      name: 'calibrate',
+      short_name: 'calibrate',
       description: 'A responsive calorie tracker.',
       theme_color: '#111827',
       background_color: '#111827',


### PR DESCRIPTION
Intent
- Rebrand the app UI and PWA metadata from "cal.io" to "calibrate" and document the new canonical domain (calibratehealth.app).

Change Summary
- Frontend: update HTML title + Apple web app meta, PWA manifest name/short_name, icon aria-label, and landing/onboarding copy.
- Dev/Test: update deterministic dev user email from test@cal.io to test@calibratehealth.app (backend seed + dev dashboard fallback).
- Persistence: migrate theme preference localStorage key from "calio.themePreference" to "calibrate.themePreference" (best-effort, backwards-compatible).
- External: update Open Food Facts User-Agent string to "calibrate/food-search".
- Docs: rename project in README/AGENTS and record the official domain.

Technical Design / Tradeoffs
- Theme key migration reads the new key first, then falls back to the legacy key and migrates/removes it when storage is available.
- Kept the GitHub repo URL as-is (still MChartier/cal-io); only updated the accessible aria-label text.
- This PR does not add runtime "canonical domain" config (CORS/origin/cookie-domain). Domain appears only in docs and dev/test defaults.

Testing
- npm run lint
- npm test
- npm run build

Risks / Rollout Notes / Follow-ups
- Existing dev DBs may still have test@cal.io, so AUTO_LOGIN_TEST_USER may no longer match; reset/seed may be required.
- Verify PWA install name/icon/title on a real device after deployment.
- Follow-up: rename repo/package/image identifiers if we want everything to align with "calibrate".

Code Pointers
- frontend/index.html - document title + Apple web app meta
- frontend/src/main.tsx - dev/prod browser title logic
- frontend/vite.config.ts - PWA manifest name/short_name
- frontend/src/context/ThemeModeContext.tsx - localStorage key migration
- frontend/src/components/Layout.tsx - app bar branding + GitHub aria-label
- frontend/src/pages/Landing.tsx - marketing copy
- frontend/src/pages/Onboarding.tsx - onboarding copy
- backend/src/utils/devAuth.ts - dev auto-login email
- backend/src/services/devTestData.ts - deterministic seed user email
- backend/src/services/foodData/openFoodFactsProvider.ts - User-Agent header
