### PR TITLE
Fixed issue with downloading deploy.sh to EC2 instances

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -151,21 +151,21 @@ jobs:
           )
 
           SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-          while IFS= read -r chunk; do
+          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
             SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/docker-compose.yml.b64\"")
           done < <(base64 -w0 deploy/docker-compose.yml | fold -w "${B64_CHUNK_WIDTH}")
           SSM_COMMANDS+=("base64 -d \"$APP_DIR/docker-compose.yml.b64\" > \"$APP_DIR/docker-compose.yml\"")
           SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
 
           SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-          while IFS= read -r chunk; do
+          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
             SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/Caddyfile.b64\"")
           done < <(base64 -w0 deploy/Caddyfile.staging | fold -w "${B64_CHUNK_WIDTH}")
           SSM_COMMANDS+=("base64 -d \"$APP_DIR/Caddyfile.b64\" > \"$APP_DIR/Caddyfile\"")
           SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
 
           SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-          while IFS= read -r chunk; do
+          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
             SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/deploy.sh.b64\"")
           done < <(base64 -w0 infra/scripts/deploy.sh | fold -w "${B64_CHUNK_WIDTH}")
           SSM_COMMANDS+=("base64 -d \"$APP_DIR/deploy.sh.b64\" > \"$APP_DIR/deploy.sh\"")

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,21 +116,21 @@ jobs:
           )
 
           SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-          while IFS= read -r chunk; do
+          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
             SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/docker-compose.yml.b64\"")
           done < <(base64 -w0 deploy/docker-compose.yml | fold -w "${B64_CHUNK_WIDTH}")
           SSM_COMMANDS+=("base64 -d \"$APP_DIR/docker-compose.yml.b64\" > \"$APP_DIR/docker-compose.yml\"")
           SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
 
           SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-          while IFS= read -r chunk; do
+          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
             SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/Caddyfile.b64\"")
           done < <(base64 -w0 deploy/Caddyfile.prod | fold -w "${B64_CHUNK_WIDTH}")
           SSM_COMMANDS+=("base64 -d \"$APP_DIR/Caddyfile.b64\" > \"$APP_DIR/Caddyfile\"")
           SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
 
           SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-          while IFS= read -r chunk; do
+          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
             SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/deploy.sh.b64\"")
           done < <(base64 -w0 infra/scripts/deploy.sh | fold -w "${B64_CHUNK_WIDTH}")
           SSM_COMMANDS+=("base64 -d \"$APP_DIR/deploy.sh.b64\" > \"$APP_DIR/deploy.sh\"")


### PR DESCRIPTION
Fix applied in both workflows:

  - .github/workflows/container.yml: all three base64 streaming loops now use:
      - while IFS= read -r chunk || [[ -n "${chunk}" ]]; do ...
  - .github/workflows/deploy-prod.yml: same change for docker-compose, Caddyfile, and deploy.sh

  That ensures the final (non-newline-terminated) folded chunk still gets appended, so base64 -d reconstructs the
  full files instead of truncated ones.
