### PR TITLE
infra: move deploy to ECS Fargate + ALB

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -92,199 +92,32 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   deploy_staging:
-    name: Deploy Staging via SSM
+    name: Deploy Staging (ECS)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: build_and_push
     if: github.ref == 'refs/heads/master'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Configure AWS credentials (staging deploy)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Resolve staging instance ID
-        id: instance
+      - name: Force new deployment (ECS)
         shell: bash
         run: |
           set -euo pipefail
-
-          INSTANCE_ID="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:App,Values=${IMAGE_NAME}" \
-              "Name=tag:Environment,Values=staging" \
-              "Name=instance-state-name,Values=running" \
-            --query "Reservations[0].Instances[0].InstanceId" \
-            --output text)"
-
-          if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
-            echo "Unable to find a running staging instance (tag App=${IMAGE_NAME}, Environment=staging)." >&2
-            exit 1
-          fi
-
-          echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
-
-      - name: Run deploy command
-        id: deploy
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          INSTANCE_ID="${{ steps.instance.outputs.instance_id }}"
-          APP_DIR="/opt/${IMAGE_NAME}"
 
           ENVIRONMENT="staging"
-          DB_INSTANCE_IDENTIFIER="${IMAGE_NAME}-${ENVIRONMENT}-postgres"
+          ECS_CLUSTER="${IMAGE_NAME}-${ENVIRONMENT}-cluster"
+          ECS_SERVICE="${IMAGE_NAME}-${ENVIRONMENT}-service"
 
-          require_value() {
-            # Fail fast (and cheaply) before dispatching an SSM command with missing config.
-            local name="$1"
-            local value="$2"
-            if [[ -z "${value}" || "${value}" == "None" || "${value}" == "null" ]]; then
-              echo "Unable to resolve required value: ${name}" >&2
-              exit 1
-            fi
-          }
+          aws ecs update-service \
+            --cluster "${ECS_CLUSTER}" \
+            --service "${ECS_SERVICE}" \
+            --force-new-deployment \
+            >/dev/null
 
-          RDS_INFO_JSON="$(aws rds describe-db-instances \
-            --db-instance-identifier "${DB_INSTANCE_IDENTIFIER}" \
-            --query 'DBInstances[0]' \
-            --output json)"
-
-          RDS_ADDRESS="$(echo "${RDS_INFO_JSON}" | jq -r '.Endpoint.Address // empty')"
-          RDS_PORT="$(echo "${RDS_INFO_JSON}" | jq -r '.Endpoint.Port // empty')"
-          RDS_DB_NAME="$(echo "${RDS_INFO_JSON}" | jq -r '.DBName // empty')"
-          RDS_SECRET_ARN="$(echo "${RDS_INFO_JSON}" | jq -r '.MasterUserSecret.SecretArn // empty')"
-          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-
-          require_value "RDS_ADDRESS" "${RDS_ADDRESS}"
-          require_value "RDS_PORT" "${RDS_PORT}"
-          require_value "RDS_DB_NAME" "${RDS_DB_NAME}"
-          require_value "RDS_SECRET_ARN" "${RDS_SECRET_ARN}"
-          require_value "ACCOUNT_ID" "${ACCOUNT_ID}"
-
-          APP_SECRET_ID="${IMAGE_NAME}/${ENVIRONMENT}/app"
-          ECR_REPOSITORY_URL="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${IMAGE_NAME}"
-          DEPLOY_TAG="${ENVIRONMENT}"
-
-          # Keep the host's deploy artifacts in sync with the repo so we don't rely on
-          # instance bootstrap (user_data) having run recently. Keep chunks comfortably under
-          # common SSM per-command limits.
-          B64_CHUNK_WIDTH=900
-
-          SSM_COMMANDS=(
-            "set -euo pipefail"
-            "APP_DIR=${APP_DIR}"
-            "mkdir -p \"$APP_DIR\""
-            "cat > \"$APP_DIR/config.env\" <<'EOF'"
-            "AWS_REGION=${AWS_REGION}"
-            "APP_NAME=${IMAGE_NAME}"
-            "ENVIRONMENT=${ENVIRONMENT}"
-            "APP_DIR=${APP_DIR}"
-            "APP_SECRET_ARN=${APP_SECRET_ID}"
-            "RDS_SECRET_ARN=${RDS_SECRET_ARN}"
-            "RDS_ADDRESS=${RDS_ADDRESS}"
-            "RDS_PORT=${RDS_PORT}"
-            "RDS_DB_NAME=${RDS_DB_NAME}"
-            "ECR_REPOSITORY_URL=${ECR_REPOSITORY_URL}"
-            "DEPLOY_TAG=${DEPLOY_TAG}"
-            "EOF"
-            "chmod 600 \"$APP_DIR/config.env\""
-            "command -v aws >/dev/null 2>&1 || (dnf -y install awscli2 || dnf -y install awscli)"
-            "command -v jq >/dev/null 2>&1 || dnf -y install jq"
-            "command -v docker >/dev/null 2>&1 || dnf -y install docker"
-            "command -v systemctl >/dev/null 2>&1 && systemctl enable --now docker"
-            "if ! docker compose version >/dev/null 2>&1; then dnf -y install docker-compose-plugin || true; fi"
-            "if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then dnf -y install docker-compose; fi"
-            "if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then echo 'Missing Docker Compose (docker compose or docker-compose)' >&2; exit 1; fi"
-          )
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/docker-compose.yml.b64\"")
-          done < <(base64 -w0 deploy/docker-compose.yml | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/docker-compose.yml.b64\" > \"$APP_DIR/docker-compose.yml\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/Caddyfile.b64\"")
-          done < <(base64 -w0 deploy/Caddyfile.staging | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/Caddyfile.b64\" > \"$APP_DIR/Caddyfile\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/deploy.sh.b64\"")
-          done < <(base64 -w0 infra/scripts/deploy.sh | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/deploy.sh.b64\" > \"$APP_DIR/deploy.sh\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-
-          SSM_COMMANDS+=("chmod +x \"$APP_DIR/deploy.sh\"")
-          SSM_COMMANDS+=("\"$APP_DIR/deploy.sh\"")
-
-          SSM_COMMANDS_JSON="$(printf '%s\n' "${SSM_COMMANDS[@]}" | jq -R . | jq -s .)"
-
-          SEND_COMMAND_PAYLOAD="$(jq -nc \
-            --arg instance_id "${INSTANCE_ID}" \
-            --arg comment "Deploy staging (${GITHUB_SHA})" \
-            --argjson commands "${SSM_COMMANDS_JSON}" \
-            '{
-              InstanceIds: [$instance_id],
-              DocumentName: "AWS-RunShellScript",
-              Comment: $comment,
-              Parameters: { commands: $commands }
-            }')"
-
-          COMMAND_ID="$(aws ssm send-command \
-            --cli-input-json "${SEND_COMMAND_PAYLOAD}" \
-            --query "Command.CommandId" \
-            --output text)"
-
-          echo "command_id=${COMMAND_ID}" >> "$GITHUB_OUTPUT"
-
-          echo "SSM deploy command id: ${COMMAND_ID} (instance: ${INSTANCE_ID})"
-
-          # The waiter exits non-zero on Failed/TimedOut/Cancelled, which prevents us from
-          # fetching stdout/stderr. Always fetch the invocation output and fail explicitly.
-          aws ssm wait command-executed --command-id "${COMMAND_ID}" --instance-id "${INSTANCE_ID}" || true
-
-          STATUS="$(aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'Status' \
-            --output text)"
-
-          RESPONSE_CODE="$(aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'ResponseCode' \
-            --output text)"
-
-          echo "SSM status: ${STATUS} (response_code: ${RESPONSE_CODE})"
-
-          echo "::group::SSM stdout"
-          aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'StandardOutputContent' \
-            --output text
-          echo "::endgroup::"
-
-          echo "::group::SSM stderr"
-          aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'StandardErrorContent' \
-            --output text
-          echo "::endgroup::"
-
-          if [[ "${STATUS}" != "Success" ]]; then
-            echo "SSM deploy failed with status: ${STATUS}" >&2
-            exit 1
-          fi
+          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,15 +18,12 @@ env:
 
 jobs:
   deploy:
