### PR TITLE
infra: allow GitHub OIDC from renamed repo

### DIFF
--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -13,7 +13,7 @@ variable "domain_name" {
 variable "github_repo" {
   description = "GitHub repo in OWNER/REPO form allowed to assume deployment roles."
   type        = string
-  default     = "MChartier/cal-io"
+  default     = "MChartier/calibrate-health"
 }
 
 variable "github_default_branch" {


### PR DESCRIPTION
Intent
- Fix GitHub Actions OIDC assume-role failures after renaming the GitHub repository from MChartier/cal-io to MChartier/calibrate-health.

Summary
- Update infra/bootstrap default `github_repo` to the new canonical repo name.
- This keeps the IAM role trust policy `token.actions.githubusercontent.com:sub` conditions aligned with GitHub's new OIDC subject strings.

Design / Tradeoffs
- Keep trust strict (single repo + branch/environment), rather than loosening to an owner-wide wildcard.
- No runtime/app changes; requires a Terraform apply to take effect.

Testing
- N/A (Terraform variable change only).

Risks / Rollout Notes
- Apply required: run `terraform apply` in `infra/bootstrap` to update the IAM assume-role policies.
- After apply, rerun staging/prod workflows; confirm GitHub repo secrets still point at the correct role ARNs.

Code Pointers
- infra/bootstrap/variables.tf: update `github_repo` default to `MChartier/calibrate-health`.
