### PR TITLE
Making ghcr image name lowercase

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -57,7 +57,8 @@ jobs:
           set -euo pipefail
 
           ECR_IMAGE="${{ steps.ecr.outputs.registry }}/${IMAGE_NAME}"
-          GHCR_IMAGE="${GHCR_IMAGE}"
+          # Docker image refs require lowercase repository names (GH owner can be mixed-case).
+          GHCR_IMAGE="${GHCR_IMAGE,,}"
 
           TAGS=()
           TAGS+=("${GHCR_IMAGE}:sha-${GITHUB_SHA}")


### PR DESCRIPTION
Fixing issue where ghcr image name contained "MChartier", which fails to push because it isn't all lowercase.