-    name: Deploy Prod via SSM
+    name: Deploy Prod (ECS)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Configure AWS credentials (prod deploy)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -71,183 +68,19 @@ jobs:
             --image-tag "prod" \
             --image-manifest "${MANIFEST}" \
             >/dev/null
-
-      - name: Resolve prod instance ID
-        id: instance
+      - name: Force new deployment (ECS)
         shell: bash
         run: |
           set -euo pipefail
-
-          INSTANCE_ID="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:App,Values=${IMAGE_NAME}" \
-              "Name=tag:Environment,Values=prod" \
-              "Name=instance-state-name,Values=running" \
-            --query "Reservations[0].Instances[0].InstanceId" \
-            --output text)"
-
-          if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
-            echo "Unable to find a running prod instance (tag App=${IMAGE_NAME}, Environment=prod)." >&2
-            exit 1
-          fi
-
-          echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
-
-      - name: Run deploy command
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          DEPLOY_SHA="${{ steps.sha.outputs.deploy_sha }}"
-          INSTANCE_ID="${{ steps.instance.outputs.instance_id }}"
-
-          APP_DIR="/opt/${IMAGE_NAME}"
 
           ENVIRONMENT="prod"
-          DB_INSTANCE_IDENTIFIER="${IMAGE_NAME}-${ENVIRONMENT}-postgres"
+          ECS_CLUSTER="${IMAGE_NAME}-${ENVIRONMENT}-cluster"
+          ECS_SERVICE="${IMAGE_NAME}-${ENVIRONMENT}-service"
 
-          require_value() {
-            # Fail fast (and cheaply) before dispatching an SSM command with missing config.
-            local name="$1"
-            local value="$2"
-            if [[ -z "${value}" || "${value}" == "None" || "${value}" == "null" ]]; then
-              echo "Unable to resolve required value: ${name}" >&2
-              exit 1
-            fi
-          }
+          aws ecs update-service \
+            --cluster "${ECS_CLUSTER}" \
+            --service "${ECS_SERVICE}" \
+            --force-new-deployment \
+            >/dev/null
 
-          RDS_INFO_JSON="$(aws rds describe-db-instances \
-            --db-instance-identifier "${DB_INSTANCE_IDENTIFIER}" \
-            --query 'DBInstances[0]' \
-            --output json)"
-
-          RDS_ADDRESS="$(echo "${RDS_INFO_JSON}" | jq -r '.Endpoint.Address // empty')"
-          RDS_PORT="$(echo "${RDS_INFO_JSON}" | jq -r '.Endpoint.Port // empty')"
-          RDS_DB_NAME="$(echo "${RDS_INFO_JSON}" | jq -r '.DBName // empty')"
-          RDS_SECRET_ARN="$(echo "${RDS_INFO_JSON}" | jq -r '.MasterUserSecret.SecretArn // empty')"
-          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-
-          require_value "RDS_ADDRESS" "${RDS_ADDRESS}"
-          require_value "RDS_PORT" "${RDS_PORT}"
-          require_value "RDS_DB_NAME" "${RDS_DB_NAME}"
-          require_value "RDS_SECRET_ARN" "${RDS_SECRET_ARN}"
-          require_value "ACCOUNT_ID" "${ACCOUNT_ID}"
-
-          APP_SECRET_ID="${IMAGE_NAME}/${ENVIRONMENT}/app"
-          ECR_REPOSITORY_URL="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${IMAGE_NAME}"
-          DEPLOY_TAG="${ENVIRONMENT}"
-
-          # Keep the host's deploy artifacts in sync with the repo so we don't rely on
-          # instance bootstrap (user_data) having run recently. Keep chunks comfortably under
-          # common SSM per-command limits.
-          B64_CHUNK_WIDTH=900
-
-          SSM_COMMANDS=(
-            "set -euo pipefail"
-            "APP_DIR=${APP_DIR}"
-            "mkdir -p \"$APP_DIR\""
-            "cat > \"$APP_DIR/config.env\" <<'EOF'"
-            "AWS_REGION=${AWS_REGION}"
-            "APP_NAME=${IMAGE_NAME}"
-            "ENVIRONMENT=${ENVIRONMENT}"
-            "APP_DIR=${APP_DIR}"
-            "APP_SECRET_ARN=${APP_SECRET_ID}"
-            "RDS_SECRET_ARN=${RDS_SECRET_ARN}"
-            "RDS_ADDRESS=${RDS_ADDRESS}"
-            "RDS_PORT=${RDS_PORT}"
-            "RDS_DB_NAME=${RDS_DB_NAME}"
-            "ECR_REPOSITORY_URL=${ECR_REPOSITORY_URL}"
-            "DEPLOY_TAG=${DEPLOY_TAG}"
-            "EOF"
-            "chmod 600 \"$APP_DIR/config.env\""
-            "command -v aws >/dev/null 2>&1 || (dnf -y install awscli2 || dnf -y install awscli)"
-            "command -v jq >/dev/null 2>&1 || dnf -y install jq"
-            "command -v docker >/dev/null 2>&1 || dnf -y install docker"
-            "command -v systemctl >/dev/null 2>&1 && systemctl enable --now docker"
-            "if ! docker compose version >/dev/null 2>&1; then dnf -y install docker-compose-plugin || true; fi"
-            "if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then dnf -y install docker-compose; fi"
-            "if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then echo 'Missing Docker Compose (docker compose or docker-compose)' >&2; exit 1; fi"
-          )
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/docker-compose.yml.b64\"")
-          done < <(base64 -w0 deploy/docker-compose.yml | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/docker-compose.yml.b64\" > \"$APP_DIR/docker-compose.yml\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/Caddyfile.b64\"")
-          done < <(base64 -w0 deploy/Caddyfile.prod | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/Caddyfile.b64\" > \"$APP_DIR/Caddyfile\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/deploy.sh.b64\"")
-          done < <(base64 -w0 infra/scripts/deploy.sh | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/deploy.sh.b64\" > \"$APP_DIR/deploy.sh\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-
-          SSM_COMMANDS+=("chmod +x \"$APP_DIR/deploy.sh\"")
-          SSM_COMMANDS+=("\"$APP_DIR/deploy.sh\"")
-
-          SSM_COMMANDS_JSON="$(printf '%s\n' "${SSM_COMMANDS[@]}" | jq -R . | jq -s .)"
-
-          SEND_COMMAND_PAYLOAD="$(jq -nc \
-            --arg instance_id "${INSTANCE_ID}" \
-            --arg comment "Deploy prod (${DEPLOY_SHA})" \
-            --argjson commands "${SSM_COMMANDS_JSON}" \
-            '{
-              InstanceIds: [$instance_id],
-              DocumentName: "AWS-RunShellScript",
-              Comment: $comment,
-              Parameters: { commands: $commands }
-            }')"
-
-          COMMAND_ID="$(aws ssm send-command \
-            --cli-input-json "${SEND_COMMAND_PAYLOAD}" \
-            --query "Command.CommandId" \
-            --output text)"
-
-          echo "SSM deploy command id: ${COMMAND_ID} (instance: ${INSTANCE_ID})"
-
-          # The waiter exits non-zero on Failed/TimedOut/Cancelled, which prevents us from
-          # fetching stdout/stderr. Always fetch the invocation output and fail explicitly.
-          aws ssm wait command-executed --command-id "${COMMAND_ID}" --instance-id "${INSTANCE_ID}" || true
-
-          STATUS="$(aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'Status' \
-            --output text)"
-
-          RESPONSE_CODE="$(aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'ResponseCode' \
-            --output text)"
-
-          echo "SSM status: ${STATUS} (response_code: ${RESPONSE_CODE})"
-
-          echo "::group::SSM stdout"
-          aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'StandardOutputContent' \
-            --output text
-          echo "::endgroup::"
-
-          echo "::group::SSM stderr"
-          aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'StandardErrorContent' \
-            --output text
-          echo "::endgroup::"
-
-          if [[ "${STATUS}" != "Success" ]]; then
-            echo "SSM deploy failed with status: ${STATUS}" >&2
-            exit 1
-          fi
+          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,194 +13,30 @@ env:
 
 jobs:
   deploy:
