### PR TITLE
ci: wait longer for ECS service stability

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -94,7 +94,7 @@ jobs:
   deploy_staging:
     name: Deploy Staging (ECS)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: build_and_push
     if: github.ref == 'refs/heads/master'
 
@@ -120,4 +120,26 @@ jobs:
             --force-new-deployment \
             >/dev/null
 
-          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"
+          wait_for_stable() {
+            # awscli's `ecs wait services-stable` hard-codes a 10-minute deadline (40x15s).
+            # ECS deployments can take longer (cold starts, image pulls, migrations, etc.), so
+            # retry once before failing the workflow.
+            local attempt
+            for attempt in 1 2; do
+              if aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"; then
+                return 0
+              fi
+
+              echo "Timed out waiting for ECS to become stable (attempt ${attempt}/2). Recent service events:" >&2
+              aws ecs describe-services \
+                --cluster "${ECS_CLUSTER}" \
+                --services "${ECS_SERVICE}" \
+                --query 'services[0].events[0:10].[createdAt,message]' \
+                --output table \
+                || true
+            done
+
+            return 1
+          }
+
+          wait_for_stable

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     name: Deploy Prod (ECS)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment: production
 
     steps:
@@ -83,4 +83,26 @@ jobs:
             --force-new-deployment \
             >/dev/null
 
-          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"
+          wait_for_stable() {
+            # awscli's `ecs wait services-stable` hard-codes a 10-minute deadline (40x15s).
+            # ECS deployments can take longer (cold starts, image pulls, migrations, etc.), so
+            # retry once before failing the workflow.
+            local attempt
+            for attempt in 1 2; do
+              if aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"; then
+                return 0
+              fi
+
+              echo "Timed out waiting for ECS to become stable (attempt ${attempt}/2). Recent service events:" >&2
+              aws ecs describe-services \
+                --cluster "${ECS_CLUSTER}" \
+                --services "${ECS_SERVICE}" \
+                --query 'services[0].events[0:10].[createdAt,message]' \
+                --output table \
+                || true
+            done
+
+            return 1
+          }
+
+          wait_for_stable

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,7 +15,7 @@ jobs:
   deploy:
     name: Deploy Staging (ECS)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Configure AWS credentials (staging deploy)
@@ -39,4 +39,26 @@ jobs:
             --force-new-deployment \
             >/dev/null
 
-          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"
+          wait_for_stable() {
+            # awscli's `ecs wait services-stable` hard-codes a 10-minute deadline (40x15s).
+            # ECS deployments can take longer (cold starts, image pulls, migrations, etc.), so
+            # retry once before failing the workflow.
+            local attempt
+            for attempt in 1 2; do
+              if aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"; then
+                return 0
+              fi
+
+              echo "Timed out waiting for ECS to become stable (attempt ${attempt}/2). Recent service events:" >&2
+              aws ecs describe-services \
+                --cluster "${ECS_CLUSTER}" \
+                --services "${ECS_SERVICE}" \
+                --query 'services[0].events[0:10].[createdAt,message]' \
+                --output table \
+                || true
+            done
+
+            return 1
+          }
+
+          wait_for_stable


### PR DESCRIPTION
Intent
- Fix false-negative staging/prod deploy failures when the AWS CLI `ecs wait services-stable` waiter times out (hard-coded 10-minute deadline).

Summary
- Increase deploy job timeouts (staging: 25m, prod: 30m).
- Wrap `aws ecs wait services-stable` in a simple retry (2x) and print recent ECS service events between attempts for faster diagnosis.

Design / Tradeoffs
- Pros: avoids costly reruns when ECS deploys legitimately take >10 minutes (cold start, image pull, Prisma migrations).
- Cons: if the service is genuinely unhealthy, the workflow may wait up to ~20 minutes before failing.

Testing
- N/A (workflow-only change).

Risks / Rollout Notes
- No infra changes.
- If deploys are consistently near the 10-minute mark, consider also increasing `health_check_grace_period_seconds` in Terraform to reduce task churn.

Code Pointers
- .github/workflows/container.yml: staging deploy job wait logic + timeout.
- .github/workflows/deploy-staging.yml: manual staging deploy wait logic + timeout.
- .github/workflows/deploy-prod.yml: prod deploy wait logic + timeout.
