### PR TITLE
feat(frontend): show birthday emoji on log summary card

### DIFF
--- a/frontend/src/components/LogSummaryCard.tsx
+++ b/frontend/src/components/LogSummaryCard.tsx
@@ -3,7 +3,12 @@ import { Box, Card, CardActionArea, CardContent, Skeleton, Typography } from '@m
 import { Gauge } from '@mui/x-charts/Gauge';
 import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
-import { formatDateToLocalDateString, formatIsoDateForDisplay, getHolidayEmojiForIsoDate } from '../utils/date';
+import {
+    formatDateToLocalDateString,
+    formatIsoDateForDisplay,
+    getBirthdayEmojiForIsoDate,
+    getHolidayEmojiForIsoDate
+} from '../utils/date';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 import { useTweenedNumber } from '../hooks/useTweenedNumber';
 import { useUserProfileQuery } from '../queries/userProfile';
@@ -73,10 +78,13 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
     const today = formatDateToLocalDateString(new Date(), timeZone);
     const activeDate = date ?? today;
     const isActiveDateToday = activeDate === today;
+    const birthdayEmoji = getBirthdayEmojiForIsoDate(activeDate, user?.date_of_birth);
     const holidayEmoji = getHolidayEmojiForIsoDate(activeDate);
+    const titleEmojis = [birthdayEmoji, holidayEmoji].filter(Boolean).join(' ');
+    const titleEmojiSuffix = titleEmojis ? ` ${titleEmojis}` : '';
     const title = isActiveDateToday
-        ? `Today's Log${holidayEmoji ? ` ${holidayEmoji}` : ''}`
-        : `Log for ${formatIsoDateForDisplay(activeDate)}${holidayEmoji ? ` ${holidayEmoji}` : ''}`;
+        ? `Today's Log${titleEmojiSuffix}`
+        : `Log for ${formatIsoDateForDisplay(activeDate)}${titleEmojiSuffix}`;
 
     const foodQuery = useFoodLogQuery(activeDate);
 


### PR DESCRIPTION
Intent
- Show a birthday decoration on the log summary card title when the active local date matches the user's birthday, consistent with existing holiday decorations.

High-level change summary
- Add a date utility to detect "birthday" for a given ISO local-date and profile date_of_birth.
- Update the LogSummaryCard title to append birthday + holiday decorations when applicable.

Technical design and tradeoffs
- Compare only month/day (ignore birth year) so the feature is stable across years and avoids coupling to age display.
- Treat inputs as calendar dates and ignore any time portion, so ISO strings with or without "T..." serialize consistently.
- Feb 29 handling: treat Feb 28 as the birthday on non-leap years to preserve an annual decoration (alternative would be Mar 1).

Testing performed
- npm --prefix frontend run lint
- npm --prefix frontend run build
- Manual: set profile date_of_birth to today's month/day and verify the dashboard and /log log summary title includes the birthday decoration; verify holiday decoration still appears on holiday dates.

Risks / rollout notes / follow-ups
- UI-only change; no API or persistence changes.
- If date_of_birth is missing or invalid, the card renders without a birthday decoration (safe fallback).
- If we want a different convention for Feb 29 birthdays, adjust the mapping in the date utility.

Code pointers
- frontend/src/utils/date.ts: getBirthdayEmojiForIsoDate() and leap-year handling.
- frontend/src/components/LogSummaryCard.tsx: title emoji composition (birthday + holiday).