-    name: Deploy Staging via SSM
+    name: Deploy Staging (ECS)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Configure AWS credentials (staging deploy)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Resolve staging instance ID
-        id: instance
+      - name: Force new deployment (ECS)
         shell: bash
         run: |
           set -euo pipefail
-
-          INSTANCE_ID="$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:App,Values=${IMAGE_NAME}" \
-              "Name=tag:Environment,Values=staging" \
-              "Name=instance-state-name,Values=running" \
-            --query "Reservations[0].Instances[0].InstanceId" \
-            --output text)"
-
-          if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
-            echo "Unable to find a running staging instance (tag App=${IMAGE_NAME}, Environment=staging)." >&2
-            exit 1
-          fi
-
-          echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
-
-      - name: Run deploy command
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          INSTANCE_ID="${{ steps.instance.outputs.instance_id }}"
-          APP_DIR="/opt/${IMAGE_NAME}"
 
           ENVIRONMENT="staging"
-          DB_INSTANCE_IDENTIFIER="${IMAGE_NAME}-${ENVIRONMENT}-postgres"
+          ECS_CLUSTER="${IMAGE_NAME}-${ENVIRONMENT}-cluster"
+          ECS_SERVICE="${IMAGE_NAME}-${ENVIRONMENT}-service"
 
-          require_value() {
-            # Fail fast (and cheaply) before dispatching an SSM command with missing config.
-            local name="$1"
-            local value="$2"
-            if [[ -z "${value}" || "${value}" == "None" || "${value}" == "null" ]]; then
-              echo "Unable to resolve required value: ${name}" >&2
-              exit 1
-            fi
-          }
+          aws ecs update-service \
+            --cluster "${ECS_CLUSTER}" \
+            --service "${ECS_SERVICE}" \
+            --force-new-deployment \
+            >/dev/null
 
-          RDS_INFO_JSON="$(aws rds describe-db-instances \
-            --db-instance-identifier "${DB_INSTANCE_IDENTIFIER}" \
-            --query 'DBInstances[0]' \
-            --output json)"
-
-          RDS_ADDRESS="$(echo "${RDS_INFO_JSON}" | jq -r '.Endpoint.Address // empty')"
-          RDS_PORT="$(echo "${RDS_INFO_JSON}" | jq -r '.Endpoint.Port // empty')"
-          RDS_DB_NAME="$(echo "${RDS_INFO_JSON}" | jq -r '.DBName // empty')"
-          RDS_SECRET_ARN="$(echo "${RDS_INFO_JSON}" | jq -r '.MasterUserSecret.SecretArn // empty')"
-          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-
-          require_value "RDS_ADDRESS" "${RDS_ADDRESS}"
-          require_value "RDS_PORT" "${RDS_PORT}"
-          require_value "RDS_DB_NAME" "${RDS_DB_NAME}"
-          require_value "RDS_SECRET_ARN" "${RDS_SECRET_ARN}"
-          require_value "ACCOUNT_ID" "${ACCOUNT_ID}"
-
-          APP_SECRET_ID="${IMAGE_NAME}/${ENVIRONMENT}/app"
-          ECR_REPOSITORY_URL="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${IMAGE_NAME}"
-          DEPLOY_TAG="${ENVIRONMENT}"
-
-          # Keep the host's deploy artifacts in sync with the repo so we don't rely on
-          # instance bootstrap (user_data) having run recently. Keep chunks comfortably under
-          # common SSM per-command limits.
-          B64_CHUNK_WIDTH=900
-
-          SSM_COMMANDS=(
-            "set -euo pipefail"
-            "APP_DIR=${APP_DIR}"
-            "mkdir -p \"$APP_DIR\""
-            "cat > \"$APP_DIR/config.env\" <<'EOF'"
-            "AWS_REGION=${AWS_REGION}"
-            "APP_NAME=${IMAGE_NAME}"
-            "ENVIRONMENT=${ENVIRONMENT}"
-            "APP_DIR=${APP_DIR}"
-            "APP_SECRET_ARN=${APP_SECRET_ID}"
-            "RDS_SECRET_ARN=${RDS_SECRET_ARN}"
-            "RDS_ADDRESS=${RDS_ADDRESS}"
-            "RDS_PORT=${RDS_PORT}"
-            "RDS_DB_NAME=${RDS_DB_NAME}"
-            "ECR_REPOSITORY_URL=${ECR_REPOSITORY_URL}"
-            "DEPLOY_TAG=${DEPLOY_TAG}"
-            "EOF"
-            "chmod 600 \"$APP_DIR/config.env\""
-            "command -v aws >/dev/null 2>&1 || (dnf -y install awscli2 || dnf -y install awscli)"
-            "command -v jq >/dev/null 2>&1 || dnf -y install jq"
-            "command -v docker >/dev/null 2>&1 || dnf -y install docker"
-            "command -v systemctl >/dev/null 2>&1 && systemctl enable --now docker"
-            "if ! docker compose version >/dev/null 2>&1; then dnf -y install docker-compose-plugin || true; fi"
-            "if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then dnf -y install docker-compose; fi"
-            "if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then echo 'Missing Docker Compose (docker compose or docker-compose)' >&2; exit 1; fi"
-          )
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/docker-compose.yml.b64\"")
-          done < <(base64 -w0 deploy/docker-compose.yml | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/docker-compose.yml.b64\" > \"$APP_DIR/docker-compose.yml\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/docker-compose.yml.b64\"")
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/Caddyfile.b64\"")
-          done < <(base64 -w0 deploy/Caddyfile.staging | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/Caddyfile.b64\" > \"$APP_DIR/Caddyfile\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/Caddyfile.b64\"")
-
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-          while IFS= read -r chunk || [[ -n "${chunk}" ]]; do
-            SSM_COMMANDS+=("printf '%s\\n' '${chunk}' >> \"$APP_DIR/deploy.sh.b64\"")
-          done < <(base64 -w0 infra/scripts/deploy.sh | fold -w "${B64_CHUNK_WIDTH}")
-          SSM_COMMANDS+=("base64 -d \"$APP_DIR/deploy.sh.b64\" > \"$APP_DIR/deploy.sh\"")
-          SSM_COMMANDS+=("rm -f \"$APP_DIR/deploy.sh.b64\"")
-
-          SSM_COMMANDS+=("chmod +x \"$APP_DIR/deploy.sh\"")
-          SSM_COMMANDS+=("\"$APP_DIR/deploy.sh\"")
-
-          SSM_COMMANDS_JSON="$(printf '%s\n' "${SSM_COMMANDS[@]}" | jq -R . | jq -s .)"
-
-          SEND_COMMAND_PAYLOAD="$(jq -nc \
-            --arg instance_id "${INSTANCE_ID}" \
-            --arg comment "Deploy staging (workflow_dispatch)" \
-            --argjson commands "${SSM_COMMANDS_JSON}" \
-            '{
-              InstanceIds: [$instance_id],
-              DocumentName: "AWS-RunShellScript",
-              Comment: $comment,
-              Parameters: { commands: $commands }
-            }')"
-
-          COMMAND_ID="$(aws ssm send-command \
-            --cli-input-json "${SEND_COMMAND_PAYLOAD}" \
-            --query "Command.CommandId" \
-            --output text)"
-
-          echo "SSM deploy command id: ${COMMAND_ID} (instance: ${INSTANCE_ID})"
-
-          # The waiter exits non-zero on Failed/TimedOut/Cancelled, which prevents us from
-          # fetching stdout/stderr. Always fetch the invocation output and fail explicitly.
-          aws ssm wait command-executed --command-id "${COMMAND_ID}" --instance-id "${INSTANCE_ID}" || true
-
-          STATUS="$(aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'Status' \
-            --output text)"
-
-          RESPONSE_CODE="$(aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'ResponseCode' \
-            --output text)"
-
-          echo "SSM status: ${STATUS} (response_code: ${RESPONSE_CODE})"
-
-          echo "::group::SSM stdout"
-          aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'StandardOutputContent' \
-            --output text
-          echo "::endgroup::"
-
-          echo "::group::SSM stderr"
-          aws ssm get-command-invocation \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}" \
-            --query 'StandardErrorContent' \
-            --output text
-          echo "::endgroup::"
-
-          if [[ "${STATUS}" != "Success" ]]; then
-            echo "SSM deploy failed with status: ${STATUS}" >&2
-            exit 1
-          fi
+          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -38,10 +38,13 @@ COPY --from=build /app/backend/node_modules /app/backend/node_modules
 COPY --from=build /app/backend/dist /app/backend/dist
 COPY --from=build /app/backend/prisma /app/backend/prisma
 COPY --from=build /app/backend/prisma.config.ts /app/backend/prisma.config.ts
+COPY --from=build /app/backend/scripts /app/backend/scripts
 
 COPY --from=build /app/frontend/dist /app/frontend/dist
 
 WORKDIR /app/backend
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+RUN chmod +x /app/backend/scripts/start-prod.sh
+
+CMD ["npm", "run", "start:prod"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "db:studio": "prisma studio",
     "prisma:generate": "prisma generate",
     "start": "node dist/backend/src/index.js",
+    "start:prod": "bash scripts/start-prod.sh",
     "pretest": "npm run prisma:generate",
     "test": "node -r ts-node/register --test",
     "pretest:coverage": "npm run prisma:generate",

--- a/backend/scripts/start-prod.sh
+++ b/backend/scripts/start-prod.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Production container entrypoint.
+#
+# We avoid storing a full DATABASE_URL secret by injecting DB components (host/user/password)
+# separately. Prisma migrations still require DATABASE_URL, so we compose it here before
+# running `prisma migrate deploy`.
+
+urlencode() {
+  # URL-encode a value for safe inclusion in DATABASE_URL (handles special chars in passwords).
+  node -e 'console.log(encodeURIComponent(process.argv[1]))' "$1"
+}
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  : "${DB_HOST:?Missing DB_HOST}"
+  : "${DB_NAME:?Missing DB_NAME}"
+  : "${DB_USER:?Missing DB_USER}"
+  : "${DB_PASSWORD:?Missing DB_PASSWORD}"
+
+  DB_PORT="${DB_PORT:-5432}"
+  DB_SCHEMA="${DB_SCHEMA:-public}"
+  DB_SSLMODE="${DB_SSLMODE:-require}"
+
+  ENCODED_USER="$(urlencode "${DB_USER}")"
+  ENCODED_PASS="$(urlencode "${DB_PASSWORD}")"
+  ENCODED_DB_NAME="$(urlencode "${DB_NAME}")"
+  ENCODED_SCHEMA="$(urlencode "${DB_SCHEMA}")"
+  ENCODED_SSLMODE="$(urlencode "${DB_SSLMODE}")"
+
+  export DATABASE_URL="postgresql://${ENCODED_USER}:${ENCODED_PASS}@${DB_HOST}:${DB_PORT}/${ENCODED_DB_NAME}?schema=${ENCODED_SCHEMA}&sslmode=${ENCODED_SSLMODE}"
+fi
+
+npm run db:migrate
+exec npm run start

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -2,10 +2,48 @@ import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 
-const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
-  throw new Error('DATABASE_URL is not set');
+/**
+ * Resolve the Prisma/pg connection string for the current runtime.
+ *
+ * Local development prefers `DATABASE_URL` directly (via `.env`). For hosted
+ * runtimes like ECS we often inject DB components (host/user/password/name) as
+ * separate environment variables, so we can compose a URL without storing the
+ * full connection string as a secret.
+ */
+function resolveDatabaseUrl(): string {
+  const directUrl = process.env.DATABASE_URL;
+  if (directUrl) return directUrl;
+
+  const host = process.env.DB_HOST;
+  const port = process.env.DB_PORT ?? '5432';
+  const dbName = process.env.DB_NAME;
+  const username = process.env.DB_USER ?? process.env.DB_USERNAME;
+  const password = process.env.DB_PASSWORD ?? process.env.DB_PASS;
+  const sslmode = process.env.DB_SSLMODE ?? 'require';
+  const schema = process.env.DB_SCHEMA ?? 'public';
+
+  if (!host || !dbName || !username || !password) {
+    const missing: string[] = [];
+    if (!host) missing.push('DB_HOST');
+    if (!dbName) missing.push('DB_NAME');
+    if (!username) missing.push('DB_USER');
+    if (!password) missing.push('DB_PASSWORD');
+
+    throw new Error(
+      `DATABASE_URL is not set and could not be composed (missing: ${missing.join(', ')}).`
+    );
+  }
+
+  const encodedUser = encodeURIComponent(username);
+  const encodedPass = encodeURIComponent(password);
+  const encodedDbName = encodeURIComponent(dbName);
+  const encodedSchema = encodeURIComponent(schema);
+  const encodedSslMode = encodeURIComponent(sslmode);
+
+  return `postgresql://${encodedUser}:${encodedPass}@${host}:${port}/${encodedDbName}?schema=${encodedSchema}&sslmode=${encodedSslMode}`;
 }
+
+const databaseUrl = resolveDatabaseUrl();
 
 const pool = new Pool({ connectionString: databaseUrl });
 const adapter = new PrismaPg(pool);

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,12 +1,12 @@
-# AWS Deployment (Terraform + EC2 + RDS)
+# AWS Deployment (Terraform + ECS Fargate + RDS)
 
 This repo deploys `calibratehealth.app` using:
 
-- EC2 (ARM/Graviton) running `docker compose`
-- RDS Postgres (one per environment)
-- Route 53 for DNS
-- Caddy for HTTPS (Let's Encrypt) and staging basic auth
-- GitHub Actions for CI/CD (multi-arch images to GHCR + ECR; deploy via SSM)
+- ECS Fargate (one service per environment) pulling the app image from ECR
+- Application Load Balancer (ALB) + ACM for HTTPS
+- RDS Postgres (one per environment, in private subnets)
+- Route 53 for DNS (+ ACM DNS validation records)
+- GitHub Actions for CI/CD (builds multi-arch images to GHCR + ECR; deploys by forcing a new ECS service deployment)
 
 ## High-Level Flow
 
@@ -17,10 +17,10 @@ This repo deploys `calibratehealth.app` using:
    - GitHub OIDC provider + IAM roles for CI/CD
 
 2) `infra/envs/staging` + `infra/envs/prod` create per-environment resources:
-   - VPC + subnets
-   - EC2 instance + Elastic IP + SSM
+   - VPC + subnets (public + private)
+   - ALB + ACM certificate (DNS validated) + Route 53 alias records
+   - ECS cluster + task definition + service (Fargate)
    - RDS Postgres (private)
-   - Route 53 records pointing to the Elastic IP
    - Secrets Manager secret placeholders for app runtime config
 
 ## One-Time Setup
@@ -105,33 +105,17 @@ Each environment creates an empty secret:
 - `calibratehealth/staging/app`
 - `calibratehealth/prod/app`
 
-Populate them in AWS Secrets Manager as JSON:
-
-Production (`calibratehealth/prod/app`):
+Populate them in AWS Secrets Manager as JSON. At minimum, the backend requires:
 
 ```json
 {
-  "session_secret": "replace-with-random",
-  "caddy_email": "you@example.com"
+  "session_secret": "replace-with-random"
 }
 ```
 
-Staging (`calibratehealth/staging/app`):
-
-```json
-{
-  "session_secret": "replace-with-random",
-  "caddy_email": "you@example.com",
-  "basic_auth_user": "staging",
-  "basic_auth_hash": "$2a$..."
-}
-```
-
-To generate `basic_auth_hash`:
-
-```sh
-docker run --rm caddy:2.8-alpine caddy hash-password --plaintext 'your-password'
-```
+Notes:
+- ECS injects `SESSION_SECRET` from this secret.
+- DB credentials come from the RDS-managed secret (`manage_master_user_password = true`); ECS injects `DB_USER` and `DB_PASSWORD` from that secret.
 
 ## GitHub Actions configuration
 
@@ -145,5 +129,9 @@ Also create a GitHub Environment named `production` and require reviewers.
 
 ## Deploying
 
-- Staging: push to `master` (builds multi-arch image, pushes to GHCR+ECR, deploys to staging via SSM).
-- Prod: run the "Deploy Prod" workflow (retags the chosen `sha-*` image to `prod` in ECR, then deploys via SSM).
+- Staging: push to `master` (builds multi-arch image, pushes to GHCR+ECR, forces a new ECS deployment of the `staging` tag).
+- Prod: run the "Deploy Prod" workflow (retags the chosen `sha-*` image to `prod` in ECR, then forces a new ECS deployment).
+
+## Staging Access Control (Optional)
+
+`infra/envs/staging` exposes `alb_allowed_cidrs` to restrict who can reach the staging ALB (80/443). The default is open (`0.0.0.0/0`).

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -226,53 +226,11 @@ resource "aws_iam_role" "github_deploy_prod" {
 
 data "aws_iam_policy_document" "github_deploy_staging_policy" {
   statement {
-    effect    = "Allow"
-    actions   = ["ec2:DescribeInstances"]
-    resources = ["*"]
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["rds:DescribeDBInstances"]
-    resources = ["*"]
-  }
-
-  statement {
-    effect  = "Allow"
-    actions = ["ssm:SendCommand"]
-    resources = [
-      "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript",
-      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:document/AWS-RunShellScript"
-    ]
-  }
-
-  statement {
-    effect  = "Allow"
-    actions = ["ssm:SendCommand"]
-    resources = [
-      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
-    ]
-
-    # Restrict commands to tagged app hosts.
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/App"
-      values   = ["calibratehealth"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/Environment"
-      values   = ["staging"]
-    }
-  }
-
-  statement {
     effect = "Allow"
     actions = [
-      "ssm:GetCommandInvocation",
-      "ssm:ListCommandInvocations",
-      "ssm:ListCommands"
+      "ecs:DescribeClusters",
+      "ecs:DescribeServices",
+      "ecs:UpdateService"
     ]
     resources = ["*"]
   }
@@ -286,52 +244,11 @@ resource "aws_iam_role_policy" "github_deploy_staging" {
 
 data "aws_iam_policy_document" "github_deploy_prod_policy" {
   statement {
-    effect    = "Allow"
-    actions   = ["ec2:DescribeInstances"]
-    resources = ["*"]
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["rds:DescribeDBInstances"]
-    resources = ["*"]
-  }
-
-  statement {
-    effect  = "Allow"
-    actions = ["ssm:SendCommand"]
-    resources = [
-      "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript",
-      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:document/AWS-RunShellScript"
-    ]
-  }
-
-  statement {
-    effect  = "Allow"
-    actions = ["ssm:SendCommand"]
-    resources = [
-      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/App"
-      values   = ["calibratehealth"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/Environment"
-      values   = ["prod"]
-    }
-  }
-
-  statement {
     effect = "Allow"
     actions = [
-      "ssm:GetCommandInvocation",
-      "ssm:ListCommandInvocations",
-      "ssm:ListCommands"
+      "ecs:DescribeClusters",
+      "ecs:DescribeServices",
+      "ecs:UpdateService"
     ]
     resources = ["*"]
   }

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -39,11 +39,11 @@ output "github_build_role_arn" {
 }
 
 output "github_deploy_staging_role_arn" {
-  description = "IAM role ARN assumed by GitHub Actions to deploy to staging via SSM."
+  description = "IAM role ARN assumed by GitHub Actions to deploy to staging (ECS)."
   value       = aws_iam_role.github_deploy_staging.arn
 }
 
 output "github_deploy_prod_role_arn" {
-  description = "IAM role ARN assumed by GitHub Actions to deploy to prod via SSM."
+  description = "IAM role ARN assumed by GitHub Actions to deploy to prod (ECS)."
   value       = aws_iam_role.github_deploy_prod.arn
 }

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -11,40 +11,19 @@ data "aws_ecr_repository" "app" {
   name = var.app_name
 }
 
-data "aws_ami" "al2023_arm64" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-*-kernel-6.1-arm64"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["arm64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
-
 locals {
   environment = "prod"
   name_prefix = "${var.app_name}-${local.environment}"
   azs         = slice(data.aws_availability_zones.available.names, 0, 2)
 
-  deploy_dir    = abspath("${path.module}/../../../deploy")
-  compose_yaml  = file("${local.deploy_dir}/docker-compose.yml")
-  caddyfile     = file("${local.deploy_dir}/Caddyfile.prod")
-  deploy_script = file("${path.module}/../../scripts/deploy.sh")
-
   backup_days = 14
   deploy_tag  = local.environment
-  apex_domain = var.domain_name
-  www_domain  = "www.${var.domain_name}"
+
+  app_image        = "${data.aws_ecr_repository.app.repository_url}:${local.deploy_tag}"
+  container_port   = 3000
+  healthcheck_path = "/api/healthz"
+  apex_domain      = var.domain_name
+  www_domain       = "www.${var.domain_name}"
 }
 
 module "network" {
@@ -59,7 +38,7 @@ module "network" {
 
 resource "aws_secretsmanager_secret" "app" {
   name        = "${var.app_name}/${local.environment}/app"
-  description = "Runtime configuration for ${local.name_prefix} (session secret, Caddy email, etc.)"
+  description = "Runtime configuration for ${local.name_prefix} (session secret, etc.)"
 }
 
 module "rds" {
@@ -73,53 +52,109 @@ module "rds" {
   deletion_protection   = true
 }
 
-module "host" {
-  source = "../../modules/ec2_compose_host"
+resource "aws_acm_certificate" "prod" {
+  domain_name               = local.apex_domain
+  subject_alternative_names = [local.www_domain]
+  validation_method         = "DNS"
 
-  name_prefix           = local.name_prefix
-  app_name              = var.app_name
-  environment           = local.environment
-  aws_region            = var.aws_region
-  vpc_id                = module.network.vpc_id
-  subnet_id             = module.network.public_subnet_ids[0]
-  ami_id                = data.aws_ami.al2023_arm64.id
-  instance_type         = var.instance_type
-  app_secret_arn        = aws_secretsmanager_secret.app.arn
-  rds_address           = module.rds.address
-  rds_port              = module.rds.port
-  rds_db_name           = module.rds.db_name
-  rds_master_secret_arn = module.rds.master_user_secret_arn
-  ecr_repository_url    = data.aws_ecr_repository.app.repository_url
-  deploy_tag            = local.deploy_tag
+  lifecycle {
+    create_before_destroy = true
+  }
 
-  compose_yaml  = local.compose_yaml
-  caddyfile     = local.caddyfile
-  deploy_script = local.deploy_script
+  tags = { NamePrefix = local.name_prefix }
 }
 
-resource "aws_security_group_rule" "rds_from_host" {
+resource "aws_route53_record" "prod_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.prod.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "prod" {
+  certificate_arn         = aws_acm_certificate.prod.arn
+  validation_record_fqdns = [for record in aws_route53_record.prod_cert_validation : record.fqdn]
+}
+
+module "service" {
+  source = "../../modules/ecs_fargate_web_service"
+
+  name_prefix = local.name_prefix
+  aws_region  = var.aws_region
+  vpc_id      = module.network.vpc_id
+
+  alb_subnet_ids     = module.network.public_subnet_ids
+  service_subnet_ids = module.network.public_subnet_ids
+  assign_public_ip   = true
+
+  allowed_inbound_cidrs = var.alb_allowed_cidrs
+  certificate_arn       = aws_acm_certificate_validation.prod.certificate_arn
+
+  container_image   = local.app_image
+  container_port    = local.container_port
+  health_check_path = local.healthcheck_path
+  desired_count     = 1
+
+  environment = {
+    NODE_ENV   = "production"
+    PORT       = tostring(local.container_port)
+    DB_HOST    = module.rds.address
+    DB_PORT    = tostring(module.rds.port)
+    DB_NAME    = module.rds.db_name
+    DB_SSLMODE = "require"
+  }
+
+  secrets = {
+    SESSION_SECRET = "${aws_secretsmanager_secret.app.arn}:session_secret::"
+    DB_USER        = "${module.rds.master_user_secret_arn}:username::"
+    DB_PASSWORD    = "${module.rds.master_user_secret_arn}:password::"
+  }
+
+  secret_arns = [
+    aws_secretsmanager_secret.app.arn,
+    module.rds.master_user_secret_arn,
+  ]
+}
+
+resource "aws_security_group_rule" "rds_from_service" {
   type                     = "ingress"
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
   security_group_id        = module.rds.security_group_id
-  source_security_group_id = module.host.security_group_id
-  description              = "Postgres from ${local.name_prefix} host"
+  source_security_group_id = module.service.service_security_group_id
+  description              = "Postgres from ${local.name_prefix} ECS service"
 }
 
 resource "aws_route53_record" "apex" {
   zone_id = data.aws_route53_zone.primary.zone_id
   name    = local.apex_domain
   type    = "A"
-  ttl     = 300
-  records = [module.host.eip_public_ip]
+
+  alias {
+    name                   = module.service.load_balancer_dns_name
+    zone_id                = module.service.load_balancer_zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "www" {
   zone_id = data.aws_route53_zone.primary.zone_id
   name    = local.www_domain
   type    = "A"
-  ttl     = 300
-  records = [module.host.eip_public_ip]
-}
 
+  alias {
+    name                   = module.service.load_balancer_dns_name
+    zone_id                = module.service.load_balancer_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/envs/prod/outputs.tf
+++ b/infra/envs/prod/outputs.tf
@@ -8,14 +8,19 @@ output "www_domain" {
   value       = aws_route53_record.www.fqdn
 }
 
-output "host_instance_id" {
-  description = "EC2 instance ID for prod."
-  value       = module.host.instance_id
+output "alb_dns_name" {
+  description = "Public ALB DNS name for prod."
+  value       = module.service.load_balancer_dns_name
 }
 
-output "host_public_ip" {
-  description = "Elastic IP for prod."
-  value       = module.host.eip_public_ip
+output "ecs_cluster_name" {
+  description = "ECS cluster name for prod."
+  value       = module.service.cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name for prod."
+  value       = module.service.service_name
 }
 
 output "rds_address" {
@@ -32,4 +37,3 @@ output "app_secret_arn" {
   description = "Secrets Manager ARN holding the prod app config JSON."
   value       = aws_secretsmanager_secret.app.arn
 }
-

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -16,10 +16,10 @@ variable "domain_name" {
   default     = "calibratehealth.app"
 }
 
-variable "instance_type" {
-  description = "EC2 instance type for the app host."
-  type        = string
-  default     = "t4g.micro"
+variable "alb_allowed_cidrs" {
+  description = "CIDR blocks allowed to reach the prod ALB (80/443)."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }
 
 variable "db_instance_class" {
@@ -27,4 +27,3 @@ variable "db_instance_class" {
   type        = string
   default     = "db.t4g.micro"
 }
-

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -11,38 +11,17 @@ data "aws_ecr_repository" "app" {
   name = var.app_name
 }
 
-data "aws_ami" "al2023_arm64" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-*-kernel-6.1-arm64"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["arm64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
-
 locals {
   environment = "staging"
   name_prefix = "${var.app_name}-${local.environment}"
   azs         = slice(data.aws_availability_zones.available.names, 0, 2)
+  backup_days = 3
 
-  deploy_dir     = abspath("${path.module}/../../../deploy")
-  compose_yaml   = file("${local.deploy_dir}/docker-compose.yml")
-  caddyfile      = file("${local.deploy_dir}/Caddyfile.staging")
-  deploy_script  = file("${path.module}/../../scripts/deploy.sh")
-  backup_days    = 3
-  deploy_tag     = local.environment
-  staging_domain = "staging.${var.domain_name}"
+  deploy_tag       = local.environment
+  staging_domain   = "staging.${var.domain_name}"
+  app_image        = "${data.aws_ecr_repository.app.repository_url}:${local.deploy_tag}"
+  container_port   = 3000
+  healthcheck_path = "/api/healthz"
 }
 
 module "network" {
@@ -57,7 +36,7 @@ module "network" {
 
 resource "aws_secretsmanager_secret" "app" {
   name        = "${var.app_name}/${local.environment}/app"
-  description = "Runtime configuration for ${local.name_prefix} (session secret, Caddy auth, etc.)"
+  description = "Runtime configuration for ${local.name_prefix} (session secret, etc.)"
 }
 
 module "rds" {
@@ -71,45 +50,96 @@ module "rds" {
   deletion_protection   = false
 }
 
-module "host" {
-  source = "../../modules/ec2_compose_host"
+resource "aws_acm_certificate" "staging" {
+  domain_name       = local.staging_domain
+  validation_method = "DNS"
 
-  name_prefix           = local.name_prefix
-  app_name              = var.app_name
-  environment           = local.environment
-  aws_region            = var.aws_region
-  vpc_id                = module.network.vpc_id
-  subnet_id             = module.network.public_subnet_ids[0]
-  ami_id                = data.aws_ami.al2023_arm64.id
-  instance_type         = var.instance_type
-  app_secret_arn        = aws_secretsmanager_secret.app.arn
-  rds_address           = module.rds.address
-  rds_port              = module.rds.port
-  rds_db_name           = module.rds.db_name
-  rds_master_secret_arn = module.rds.master_user_secret_arn
-  ecr_repository_url    = data.aws_ecr_repository.app.repository_url
-  deploy_tag            = local.deploy_tag
+  lifecycle {
+    create_before_destroy = true
+  }
 
-  compose_yaml  = local.compose_yaml
-  caddyfile     = local.caddyfile
-  deploy_script = local.deploy_script
+  tags = { NamePrefix = local.name_prefix }
 }
 
-resource "aws_security_group_rule" "rds_from_host" {
+resource "aws_route53_record" "staging_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.staging.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "staging" {
+  certificate_arn         = aws_acm_certificate.staging.arn
+  validation_record_fqdns = [for record in aws_route53_record.staging_cert_validation : record.fqdn]
+}
+
+module "service" {
+  source = "../../modules/ecs_fargate_web_service"
+
+  name_prefix = local.name_prefix
+  aws_region  = var.aws_region
+  vpc_id      = module.network.vpc_id
+
+  alb_subnet_ids     = module.network.public_subnet_ids
+  service_subnet_ids = module.network.public_subnet_ids
+  assign_public_ip   = true
+
+  allowed_inbound_cidrs = var.alb_allowed_cidrs
+  certificate_arn       = aws_acm_certificate_validation.staging.certificate_arn
+
+  container_image   = local.app_image
+  container_port    = local.container_port
+  health_check_path = local.healthcheck_path
+  desired_count     = 1
+
+  environment = {
+    NODE_ENV   = "production"
+    PORT       = tostring(local.container_port)
+    DB_HOST    = module.rds.address
+    DB_PORT    = tostring(module.rds.port)
+    DB_NAME    = module.rds.db_name
+    DB_SSLMODE = "require"
+  }
+
+  secrets = {
+    SESSION_SECRET = "${aws_secretsmanager_secret.app.arn}:session_secret::"
+    DB_USER        = "${module.rds.master_user_secret_arn}:username::"
+    DB_PASSWORD    = "${module.rds.master_user_secret_arn}:password::"
+  }
+
+  secret_arns = [
+    aws_secretsmanager_secret.app.arn,
+    module.rds.master_user_secret_arn,
+  ]
+}
+
+resource "aws_security_group_rule" "rds_from_service" {
   type                     = "ingress"
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
   security_group_id        = module.rds.security_group_id
-  source_security_group_id = module.host.security_group_id
-  description              = "Postgres from ${local.name_prefix} host"
+  source_security_group_id = module.service.service_security_group_id
+  description              = "Postgres from ${local.name_prefix} ECS service"
 }
 
 resource "aws_route53_record" "staging" {
   zone_id = data.aws_route53_zone.primary.zone_id
   name    = local.staging_domain
   type    = "A"
-  ttl     = 300
-  records = [module.host.eip_public_ip]
-}
 
+  alias {
+    name                   = module.service.load_balancer_dns_name
+    zone_id                = module.service.load_balancer_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/envs/staging/outputs.tf
+++ b/infra/envs/staging/outputs.tf
@@ -3,14 +3,19 @@ output "staging_domain" {
   value       = aws_route53_record.staging.fqdn
 }
 
-output "host_instance_id" {
-  description = "EC2 instance ID for staging."
-  value       = module.host.instance_id
+output "alb_dns_name" {
+  description = "Public ALB DNS name for staging."
+  value       = module.service.load_balancer_dns_name
 }
 
-output "host_public_ip" {
-  description = "Elastic IP for staging."
-  value       = module.host.eip_public_ip
+output "ecs_cluster_name" {
+  description = "ECS cluster name for staging."
+  value       = module.service.cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name for staging."
+  value       = module.service.service_name
 }
 
 output "rds_address" {
@@ -27,4 +32,3 @@ output "app_secret_arn" {
   description = "Secrets Manager ARN holding the staging app config JSON."
   value       = aws_secretsmanager_secret.app.arn
 }
-

--- a/infra/envs/staging/variables.tf
+++ b/infra/envs/staging/variables.tf
@@ -16,10 +16,10 @@ variable "domain_name" {
   default     = "calibratehealth.app"
 }
 
-variable "instance_type" {
-  description = "EC2 instance type for the app host."
-  type        = string
-  default     = "t4g.micro"
+variable "alb_allowed_cidrs" {
+  description = "CIDR blocks allowed to reach the staging ALB (80/443)."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }
 
 variable "db_instance_class" {
@@ -27,4 +27,3 @@ variable "db_instance_class" {
   type        = string
   default     = "db.t4g.micro"
 }
-

--- a/infra/modules/ecs_fargate_web_service/main.tf
+++ b/infra/modules/ecs_fargate_web_service/main.tf
@@ -1,0 +1,260 @@
+locals {
+  common_tags = {
+    NamePrefix = var.name_prefix
+  }
+
+  # ALB and target group names are limited to 32 characters.
+  alb_name = substr("${var.name_prefix}-alb", 0, 32)
+  tg_name  = substr("${var.name_prefix}-tg", 0, 32)
+
+  # Deterministic container name so workflows can reference it if needed.
+  container_name = "app"
+
+  container_environment = [
+    for key, value in var.environment : {
+      name  = key
+      value = value
+    }
+  ]
+
+  container_secrets = [
+    for key, value_from in var.secrets : {
+      name      = key
+      valueFrom = value_from
+    }
+  ]
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "ALB ingress for ${var.name_prefix}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_inbound_cidrs
+    description = "HTTP from allowed CIDRs"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_inbound_cidrs
+    description = "HTTPS from allowed CIDRs"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All egress"
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.name_prefix}-alb-sg" })
+}
+
+resource "aws_security_group" "service" {
+  name        = "${var.name_prefix}-svc-sg"
+  description = "ECS service ingress for ${var.name_prefix}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+    description     = "App traffic from ALB"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All egress"
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.name_prefix}-svc-sg" })
+}
+
+resource "aws_lb" "this" {
+  name               = local.alb_name
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.alb_subnet_ids
+
+  tags = merge(local.common_tags, { Name = local.alb_name })
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = local.tg_name
+  port        = var.container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    enabled             = true
+    path                = var.health_check_path
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 15
+    timeout             = 5
+    matcher             = "200-399"
+  }
+
+  tags = merge(local.common_tags, { Name = local.tg_name })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name_prefix}"
+  retention_in_days = var.log_retention_in_days
+
+  tags = merge(local.common_tags, { Name = "/ecs/${var.name_prefix}" })
+}
+
+data "aws_iam_policy_document" "task_execution_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = substr("${var.name_prefix}-ecs-task-exec", 0, 64)
+  assume_role_policy = data.aws_iam_policy_document.task_execution_assume_role.json
+
+  tags = merge(local.common_tags, { Name = "${var.name_prefix}-ecs-task-exec" })
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_managed" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "task_execution_secrets_policy" {
+  count = length(var.secret_arns) > 0 ? 1 : 0
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    resources = var.secret_arns
+  }
+}
+
+resource "aws_iam_role_policy" "task_execution_secrets" {
+  count  = length(var.secret_arns) > 0 ? 1 : 0
+  name   = substr("${var.name_prefix}-ecs-task-secrets", 0, 128)
+  role   = aws_iam_role.task_execution.id
+  policy = data.aws_iam_policy_document.task_execution_secrets_policy[0].json
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "${var.name_prefix}-cluster"
+
+  tags = merge(local.common_tags, { Name = "${var.name_prefix}-cluster" })
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${var.name_prefix}-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = local.container_name
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = local.container_environment
+      secrets     = local.container_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+
+  tags = merge(local.common_tags, { Name = "${var.name_prefix}-task" })
+}
+
+resource "aws_ecs_service" "this" {
+  name            = "${var.name_prefix}-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+  health_check_grace_period_seconds  = 180
+
+  network_configuration {
+    subnets          = var.service_subnet_ids
+    security_groups  = [aws_security_group.service.id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = local.container_name
+    container_port   = var.container_port
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.task_execution_managed,
+    aws_iam_role_policy.task_execution_secrets,
+    aws_lb_listener.https,
+  ]
+
+  tags = merge(local.common_tags, { Name = "${var.name_prefix}-service" })
+}

--- a/infra/modules/ecs_fargate_web_service/outputs.tf
+++ b/infra/modules/ecs_fargate_web_service/outputs.tf
@@ -1,0 +1,29 @@
+output "load_balancer_dns_name" {
+  description = "DNS name of the public ALB."
+  value       = aws_lb.this.dns_name
+}
+
+output "load_balancer_zone_id" {
+  description = "Route 53 zone ID of the public ALB (for alias records)."
+  value       = aws_lb.this.zone_id
+}
+
+output "service_security_group_id" {
+  description = "Security group ID attached to ECS tasks."
+  value       = aws_security_group.service.id
+}
+
+output "cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.this.name
+}
+
+output "service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.this.name
+}
+
+output "service_id" {
+  description = "ECS service identifier (provider-specific; typically the service ARN)."
+  value       = aws_ecs_service.this.id
+}

--- a/infra/modules/ecs_fargate_web_service/variables.tf
+++ b/infra/modules/ecs_fargate_web_service/variables.tf
@@ -1,0 +1,101 @@
+variable "name_prefix" {
+  description = "Prefix used for naming/tagging resources (should be unique per environment)."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region hosting the ECS service/ALB (used for CloudWatch Logs configuration)."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the ALB + ECS tasks run."
+  type        = string
+}
+
+variable "alb_subnet_ids" {
+  description = "Subnet IDs for the public (internet-facing) ALB."
+  type        = list(string)
+}
+
+variable "service_subnet_ids" {
+  description = "Subnet IDs for ECS tasks. These must have egress to ECR/CloudWatch Logs/Secrets Manager."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Whether ECS tasks should receive public IPs (simple option when you do not have NAT for private subnets)."
+  type        = bool
+  default     = true
+}
+
+variable "allowed_inbound_cidrs" {
+  description = "CIDR blocks allowed to reach the ALB (80/443). Use this to restrict staging access."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for the ALB HTTPS listener."
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image URI (typically an ECR repo URL with a tag)."
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port exposed to the target group."
+  type        = number
+  default     = 3000
+}
+
+variable "health_check_path" {
+  description = "HTTP path used by the ALB target group health check."
+  type        = string
+  default     = "/api/healthz"
+}
+
+variable "desired_count" {
+  description = "Number of running tasks."
+  type        = number
+  default     = 1
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units."
+  type        = string
+  default     = "256"
+}
+
+variable "memory" {
+  description = "Fargate task memory (MiB)."
+  type        = string
+  default     = "512"
+}
+
+variable "environment" {
+  description = "Plaintext environment variables (non-secret) for the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Secret environment variables for the container (env var name -> valueFrom ARN, optionally with JSON key selectors)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_arns" {
+  description = "Base Secrets Manager ARNs the task execution role is allowed to read (do NOT include JSON key suffixes)."
+  type        = list(string)
+  default     = []
+}
+
+variable "log_retention_in_days" {
+  description = "CloudWatch Logs retention period for the ECS service."
+  type        = number
+  default     = 14
+}
+


### PR DESCRIPTION
Intent
- Replace brittle EC2 + SSM + docker-compose deploys (bootstrap drift, missing compose plugin, SSM payload limits) with a simpler, repeatable AWS-native container deployment.

Summary
- Terraform: replace per-env EC2 host + EIP with an ECS Fargate service behind an internet-facing ALB (HTTPS via ACM DNS validation).
- Keep existing per-env RDS Postgres and Secrets Manager app secret; wire ECS tasks to RDS SG and inject secrets into the container.
- CI/CD: update workflows to deploy by forcing an ECS service deployment after pushing/retagging images in ECR (no SSM).
- Runtime: compose DATABASE_URL from DB_* env vars and run `prisma migrate deploy` on container startup.

Design / Tradeoffs
- Network: tasks run in public subnets with assign_public_ip=true because the VPC module has no NAT; inbound is still restricted to the ALB security group.
- TLS: ALB terminates HTTPS using per-env ACM certs (DNS-validated in the same Route53 zone); 80->443 redirect.
- Secrets: ECS task execution role is granted read-only access to the exact Secrets Manager ARNs used for SESSION_SECRET and RDS master credentials.
- Migrations: migrations run at startup via backend/scripts/start-prod.sh.
  - Pro: keeps deploy pipeline simple.
  - Con: concurrent tasks could race migrations; current config uses desired_count=1 and deployment_minimum_healthy_percent=0 to avoid overlap.

Testing
- terraform fmt -recursive infra
- npm --prefix backend run build

Risks / Rollout
- Applying infra/envs/staging and infra/envs/prod will destroy the EC2 host/EIP resources previously managed by Terraform and switch DNS to the ALB.
- Apply infra/bootstrap first to update GitHub deploy-role IAM policies (SSM permissions removed, ECS permissions added).
- Follow-up: consider adding NAT gateways (or VPC endpoints) so tasks can run in private subnets without public IPs.

Code Pointers
- infra/modules/ecs_fargate_web_service/*: new ECS+ALB module.
- infra/envs/staging/main.tf and infra/envs/prod/main.tf: ACM certs, ALB alias records, ECS service wiring, RDS SG ingress.
- .github/workflows/container.yml, .github/workflows/deploy-staging.yml, .github/workflows/deploy-prod.yml: deploy via aws ecs update-service --force-new-deployment.
- backend/scripts/start-prod.sh, Dockerfile.app, backend/src/config/database.ts: runtime DB URL composition + startup migrations.
