### PR TITLE
Backend: increase unit test coverage (routes + extracted helpers)

### DIFF
--- a/backend/src/routes/food.ts
+++ b/backend/src/routes/food.ts
@@ -1,16 +1,9 @@
 import express from 'express';
 import prisma from '../config/database';
 import { getFoodDataProvider } from '../services/foodData';
-import type { MealPeriod } from '@prisma/client';
-import { getSafeUtcTodayDateOnlyInTimeZone, parseLocalDateOnly } from '../utils/date';
-import { parseMealPeriod } from '../utils/mealPeriod';
-import {
-    parseNonNegativeInteger,
-    parseNonNegativeNumber,
-    parsePositiveInteger,
-    parsePositiveNumber,
-    resolveLanguageCode
-} from '../utils/requestParsing';
+import { parseLocalDateOnly } from '../utils/date';
+import { parsePositiveInteger } from '../utils/requestParsing';
+import { parseFoodLogCreateBody, parseFoodLogUpdateBody, parseFoodSearchParams } from './foodUtils';
 
 const router = express.Router();
 
@@ -24,31 +17,19 @@ const isAuthenticated = (req: express.Request, res: express.Response, next: expr
 router.use(isAuthenticated);
 
 router.get('/search', async (req, res) => {
-    const provider = getFoodDataProvider();
-    const query = (req.query.q as string) || (req.query.query as string);
-    const barcode = req.query.barcode as string | undefined;
-
-    if (!query && !barcode) {
-        return res.status(400).json({ message: 'Provide a search query or barcode.' });
-    }
-
-    const page = req.query.page ? parseInt(req.query.page as string, 10) : undefined;
-    const pageSize = req.query.pageSize ? parseInt(req.query.pageSize as string, 10) : undefined;
-    const quantityInGrams = req.query.grams ? parseFloat(req.query.grams as string) : undefined;
-    const languageCode = resolveLanguageCode({
-        queryLanguageCode: req.query.lc,
+    const parsed = parseFoodSearchParams({
+        query: req.query as Record<string, unknown>,
         acceptLanguageHeader: req.headers['accept-language']
     });
 
+    if (!parsed.ok) {
+        return res.status(parsed.statusCode).json({ message: parsed.message });
+    }
+
+    const provider = getFoodDataProvider();
+
     try {
-        const result = await provider.searchFoods({
-            query: query || undefined,
-            barcode,
-            page,
-            pageSize,
-            quantityInGrams,
-            languageCode
-        });
+        const result = await provider.searchFoods(parsed.params);
 
         res.json({
             provider: provider.name,
@@ -89,54 +70,25 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
     const user = req.user as any;
-    const { name, calories, meal_period, date, my_food_id, servings_consumed } = req.body;
     try {
-        const parsedMealPeriod = parseMealPeriod(meal_period);
-        if (!parsedMealPeriod) {
-            return res.status(400).json({ message: 'Invalid meal period' });
+        const parsedBody = parseFoodLogCreateBody({
+            body: req.body,
+            userTimeZone: user.timezone
+        });
+
+        if (!parsedBody.ok) {
+            return res.status(parsedBody.statusCode).json({ message: parsedBody.message });
         }
 
-        let local_date: Date;
-        if (date === undefined || date === null || (typeof date === 'string' && date.trim().length === 0)) {
-            local_date = getSafeUtcTodayDateOnlyInTimeZone(user.timezone);
-        } else {
-            try {
-                local_date = parseLocalDateOnly(date);
-            } catch {
-                return res.status(400).json({ message: 'Invalid date' });
-            }
-        }
-
-        const entryTimestamp = date ? new Date(date) : new Date();
-        if (Number.isNaN(entryTimestamp.getTime())) {
-            return res.status(400).json({ message: 'Invalid date' });
-        }
-
-        const wantsMyFood = my_food_id !== undefined && my_food_id !== null && String(my_food_id).trim().length > 0;
-        const wantsManual = name !== undefined || calories !== undefined;
-        if (wantsMyFood && wantsManual) {
-            return res.status(400).json({ message: 'Provide either my_food_id+servings_consumed or name+calories, not both.' });
-        }
-
-        if (wantsMyFood) {
-            const myFoodId = parsePositiveInteger(my_food_id);
-            if (myFoodId === null) {
-                return res.status(400).json({ message: 'Invalid my food id' });
-            }
-
-            const servings = parsePositiveNumber(servings_consumed);
-            if (servings === null) {
-                return res.status(400).json({ message: 'Invalid servings consumed' });
-            }
-
+        if (parsedBody.kind === 'MY_FOOD') {
             const myFood = await prisma.myFood.findFirst({
-                where: { id: myFoodId, user_id: user.id }
+                where: { id: parsedBody.myFoodId, user_id: user.id }
             });
             if (!myFood) {
                 return res.status(404).json({ message: 'My food not found' });
             }
 
-            const caloriesTotal = Math.round(servings * myFood.calories_per_serving);
+            const caloriesTotal = Math.round(parsedBody.servingsConsumed * myFood.calories_per_serving);
 
             const log = await prisma.foodLog.create({
                 data: {
@@ -144,10 +96,10 @@ router.post('/', async (req, res) => {
                     my_food_id: myFood.id,
                     name: myFood.name,
                     calories: caloriesTotal,
-                    meal_period: parsedMealPeriod,
-                    date: entryTimestamp,
-                    local_date,
-                    servings_consumed: servings,
+                    meal_period: parsedBody.mealPeriod,
+                    date: parsedBody.entryTimestamp,
+                    local_date: parsedBody.localDate,
+                    servings_consumed: parsedBody.servingsConsumed,
                     serving_size_quantity_snapshot: myFood.serving_size_quantity,
                     serving_unit_label_snapshot: myFood.serving_unit_label,
                     calories_per_serving_snapshot: myFood.calories_per_serving
@@ -156,25 +108,14 @@ router.post('/', async (req, res) => {
             return res.json(log);
         }
 
-        const trimmedName = typeof name === 'string' ? name.trim() : '';
-        if (!trimmedName) {
-            return res.status(400).json({ message: 'Invalid name' });
-        }
-
-        const caloriesNumber = parseNonNegativeNumber(calories);
-        if (caloriesNumber === null) {
-            return res.status(400).json({ message: 'Invalid calories' });
-        }
-        const caloriesValue = Math.round(caloriesNumber);
-
         const log = await prisma.foodLog.create({
             data: {
                 user_id: user.id,
-                name: trimmedName,
-                calories: caloriesValue,
-                meal_period: parsedMealPeriod,
-                date: entryTimestamp,
-                local_date
+                name: parsedBody.name,
+                calories: parsedBody.calories,
+                meal_period: parsedBody.mealPeriod,
+                date: parsedBody.entryTimestamp,
+                local_date: parsedBody.localDate
             }
         });
         return res.json(log);
@@ -190,81 +131,20 @@ router.patch('/:id', async (req, res) => {
         return res.status(400).json({ message: 'Invalid food log id' });
     }
 
-    const { name, calories, meal_period, servings_consumed } = req.body;
-
     const existing = await prisma.foodLog.findFirst({ where: { id, user_id: user.id } });
     if (!existing) {
         return res.status(404).json({ message: 'Food log not found' });
     }
 
-    const updateData: Partial<{
-        name: string;
-        calories: number;
-        meal_period: MealPeriod;
-        servings_consumed: number | null;
-        calories_per_serving_snapshot: number | null;
-    }> = {};
-
-    if (name !== undefined) {
-        if (typeof name !== 'string' || !name.trim()) {
-            return res.status(400).json({ message: 'Invalid name' });
-        }
-        updateData.name = name.trim();
-    }
-
-    if (calories !== undefined) {
-        const parsedCalories = parseNonNegativeNumber(calories);
-        if (parsedCalories === null) {
-            return res.status(400).json({ message: 'Invalid calories' });
-        }
-        updateData.calories = Math.round(parsedCalories);
-    }
-
-    if (meal_period !== undefined) {
-        const parsedMealPeriod = parseMealPeriod(meal_period);
-        if (!parsedMealPeriod) {
-            return res.status(400).json({ message: 'Invalid meal period' });
-        }
-        updateData.meal_period = parsedMealPeriod;
-    }
-
-    if (servings_consumed !== undefined) {
-        const parsedServings = parsePositiveNumber(servings_consumed);
-        if (parsedServings === null) {
-            return res.status(400).json({ message: 'Invalid servings consumed' });
-        }
-
-        if (existing.calories_per_serving_snapshot === null || existing.calories_per_serving_snapshot === undefined) {
-            return res.status(400).json({ message: 'This entry does not include serving info.' });
-        }
-
-        updateData.servings_consumed = parsedServings;
-
-        if (updateData.calories === undefined) {
-            updateData.calories = Math.round(parsedServings * existing.calories_per_serving_snapshot);
-        }
-    }
-
-    // If the caller supplied calories for an entry that has serving data, keep the snapshot consistent by
-    // deriving calories-per-serving from the (possibly updated) servings count.
-    if (updateData.calories !== undefined) {
-        const servings =
-            updateData.servings_consumed ??
-            (existing.servings_consumed !== null && existing.servings_consumed !== undefined ? existing.servings_consumed : null);
-
-        if (servings && servings > 0) {
-            updateData.calories_per_serving_snapshot = updateData.calories / servings;
-        }
-    }
-
-    if (Object.keys(updateData).length === 0) {
-        return res.status(400).json({ message: 'No fields to update' });
+    const parsedUpdate = parseFoodLogUpdateBody({ body: req.body, existing });
+    if (!parsedUpdate.ok) {
+        return res.status(parsedUpdate.statusCode).json({ message: parsedUpdate.message });
     }
 
     try {
         const updated = await prisma.foodLog.update({
             where: { id },
-            data: updateData
+            data: parsedUpdate.updateData
         });
 
         res.json(updated);

--- a/backend/src/routes/foodUtils.ts
+++ b/backend/src/routes/foodUtils.ts
@@ -1,0 +1,271 @@
+import type { MealPeriod } from '@prisma/client';
+import { getSafeUtcTodayDateOnlyInTimeZone, parseLocalDateOnly } from '../utils/date';
+import { parseMealPeriod } from '../utils/mealPeriod';
+import {
+  parseNonNegativeNumber,
+  parsePositiveInteger,
+  parsePositiveNumber,
+  resolveLanguageCode,
+} from '../utils/requestParsing';
+
+export type FoodSearchParams = {
+  query: string | undefined;
+  barcode: string | undefined;
+  page: number | undefined;
+  pageSize: number | undefined;
+  quantityInGrams: number | undefined;
+  languageCode: string | undefined;
+};
+
+export type FoodSearchParamsParseResult =
+  | { ok: true; params: FoodSearchParams }
+  | { ok: false; statusCode: number; message: string };
+
+/**
+ * Parse and validate `/api/food/search` query params.
+ *
+ * Returns a friendly 400 when neither query nor barcode are present.
+ */
+export function parseFoodSearchParams(opts: {
+  query: Record<string, unknown>;
+  acceptLanguageHeader: unknown;
+}): FoodSearchParamsParseResult {
+  const queryParam =
+    typeof opts.query.q === 'string'
+      ? opts.query.q
+      : typeof opts.query.query === 'string'
+        ? opts.query.query
+        : undefined;
+  const barcode = typeof opts.query.barcode === 'string' ? opts.query.barcode : undefined;
+
+  if (!queryParam && !barcode) {
+    return { ok: false, statusCode: 400, message: 'Provide a search query or barcode.' };
+  }
+
+  const pageRaw = typeof opts.query.page === 'string' ? Number.parseInt(opts.query.page, 10) : undefined;
+  const page = typeof pageRaw === 'number' && Number.isFinite(pageRaw) ? pageRaw : undefined;
+
+  const pageSizeRaw = typeof opts.query.pageSize === 'string' ? Number.parseInt(opts.query.pageSize, 10) : undefined;
+  const pageSize = typeof pageSizeRaw === 'number' && Number.isFinite(pageSizeRaw) ? pageSizeRaw : undefined;
+
+  const gramsRaw = typeof opts.query.grams === 'string' ? Number.parseFloat(opts.query.grams) : undefined;
+  const quantityInGrams = typeof gramsRaw === 'number' && Number.isFinite(gramsRaw) ? gramsRaw : undefined;
+
+  const languageCode = resolveLanguageCode({
+    queryLanguageCode: opts.query.lc,
+    acceptLanguageHeader: opts.acceptLanguageHeader,
+  });
+
+  return {
+    ok: true,
+    params: {
+      query: queryParam || undefined,
+      barcode,
+      page,
+      pageSize,
+      quantityInGrams,
+      languageCode,
+    },
+  };
+}
+
+export type FoodLogCreateParseResult =
+  | {
+      ok: true;
+      kind: 'MY_FOOD';
+      mealPeriod: MealPeriod;
+      localDate: Date;
+      entryTimestamp: Date;
+      myFoodId: number;
+      servingsConsumed: number;
+    }
+  | {
+      ok: true;
+      kind: 'MANUAL';
+      mealPeriod: MealPeriod;
+      localDate: Date;
+      entryTimestamp: Date;
+      name: string;
+      calories: number;
+    }
+  | { ok: false; statusCode: number; message: string };
+
+/**
+ * Parse and validate a create-food-log request body.
+ *
+ * This is Prisma-free by design; it only validates user inputs and computes date defaults.
+ */
+export function parseFoodLogCreateBody(opts: {
+  body: unknown;
+  userTimeZone: unknown;
+  now?: Date;
+}): FoodLogCreateParseResult {
+  if (!opts.body || typeof opts.body !== 'object') {
+    return { ok: false, statusCode: 400, message: 'Invalid request body' };
+  }
+
+  const body = opts.body as Record<string, unknown>;
+  const now = opts.now ?? new Date();
+
+  const parsedMealPeriod = parseMealPeriod(body.meal_period);
+  if (!parsedMealPeriod) {
+    return { ok: false, statusCode: 400, message: 'Invalid meal period' };
+  }
+
+  const rawDate = body.date;
+
+  let localDate: Date;
+  if (rawDate === undefined || rawDate === null || (typeof rawDate === 'string' && rawDate.trim().length === 0)) {
+    localDate = getSafeUtcTodayDateOnlyInTimeZone(opts.userTimeZone, now);
+  } else {
+    try {
+      localDate = parseLocalDateOnly(rawDate);
+    } catch {
+      return { ok: false, statusCode: 400, message: 'Invalid date' };
+    }
+  }
+
+  const entryTimestamp = rawDate ? new Date(rawDate as any) : now;
+  if (Number.isNaN(entryTimestamp.getTime())) {
+    return { ok: false, statusCode: 400, message: 'Invalid date' };
+  }
+
+  const wantsMyFood =
+    body.my_food_id !== undefined && body.my_food_id !== null && String(body.my_food_id).trim().length > 0;
+  const wantsManual = body.name !== undefined || body.calories !== undefined;
+  if (wantsMyFood && wantsManual) {
+    return {
+      ok: false,
+      statusCode: 400,
+      message: 'Provide either my_food_id+servings_consumed or name+calories, not both.',
+    };
+  }
+
+  if (wantsMyFood) {
+    const myFoodId = parsePositiveInteger(body.my_food_id);
+    if (myFoodId === null) {
+      return { ok: false, statusCode: 400, message: 'Invalid my food id' };
+    }
+
+    const servingsConsumed = parsePositiveNumber(body.servings_consumed);
+    if (servingsConsumed === null) {
+      return { ok: false, statusCode: 400, message: 'Invalid servings consumed' };
+    }
+
+    return {
+      ok: true,
+      kind: 'MY_FOOD',
+      mealPeriod: parsedMealPeriod,
+      localDate,
+      entryTimestamp,
+      myFoodId,
+      servingsConsumed,
+    };
+  }
+
+  const trimmedName = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!trimmedName) {
+    return { ok: false, statusCode: 400, message: 'Invalid name' };
+  }
+
+  const caloriesNumber = parseNonNegativeNumber(body.calories);
+  if (caloriesNumber === null) {
+    return { ok: false, statusCode: 400, message: 'Invalid calories' };
+  }
+
+  return {
+    ok: true,
+    kind: 'MANUAL',
+    mealPeriod: parsedMealPeriod,
+    localDate,
+    entryTimestamp,
+    name: trimmedName,
+    calories: Math.round(caloriesNumber),
+  };
+}
+
+export type FoodLogUpdateData = Partial<{
+  name: string;
+  calories: number;
+  meal_period: MealPeriod;
+  servings_consumed: number | null;
+  calories_per_serving_snapshot: number | null;
+}>;
+
+export type FoodLogUpdateParseResult =
+  | { ok: true; updateData: FoodLogUpdateData }
+  | { ok: false; statusCode: number; message: string };
+
+/**
+ * Parse and validate a PATCH-food-log request body.
+ */
+export function parseFoodLogUpdateBody(opts: {
+  body: unknown;
+  existing: { calories_per_serving_snapshot?: number | null; servings_consumed?: number | null };
+}): FoodLogUpdateParseResult {
+  if (!opts.body || typeof opts.body !== 'object') {
+    return { ok: false, statusCode: 400, message: 'Invalid request body' };
+  }
+
+  const body = opts.body as Record<string, unknown>;
+
+  const updateData: FoodLogUpdateData = {};
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== 'string' || !body.name.trim()) {
+      return { ok: false, statusCode: 400, message: 'Invalid name' };
+    }
+    updateData.name = body.name.trim();
+  }
+
+  if (body.calories !== undefined) {
+    const parsedCalories = parseNonNegativeNumber(body.calories);
+    if (parsedCalories === null) {
+      return { ok: false, statusCode: 400, message: 'Invalid calories' };
+    }
+    updateData.calories = Math.round(parsedCalories);
+  }
+
+  if (body.meal_period !== undefined) {
+    const parsedMealPeriod = parseMealPeriod(body.meal_period);
+    if (!parsedMealPeriod) {
+      return { ok: false, statusCode: 400, message: 'Invalid meal period' };
+    }
+    updateData.meal_period = parsedMealPeriod;
+  }
+
+  if (body.servings_consumed !== undefined) {
+    const parsedServings = parsePositiveNumber(body.servings_consumed);
+    if (parsedServings === null) {
+      return { ok: false, statusCode: 400, message: 'Invalid servings consumed' };
+    }
+
+    if (opts.existing.calories_per_serving_snapshot === null || opts.existing.calories_per_serving_snapshot === undefined) {
+      return { ok: false, statusCode: 400, message: 'This entry does not include serving info.' };
+    }
+
+    updateData.servings_consumed = parsedServings;
+
+    if (updateData.calories === undefined) {
+      updateData.calories = Math.round(parsedServings * opts.existing.calories_per_serving_snapshot);
+    }
+  }
+
+  if (updateData.calories !== undefined) {
+    const servings =
+      updateData.servings_consumed ??
+      (opts.existing.servings_consumed !== null && opts.existing.servings_consumed !== undefined
+        ? opts.existing.servings_consumed
+        : null);
+
+    if (servings && servings > 0) {
+      updateData.calories_per_serving_snapshot = updateData.calories / servings;
+    }
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return { ok: false, statusCode: 400, message: 'No fields to update' };
+  }
+
+  return { ok: true, updateData };
+}

--- a/backend/src/routes/myFoodsRecipeUtils.ts
+++ b/backend/src/routes/myFoodsRecipeUtils.ts
@@ -1,0 +1,80 @@
+import { parseNonNegativeNumber, parsePositiveInteger, parsePositiveNumber } from '../utils/requestParsing';
+import { createHttpError, normalizeMyFoodName, normalizeOptionalString, type HttpError } from './myFoodsUtils';
+
+export type ExternalIngredientSnapshotRow = {
+  sort_order: number;
+  source: 'EXTERNAL';
+  name_snapshot: string;
+  calories_total_snapshot: number;
+  external_source: string | null;
+  external_id: string | null;
+  brand_snapshot: string | null;
+  locale_snapshot: string | null;
+  barcode_snapshot: string | null;
+  measure_label_snapshot: string | null;
+  grams_per_measure_snapshot: number | null;
+  measure_quantity_snapshot: number | null;
+  grams_total_snapshot: number | null;
+};
+
+export type ParseResult<T> = { ok: true; value: T } | { ok: false; error: HttpError };
+
+/**
+ * Validate and normalize a "MY_FOOD" recipe ingredient payload.
+ */
+export function parseMyFoodIngredientInput(
+  ingredient: unknown
+): ParseResult<{ myFoodId: number; quantityServings: number }> {
+  const record = ingredient && typeof ingredient === 'object' ? (ingredient as Record<string, unknown>) : null;
+  const myFoodId = parsePositiveInteger(record?.my_food_id);
+  if (myFoodId === null) {
+    return { ok: false, error: createHttpError(400, 'Invalid ingredient my_food_id') };
+  }
+
+  const quantityServings = parsePositiveNumber(record?.quantity_servings);
+  if (quantityServings === null) {
+    return { ok: false, error: createHttpError(400, 'Invalid ingredient quantity_servings') };
+  }
+
+  return { ok: true, value: { myFoodId, quantityServings } };
+}
+
+/**
+ * Build a validated snapshot row for an "EXTERNAL" recipe ingredient payload.
+ */
+export function buildExternalIngredientSnapshotRow(
+  ingredient: unknown,
+  sortOrder: number
+): ParseResult<ExternalIngredientSnapshotRow> {
+  const record = ingredient && typeof ingredient === 'object' ? (ingredient as Record<string, unknown>) : null;
+
+  const externalName = normalizeMyFoodName(record?.name);
+  if (!externalName) {
+    return { ok: false, error: createHttpError(400, 'Invalid external ingredient name') };
+  }
+
+  const caloriesTotal = parseNonNegativeNumber(record?.calories_total);
+  if (caloriesTotal === null) {
+    return { ok: false, error: createHttpError(400, 'Invalid external ingredient calories_total') };
+  }
+
+  return {
+    ok: true,
+    value: {
+      sort_order: sortOrder,
+      source: 'EXTERNAL',
+      name_snapshot: externalName,
+      calories_total_snapshot: caloriesTotal,
+      external_source: normalizeOptionalString(record?.external_source),
+      external_id: normalizeOptionalString(record?.external_id),
+      brand_snapshot: normalizeOptionalString(record?.brand),
+      locale_snapshot: normalizeOptionalString(record?.locale),
+      barcode_snapshot: normalizeOptionalString(record?.barcode),
+      measure_label_snapshot: normalizeOptionalString(record?.measure_label),
+      grams_per_measure_snapshot: parsePositiveNumber(record?.grams_per_measure),
+      measure_quantity_snapshot: parsePositiveNumber(record?.measure_quantity),
+      grams_total_snapshot: parsePositiveNumber(record?.grams_total),
+    },
+  };
+}
+

--- a/backend/src/routes/myFoodsUtils.ts
+++ b/backend/src/routes/myFoodsUtils.ts
@@ -1,0 +1,66 @@
+/**
+ * Utilities for the `/api/my-foods` routes.
+ *
+ * This file intentionally avoids importing Prisma so unit tests can exercise input
+ * normalization and error mapping without requiring DATABASE_URL or a running DB.
+ */
+
+export const SERVING_UNIT_LABEL_MAX_LENGTH = 48;
+export const MY_FOOD_NAME_MAX_LENGTH = 120;
+
+const MULTI_SPACE_PATTERN = /\s+/g;
+
+/**
+ * Normalize a free-form serving unit label for storage and validation.
+ *
+ * We avoid enforcing an enum so users can type locale-appropriate units ("g", "ml", "fl oz", "slice", etc.).
+ */
+export function normalizeServingUnitLabel(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(MULTI_SPACE_PATTERN, ' ');
+  if (!trimmed) return null;
+  if (trimmed.length > SERVING_UNIT_LABEL_MAX_LENGTH) return null;
+  return trimmed;
+}
+
+/**
+ * Normalize a user-defined food/recipe name for storage.
+ */
+export function normalizeMyFoodName(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(MULTI_SPACE_PATTERN, ' ');
+  if (!trimmed) return null;
+  if (trimmed.length > MY_FOOD_NAME_MAX_LENGTH) return null;
+  return trimmed;
+}
+
+/**
+ * Normalize an optional string field (trim, treat empty as "not provided").
+ */
+export function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export type HttpError = Error & { statusCode: number };
+
+/**
+ * Create a typed HTTP error so route handlers can map validation failures to status codes
+ * without leaking stack traces or turning everything into a 500.
+ */
+export function createHttpError(statusCode: number, message: string): HttpError {
+  const err = new Error(message) as HttpError;
+  err.statusCode = statusCode;
+  return err;
+}
+
+/**
+ * Narrow unknown errors into our lightweight HttpError shape.
+ */
+export function isHttpError(value: unknown): value is HttpError {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.statusCode === 'number';
+}
+

--- a/backend/src/services/devTestData.ts
+++ b/backend/src/services/devTestData.ts
@@ -2,8 +2,8 @@ import bcrypt from 'bcryptjs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import prisma from '../config/database';
-import { ActivityLevel, HeightUnit, MealPeriod, Sex, WeightUnit } from '@prisma/client';
-import { formatDateToLocalDateString, normalizeToUtcDateOnly } from '../utils/date';
+import { ActivityLevel, HeightUnit, Sex, WeightUnit } from '@prisma/client';
+import { buildMealLogsForDay, getPastWeekDates, getSeedUserCreatedAt } from './devTestDataUtils';
 
 const TEST_USER_EMAIL = 'test@calibratehealth.app';
 const TEST_USER_PASSWORD = 'password123';
@@ -16,111 +16,6 @@ const TEST_GOAL_TARGET_WEIGHT_GRAMS = 76000;
 
 const PROFILE_PLACEHOLDER_IMAGE_PATH = path.resolve(__dirname, '../../prisma/assets/profile-placeholder.png');
 const PROFILE_PLACEHOLDER_IMAGE_MIME_TYPE = 'image/png';
-
-type MealTemplate = {
-  mealPeriod: MealPeriod;
-  name: string;
-  calories: number;
-  hour: number;
-  minute?: number;
-};
-
-const SEED_MEAL_ITEMS = {
-  spinachOmelet: { mealPeriod: MealPeriod.BREAKFAST, name: 'Spinach omelet', calories: 320, hour: 7 },
-  sourdoughToast: { mealPeriod: MealPeriod.BREAKFAST, name: 'Sourdough toast', calories: 150, hour: 7, minute: 20 },
-  latte: { mealPeriod: MealPeriod.BREAKFAST, name: 'Latte', calories: 120, hour: 8, minute: 10 },
-
-  appleWithPeanutButter: {
-    mealPeriod: MealPeriod.MORNING_SNACK,
-    name: 'Apple with peanut butter',
-    calories: 180,
-    hour: 10,
-  },
-  greekYogurt: { mealPeriod: MealPeriod.MORNING_SNACK, name: 'Greek yogurt', calories: 190, hour: 10 },
-
-  turkeySandwich: { mealPeriod: MealPeriod.LUNCH, name: 'Turkey sandwich', calories: 520, hour: 13 },
-  sideSalad: { mealPeriod: MealPeriod.LUNCH, name: 'Side salad', calories: 180, hour: 13, minute: 15 },
-  chickenBurritoBowl: { mealPeriod: MealPeriod.LUNCH, name: 'Chicken burrito bowl', calories: 680, hour: 13 },
-
-  proteinShake: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Protein shake', calories: 210, hour: 16 },
-  trailMix: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Trail mix', calories: 160, hour: 16, minute: 25 },
-  granolaBar: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Granola bar', calories: 140, hour: 16, minute: 20 },
-
-  chickenStirFry: { mealPeriod: MealPeriod.DINNER, name: 'Chicken stir-fry', calories: 650, hour: 19 },
-  steamedRice: { mealPeriod: MealPeriod.DINNER, name: 'Steamed rice', calories: 200, hour: 19, minute: 15 },
-  roastedVeggies: { mealPeriod: MealPeriod.DINNER, name: 'Roasted veggies', calories: 110, hour: 19, minute: 20 },
-
-  darkChocolateSquare: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Dark chocolate square', calories: 120, hour: 21 },
-  popcorn: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Popcorn', calories: 150, hour: 21, minute: 5 },
-  iceCreamScoop: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Ice cream scoop', calories: 220, hour: 21, minute: 10 },
-} satisfies Record<string, MealTemplate>;
-
-const WEEK_MEAL_PLANS: MealTemplate[][] = [
-  // 2160 kcal: full day + extra afternoon snack item (multi-item meal).
-  [
-    SEED_MEAL_ITEMS.spinachOmelet,
-    SEED_MEAL_ITEMS.appleWithPeanutButter,
-    SEED_MEAL_ITEMS.turkeySandwich,
-    SEED_MEAL_ITEMS.proteinShake,
-    SEED_MEAL_ITEMS.trailMix,
-    SEED_MEAL_ITEMS.chickenStirFry,
-    SEED_MEAL_ITEMS.darkChocolateSquare,
-  ],
-  // 1900 kcal: no morning snack / evening snack, dinner has multiple items.
-  [
-    SEED_MEAL_ITEMS.spinachOmelet,
-    SEED_MEAL_ITEMS.turkeySandwich,
-    SEED_MEAL_ITEMS.proteinShake,
-    SEED_MEAL_ITEMS.chickenStirFry,
-    SEED_MEAL_ITEMS.steamedRice,
-  ],
-  // 1740 kcal: lunch empty, breakfast + afternoon snack have multiple items.
-  [
-    SEED_MEAL_ITEMS.spinachOmelet,
-    SEED_MEAL_ITEMS.latte,
-    SEED_MEAL_ITEMS.appleWithPeanutButter,
-    SEED_MEAL_ITEMS.proteinShake,
-    SEED_MEAL_ITEMS.granolaBar,
-    SEED_MEAL_ITEMS.chickenStirFry,
-    SEED_MEAL_ITEMS.darkChocolateSquare,
-  ],
-  // 1870 kcal: breakfast empty, lunch has multiple items.
-  [
-    SEED_MEAL_ITEMS.greekYogurt,
-    SEED_MEAL_ITEMS.turkeySandwich,
-    SEED_MEAL_ITEMS.sideSalad,
-    SEED_MEAL_ITEMS.proteinShake,
-    SEED_MEAL_ITEMS.chickenStirFry,
-    SEED_MEAL_ITEMS.darkChocolateSquare,
-  ],
-  // 1540 kcal: dinner empty, swapped lunch + swapped evening snack.
-  [
-    SEED_MEAL_ITEMS.spinachOmelet,
-    SEED_MEAL_ITEMS.appleWithPeanutButter,
-    SEED_MEAL_ITEMS.chickenBurritoBowl,
-    SEED_MEAL_ITEMS.proteinShake,
-    SEED_MEAL_ITEMS.popcorn,
-  ],
-  // 2050 kcal: afternoon snack empty, breakfast + dinner have multiple items.
-  [
-    SEED_MEAL_ITEMS.spinachOmelet,
-    SEED_MEAL_ITEMS.sourdoughToast,
-    SEED_MEAL_ITEMS.appleWithPeanutButter,
-    SEED_MEAL_ITEMS.turkeySandwich,
-    SEED_MEAL_ITEMS.chickenStirFry,
-    SEED_MEAL_ITEMS.roastedVeggies,
-    SEED_MEAL_ITEMS.darkChocolateSquare,
-  ],
-  // 2040 kcal: morning snack empty, breakfast swapped in extra item + higher-cal evening snack.
-  [
-    SEED_MEAL_ITEMS.spinachOmelet,
-    SEED_MEAL_ITEMS.latte,
-    SEED_MEAL_ITEMS.turkeySandwich,
-    SEED_MEAL_ITEMS.proteinShake,
-    SEED_MEAL_ITEMS.chickenStirFry,
-    SEED_MEAL_ITEMS.iceCreamScoop,
-  ],
-];
 
 type SeedProfileImage = {
   mimeType: string;
@@ -149,58 +44,6 @@ const loadProfilePlaceholderImage = async (): Promise<SeedProfileImage | null> =
   }
 
   return cachedProfilePlaceholderImage;
-};
-
-/**
- * Build a new date-only value by adding the provided day offset (UTC, no DST surprises).
- */
-const addUtcDays = (date: Date, offset: number): Date => {
-  const result = new Date(date);
-  result.setUTCDate(result.getUTCDate() + offset);
-  return result;
-};
-
-/**
- * Return an array of UTC-normalized DATE values covering the past week in the provided time zone.
- */
-const getPastWeekDates = (timeZone: string, now: Date = new Date()): Date[] => {
-  const todayLocalDate = formatDateToLocalDateString(now, timeZone);
-  const today = normalizeToUtcDateOnly(todayLocalDate);
-  return Array.from({ length: 7 }, (_, index) => addUtcDays(today, index - 6));
-};
-
-/**
- * Choose a deterministic created_at timestamp that won't hide seeded history in the /log date picker.
- *
- * The /log page clamps its minimum selectable day to the user's account creation local day.
- * We set created_at to land on the earliest seeded local_date (when formatted in the user's
- * timezone), so all generated seed days remain selectable without widening bounds globally.
- */
-const getSeedUserCreatedAt = (seedDays: Date[], timeZone: string): Date => {
-  const earliestSeedDay = seedDays[0];
-  if (!earliestSeedDay) {
-    return new Date();
-  }
-
-  const seedDateIso = earliestSeedDay.toISOString().slice(0, 10);
-  const candidateHoursUtc = [12, 0, 6, 18];
-
-  for (const hour of candidateHoursUtc) {
-    const candidate = new Date(earliestSeedDay);
-    candidate.setUTCHours(hour, 0, 0, 0);
-
-    try {
-      if (formatDateToLocalDateString(candidate, timeZone) === seedDateIso) {
-        return candidate;
-      }
-    } catch {
-      // Ignore invalid timezone inputs (we'll fall back to a best-effort value below).
-    }
-  }
-
-  const fallback = new Date(earliestSeedDay);
-  fallback.setUTCHours(12, 0, 0, 0);
-  return fallback;
 };
 
 /**
@@ -283,50 +126,6 @@ const ensureBodyMetrics = async (userId: number, days: Date[]): Promise<void> =>
       },
     });
   }
-};
-
-/**
- * Return a deterministic-but-varied meal plan for the provided seed day index.
- *
- * This keeps local dev data reproducible while exercising UI states like:
- * - different day totals
- * - empty meals (no items for a meal period)
- * - multi-item meals (multiple food logs in one meal period)
- */
-const getMealTemplatesForSeedDayIndex = (dayIndex: number): MealTemplate[] => {
-  const plan = WEEK_MEAL_PLANS[dayIndex % WEEK_MEAL_PLANS.length];
-  return plan ?? [];
-};
-
-/**
- * Build meal logs for a given day using the varied seed templates.
- */
-const buildMealLogsForDay = (
-  userId: number,
-  day: Date,
-  dayIndex: number
-): Array<{
-  user_id: number;
-  date: Date;
-  local_date: Date;
-  meal_period: MealPeriod;
-  name: string;
-  calories: number;
-}> => {
-  const templates = getMealTemplatesForSeedDayIndex(dayIndex);
-
-  return templates.map((template) => {
-    const mealDate = new Date(day);
-    mealDate.setUTCHours(template.hour, template.minute ?? 0, 0, 0);
-    return {
-      user_id: userId,
-      date: mealDate,
-      local_date: day,
-      meal_period: template.mealPeriod,
-      name: template.name,
-      calories: template.calories,
-    };
-  });
 };
 
 /**

--- a/backend/src/services/devTestDataUtils.ts
+++ b/backend/src/services/devTestDataUtils.ts
@@ -1,0 +1,209 @@
+import { MealPeriod } from '@prisma/client';
+import { formatDateToLocalDateString, normalizeToUtcDateOnly } from '../utils/date';
+
+/**
+ * Pure helpers for building deterministic dev seed data.
+ *
+ * This file intentionally avoids importing Prisma/db clients so unit tests can cover the
+ * seed math without requiring DATABASE_URL or a running Postgres instance.
+ */
+export type MealTemplate = {
+  mealPeriod: MealPeriod;
+  name: string;
+  calories: number;
+  hour: number;
+  minute?: number;
+};
+
+const SEED_MEAL_ITEMS = {
+  spinachOmelet: { mealPeriod: MealPeriod.BREAKFAST, name: 'Spinach omelet', calories: 320, hour: 7 },
+  sourdoughToast: { mealPeriod: MealPeriod.BREAKFAST, name: 'Sourdough toast', calories: 150, hour: 7, minute: 20 },
+  latte: { mealPeriod: MealPeriod.BREAKFAST, name: 'Latte', calories: 120, hour: 8, minute: 10 },
+
+  appleWithPeanutButter: {
+    mealPeriod: MealPeriod.MORNING_SNACK,
+    name: 'Apple with peanut butter',
+    calories: 180,
+    hour: 10,
+  },
+  greekYogurt: { mealPeriod: MealPeriod.MORNING_SNACK, name: 'Greek yogurt', calories: 190, hour: 10 },
+
+  turkeySandwich: { mealPeriod: MealPeriod.LUNCH, name: 'Turkey sandwich', calories: 520, hour: 13 },
+  sideSalad: { mealPeriod: MealPeriod.LUNCH, name: 'Side salad', calories: 180, hour: 13, minute: 15 },
+  chickenBurritoBowl: { mealPeriod: MealPeriod.LUNCH, name: 'Chicken burrito bowl', calories: 680, hour: 13 },
+
+  proteinShake: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Protein shake', calories: 210, hour: 16 },
+  trailMix: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Trail mix', calories: 160, hour: 16, minute: 25 },
+  granolaBar: { mealPeriod: MealPeriod.AFTERNOON_SNACK, name: 'Granola bar', calories: 140, hour: 16, minute: 20 },
+
+  chickenStirFry: { mealPeriod: MealPeriod.DINNER, name: 'Chicken stir-fry', calories: 650, hour: 19 },
+  steamedRice: { mealPeriod: MealPeriod.DINNER, name: 'Steamed rice', calories: 200, hour: 19, minute: 15 },
+  roastedVeggies: { mealPeriod: MealPeriod.DINNER, name: 'Roasted veggies', calories: 110, hour: 19, minute: 20 },
+
+  darkChocolateSquare: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Dark chocolate square', calories: 120, hour: 21 },
+  popcorn: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Popcorn', calories: 150, hour: 21, minute: 5 },
+  iceCreamScoop: { mealPeriod: MealPeriod.EVENING_SNACK, name: 'Ice cream scoop', calories: 220, hour: 21, minute: 10 },
+} satisfies Record<string, MealTemplate>;
+
+const WEEK_MEAL_PLANS: MealTemplate[][] = [
+  // 2160 kcal: full day + extra afternoon snack item (multi-item meal).
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.trailMix,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 1900 kcal: no morning snack / evening snack, dinner has multiple items.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.steamedRice,
+  ],
+  // 1740 kcal: lunch empty, breakfast + afternoon snack have multiple items.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.latte,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.granolaBar,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 1870 kcal: breakfast empty, lunch has multiple items.
+  [
+    SEED_MEAL_ITEMS.greekYogurt,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.sideSalad,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 1540 kcal: dinner empty, swapped lunch + swapped evening snack.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.chickenBurritoBowl,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.popcorn,
+  ],
+  // 2050 kcal: afternoon snack empty, breakfast + dinner have multiple items.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.sourdoughToast,
+    SEED_MEAL_ITEMS.appleWithPeanutButter,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.roastedVeggies,
+    SEED_MEAL_ITEMS.darkChocolateSquare,
+  ],
+  // 2040 kcal: morning snack empty, breakfast swapped in extra item + higher-cal evening snack.
+  [
+    SEED_MEAL_ITEMS.spinachOmelet,
+    SEED_MEAL_ITEMS.latte,
+    SEED_MEAL_ITEMS.turkeySandwich,
+    SEED_MEAL_ITEMS.proteinShake,
+    SEED_MEAL_ITEMS.chickenStirFry,
+    SEED_MEAL_ITEMS.iceCreamScoop,
+  ],
+];
+
+/**
+ * Build a new Date by adding the provided day offset using UTC math (no DST surprises).
+ */
+export function addUtcDays(date: Date, offset: number): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + offset);
+  return result;
+}
+
+/**
+ * Return an array of UTC-normalized DATE values covering the past week in the provided time zone.
+ */
+export function getPastWeekDates(timeZone: string, now: Date = new Date()): Date[] {
+  const todayLocalDate = formatDateToLocalDateString(now, timeZone);
+  const today = normalizeToUtcDateOnly(todayLocalDate);
+  return Array.from({ length: 7 }, (_, index) => addUtcDays(today, index - 6));
+}
+
+/**
+ * Choose a deterministic created_at timestamp that matches the earliest seeded local day.
+ *
+ * The /log page clamps its minimum selectable day to the user's account creation local day.
+ * We set created_at to land on the earliest seeded local_date (when formatted in the user's
+ * timezone), so all generated seed days remain selectable without widening bounds globally.
+ */
+export function getSeedUserCreatedAt(seedDays: Date[], timeZone: string): Date {
+  const earliestSeedDay = seedDays[0];
+  if (!earliestSeedDay) {
+    return new Date();
+  }
+
+  const seedDateIso = earliestSeedDay.toISOString().slice(0, 10);
+  const candidateHoursUtc = [12, 0, 6, 18];
+
+  for (const hour of candidateHoursUtc) {
+    const candidate = new Date(earliestSeedDay);
+    candidate.setUTCHours(hour, 0, 0, 0);
+
+    try {
+      if (formatDateToLocalDateString(candidate, timeZone) === seedDateIso) {
+        return candidate;
+      }
+    } catch {
+      // Ignore invalid timezone inputs (we'll fall back to a best-effort value below).
+    }
+  }
+
+  const fallback = new Date(earliestSeedDay);
+  fallback.setUTCHours(12, 0, 0, 0);
+  return fallback;
+}
+
+/**
+ * Return a deterministic-but-varied meal plan for the provided seed day index.
+ *
+ * This keeps local dev data reproducible while exercising UI states like:
+ * - different day totals
+ * - empty meals (no items for a meal period)
+ * - multi-item meals (multiple food logs in one meal period)
+ */
+export function getMealTemplatesForSeedDayIndex(dayIndex: number): MealTemplate[] {
+  const plan = WEEK_MEAL_PLANS[dayIndex % WEEK_MEAL_PLANS.length];
+  return plan ?? [];
+}
+
+/**
+ * Build meal logs for a given seed day using the varied meal templates.
+ */
+export function buildMealLogsForDay(
+  userId: number,
+  day: Date,
+  dayIndex: number
+): Array<{
+  user_id: number;
+  date: Date;
+  local_date: Date;
+  meal_period: MealPeriod;
+  name: string;
+  calories: number;
+}> {
+  const templates = getMealTemplatesForSeedDayIndex(dayIndex);
+
+  return templates.map((template) => {
+    const mealDate = new Date(day);
+    mealDate.setUTCHours(template.hour, template.minute ?? 0, 0, 0);
+    return {
+      user_id: userId,
+      date: mealDate,
+      local_date: day,
+      meal_period: template.mealPeriod,
+      name: template.name,
+      calories: template.calories,
+    };
+  });
+}

--- a/backend/src/utils/devAuth.ts
+++ b/backend/src/utils/devAuth.ts
@@ -1,18 +1,9 @@
 import type { NextFunction, Request, Response } from 'express';
 import prisma from '../config/database';
 import { ensureDevTestData } from '../services/devTestData';
+import { shouldAutoLoginTestUser } from './devAutoLoginPolicy';
 
 const TEST_USER_EMAIL = 'test@calibratehealth.app';
-
-/**
- * Decide whether the current request should auto-login the local test user.
- */
-const shouldAutoLogin = (req: Request): boolean => {
-  const enabled = process.env.AUTO_LOGIN_TEST_USER === 'true';
-  const isProduction = process.env.NODE_ENV === 'production';
-  const isLoggingOut = req.path.startsWith('/auth/logout');
-  return enabled && !isProduction && !isLoggingOut && !req.isAuthenticated();
-};
 
 /**
  * Attach the test user to the session for local development convenience.
@@ -22,7 +13,7 @@ export const autoLoginTestUser = async (
   _res: Response,
   next: NextFunction
 ): Promise<void> => {
-  if (!shouldAutoLogin(req)) {
+  if (!shouldAutoLoginTestUser(req)) {
     next();
     return;
   }

--- a/backend/src/utils/devAutoLoginPolicy.ts
+++ b/backend/src/utils/devAutoLoginPolicy.ts
@@ -1,0 +1,20 @@
+import type { Request } from 'express';
+
+export type AutoLoginRequestLike = Pick<Request, 'path' | 'isAuthenticated'>;
+
+/**
+ * Decide whether the current request should auto-login the local test user.
+ *
+ * We keep this logic separate from the Prisma-dependent middleware so it can be unit tested
+ * without requiring DATABASE_URL.
+ */
+export function shouldAutoLoginTestUser(
+  req: AutoLoginRequestLike,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const enabled = env.AUTO_LOGIN_TEST_USER === 'true';
+  const isProduction = env.NODE_ENV === 'production';
+  const isLoggingOut = req.path.startsWith('/auth/logout');
+  return enabled && !isProduction && !isLoggingOut && !req.isAuthenticated();
+}
+

--- a/backend/test/dev-auto-login-policy.test.js
+++ b/backend/test/dev-auto-login-policy.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { shouldAutoLoginTestUser } = require('../src/utils/devAutoLoginPolicy');
+
+const buildReq = (opts) => ({
+  path: opts.path ?? '/some/path',
+  isAuthenticated: () => Boolean(opts.isAuthenticated)
+});
+
+test('devAutoLoginPolicy: shouldAutoLoginTestUser returns false when not explicitly enabled', () => {
+  const req = buildReq({ isAuthenticated: false });
+  assert.equal(shouldAutoLoginTestUser(req, { NODE_ENV: 'development' }), false);
+  assert.equal(shouldAutoLoginTestUser(req, { AUTO_LOGIN_TEST_USER: 'false' }), false);
+});
+
+test('devAutoLoginPolicy: shouldAutoLoginTestUser blocks auto-login in production', () => {
+  const req = buildReq({ isAuthenticated: false });
+  assert.equal(shouldAutoLoginTestUser(req, { AUTO_LOGIN_TEST_USER: 'true', NODE_ENV: 'production' }), false);
+});
+
+test('devAutoLoginPolicy: shouldAutoLoginTestUser blocks auto-login when already authenticated', () => {
+  const req = buildReq({ isAuthenticated: true });
+  assert.equal(shouldAutoLoginTestUser(req, { AUTO_LOGIN_TEST_USER: 'true', NODE_ENV: 'development' }), false);
+});
+
+test('devAutoLoginPolicy: shouldAutoLoginTestUser blocks auto-login on logout requests', () => {
+  const req = buildReq({ path: '/auth/logout', isAuthenticated: false });
+  assert.equal(shouldAutoLoginTestUser(req, { AUTO_LOGIN_TEST_USER: 'true', NODE_ENV: 'development' }), false);
+});
+
+test('devAutoLoginPolicy: shouldAutoLoginTestUser enables auto-login only for unauthenticated non-logout dev requests', () => {
+  const req = buildReq({ path: '/metrics/today', isAuthenticated: false });
+  assert.equal(shouldAutoLoginTestUser(req, { AUTO_LOGIN_TEST_USER: 'true', NODE_ENV: 'development' }), true);
+});
+

--- a/backend/test/dev-test-data-utils.test.js
+++ b/backend/test/dev-test-data-utils.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  addUtcDays,
+  buildMealLogsForDay,
+  getMealTemplatesForSeedDayIndex,
+  getPastWeekDates,
+  getSeedUserCreatedAt
+} = require('../src/services/devTestDataUtils');
+
+test('devTestDataUtils: addUtcDays adds days using UTC math without mutating the input', () => {
+  const input = new Date('2025-01-15T12:34:56Z');
+  const result = addUtcDays(input, 2);
+
+  assert.equal(input.toISOString(), '2025-01-15T12:34:56.000Z');
+  assert.equal(result.toISOString(), '2025-01-17T12:34:56.000Z');
+});
+
+test('devTestDataUtils: getPastWeekDates returns 7 UTC date-only values ending on the local day', () => {
+  // 05:00Z is prior local day in America/Los_Angeles (UTC-8 in winter).
+  const now = new Date('2025-01-02T05:00:00Z');
+  const dates = getPastWeekDates('America/Los_Angeles', now);
+
+  assert.equal(dates.length, 7);
+
+  // Local day is 2025-01-01, so the seed week ends at that local day.
+  assert.equal(dates[6].toISOString(), '2025-01-01T00:00:00.000Z');
+  assert.equal(dates[0].toISOString(), '2024-12-26T00:00:00.000Z');
+
+  for (const date of dates) {
+    assert.equal(date.getUTCHours(), 0);
+    assert.equal(date.getUTCMinutes(), 0);
+    assert.equal(date.getUTCSeconds(), 0);
+    assert.equal(date.getUTCMilliseconds(), 0);
+  }
+});
+
+test('devTestDataUtils: getSeedUserCreatedAt picks a UTC hour that preserves the earliest seed local day', () => {
+  const seedDays = [new Date('2025-01-01T00:00:00Z')];
+
+  const laCreatedAt = getSeedUserCreatedAt(seedDays, 'America/Los_Angeles');
+  assert.equal(laCreatedAt.toISOString(), '2025-01-01T12:00:00.000Z');
+
+  // Pacific/Kiritimati is UTC+14; noon UTC would land on the next local day, so we use 00:00 UTC.
+  const kiritimatiCreatedAt = getSeedUserCreatedAt(seedDays, 'Pacific/Kiritimati');
+  assert.equal(kiritimatiCreatedAt.toISOString(), '2025-01-01T00:00:00.000Z');
+});
+
+test('devTestDataUtils: getSeedUserCreatedAt falls back when the timezone is invalid', () => {
+  const seedDays = [new Date('2025-01-01T00:00:00Z')];
+  const createdAt = getSeedUserCreatedAt(seedDays, 'Not/AZone');
+  assert.equal(createdAt.toISOString(), '2025-01-01T12:00:00.000Z');
+});
+
+test('devTestDataUtils: getMealTemplatesForSeedDayIndex returns deterministic week plans', () => {
+  const day0 = getMealTemplatesForSeedDayIndex(0);
+  assert.ok(day0.length > 0);
+  assert.equal(day0[0].name, 'Spinach omelet');
+
+  const day7 = getMealTemplatesForSeedDayIndex(7);
+  assert.deepEqual(
+    day7.map((item) => item.name),
+    day0.map((item) => item.name)
+  );
+
+  assert.deepEqual(getMealTemplatesForSeedDayIndex(-1), []);
+});
+
+test('devTestDataUtils: buildMealLogsForDay stamps log timestamps using the template time-of-day', () => {
+  const userId = 123;
+  const day = new Date('2025-01-01T00:00:00Z');
+
+  const logs = buildMealLogsForDay(userId, day, 0);
+  assert.ok(logs.length > 0);
+
+  assert.equal(logs[0].user_id, userId);
+  assert.equal(logs[0].local_date.toISOString(), day.toISOString());
+  assert.equal(logs[0].name, 'Spinach omelet');
+  assert.equal(logs[0].date.toISOString(), '2025-01-01T07:00:00.000Z');
+});
+

--- a/backend/test/food-utils.test.js
+++ b/backend/test/food-utils.test.js
@@ -1,0 +1,134 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseFoodLogCreateBody,
+  parseFoodLogUpdateBody,
+  parseFoodSearchParams
+} = require('../src/routes/foodUtils');
+
+test('foodUtils: parseFoodSearchParams requires a query or barcode', () => {
+  const missing = parseFoodSearchParams({ query: {}, acceptLanguageHeader: undefined });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.statusCode, 400);
+  assert.equal(missing.message, 'Provide a search query or barcode.');
+
+  const withQuery = parseFoodSearchParams({
+    query: { q: 'banana', page: '2', pageSize: '10', grams: '50', lc: 'en' },
+    acceptLanguageHeader: 'fr-FR,fr;q=0.9'
+  });
+  assert.equal(withQuery.ok, true);
+  assert.deepEqual(withQuery.params, {
+    query: 'banana',
+    barcode: undefined,
+    page: 2,
+    pageSize: 10,
+    quantityInGrams: 50,
+    languageCode: 'en'
+  });
+});
+
+test('foodUtils: parseFoodLogCreateBody rejects invalid bodies and meal periods', () => {
+  assert.equal(parseFoodLogCreateBody({ body: null, userTimeZone: 'UTC' }).ok, false);
+
+  const badPeriod = parseFoodLogCreateBody({
+    body: { meal_period: 'INVALID', name: 'Apple', calories: 10 },
+    userTimeZone: 'UTC'
+  });
+  assert.equal(badPeriod.ok, false);
+  assert.equal(badPeriod.statusCode, 400);
+  assert.equal(badPeriod.message, 'Invalid meal period');
+});
+
+test('foodUtils: parseFoodLogCreateBody defaults date fields when date is omitted', () => {
+  const now = new Date('2025-01-02T05:00:00Z');
+  const result = parseFoodLogCreateBody({
+    body: { meal_period: 'BREAKFAST', name: 'Apple', calories: 12.4 },
+    userTimeZone: 'America/Los_Angeles',
+    now
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, 'MANUAL');
+  assert.equal(result.entryTimestamp.toISOString(), now.toISOString());
+  // 05:00Z is still the previous local day in America/Los_Angeles.
+  assert.equal(result.localDate.toISOString(), '2025-01-01T00:00:00.000Z');
+  assert.equal(result.calories, 12);
+});
+
+test('foodUtils: parseFoodLogCreateBody rejects invalid dates and mutual exclusivity', () => {
+  const badDate = parseFoodLogCreateBody({
+    body: { meal_period: 'LUNCH', name: 'Apple', calories: 10, date: 'not-a-date' },
+    userTimeZone: 'UTC'
+  });
+  assert.equal(badDate.ok, false);
+  assert.equal(badDate.message, 'Invalid date');
+
+  const both = parseFoodLogCreateBody({
+    body: { meal_period: 'LUNCH', name: 'Apple', calories: 10, my_food_id: '1', servings_consumed: 1 },
+    userTimeZone: 'UTC'
+  });
+  assert.equal(both.ok, false);
+  assert.equal(both.message, 'Provide either my_food_id+servings_consumed or name+calories, not both.');
+});
+
+test('foodUtils: parseFoodLogCreateBody parses my_food_id and servings_consumed inputs', () => {
+  const ok = parseFoodLogCreateBody({
+    body: { meal_period: 'DINNER', my_food_id: '42', servings_consumed: '1.5', date: '2025-01-01' },
+    userTimeZone: 'UTC'
+  });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.kind, 'MY_FOOD');
+  assert.equal(ok.myFoodId, 42);
+  assert.equal(ok.servingsConsumed, 1.5);
+  assert.equal(ok.localDate.toISOString(), '2025-01-01T00:00:00.000Z');
+  assert.equal(ok.entryTimestamp.toISOString(), '2025-01-01T00:00:00.000Z');
+});
+
+test('foodUtils: parseFoodLogUpdateBody rejects non-object bodies and empty updates', () => {
+  const nonObject = parseFoodLogUpdateBody({ body: null, existing: {} });
+  assert.equal(nonObject.ok, false);
+  assert.equal(nonObject.message, 'Invalid request body');
+
+  const empty = parseFoodLogUpdateBody({ body: {}, existing: {} });
+  assert.equal(empty.ok, false);
+  assert.equal(empty.message, 'No fields to update');
+});
+
+test('foodUtils: parseFoodLogUpdateBody computes calories from servings when snapshot exists', () => {
+  const parsed = parseFoodLogUpdateBody({
+    body: { servings_consumed: 2 },
+    existing: { calories_per_serving_snapshot: 110 }
+  });
+
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.updateData, {
+    servings_consumed: 2,
+    calories: 220,
+    calories_per_serving_snapshot: 110
+  });
+});
+
+test('foodUtils: parseFoodLogUpdateBody rejects servings updates when the entry has no snapshot', () => {
+  const parsed = parseFoodLogUpdateBody({
+    body: { servings_consumed: 2 },
+    existing: { calories_per_serving_snapshot: null }
+  });
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.message, 'This entry does not include serving info.');
+});
+
+test('foodUtils: parseFoodLogUpdateBody derives calories_per_serving_snapshot from calories and servings', () => {
+  const parsed = parseFoodLogUpdateBody({
+    body: { calories: 250 },
+    existing: { servings_consumed: 2 }
+  });
+
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.updateData, {
+    calories: 250,
+    calories_per_serving_snapshot: 125
+  });
+});
+

--- a/backend/test/my-foods-recipe-utils.test.js
+++ b/backend/test/my-foods-recipe-utils.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildExternalIngredientSnapshotRow,
+  parseMyFoodIngredientInput
+} = require('../src/routes/myFoodsRecipeUtils');
+
+test('myFoodsRecipeUtils: parseMyFoodIngredientInput validates ids and quantities', () => {
+  const ok = parseMyFoodIngredientInput({ my_food_id: '123', quantity_servings: '1.5' });
+  assert.equal(ok.ok, true);
+  assert.deepEqual(ok.value, { myFoodId: 123, quantityServings: 1.5 });
+
+  const badId = parseMyFoodIngredientInput({ my_food_id: 0, quantity_servings: 1 });
+  assert.equal(badId.ok, false);
+  assert.equal(badId.error.statusCode, 400);
+  assert.equal(badId.error.message, 'Invalid ingredient my_food_id');
+
+  const badQty = parseMyFoodIngredientInput({ my_food_id: 123, quantity_servings: 0 });
+  assert.equal(badQty.ok, false);
+  assert.equal(badQty.error.statusCode, 400);
+  assert.equal(badQty.error.message, 'Invalid ingredient quantity_servings');
+});
+
+test('myFoodsRecipeUtils: buildExternalIngredientSnapshotRow validates required fields and normalizes optionals', () => {
+  const ok = buildExternalIngredientSnapshotRow(
+    {
+      name: '  Tomato   sauce ',
+      calories_total: '120',
+      external_source: '   OF  ',
+      grams_total: '250',
+      grams_per_measure: 'abc' // invalid optional value -> becomes null
+    },
+    2
+  );
+
+  assert.equal(ok.ok, true);
+  assert.equal(ok.value.sort_order, 2);
+  assert.equal(ok.value.source, 'EXTERNAL');
+  assert.equal(ok.value.name_snapshot, 'Tomato sauce');
+  assert.equal(ok.value.calories_total_snapshot, 120);
+  assert.equal(ok.value.external_source, 'OF');
+  assert.equal(ok.value.grams_total_snapshot, 250);
+  assert.equal(ok.value.grams_per_measure_snapshot, null);
+});
+
+test('myFoodsRecipeUtils: buildExternalIngredientSnapshotRow rejects invalid inputs', () => {
+  const badName = buildExternalIngredientSnapshotRow({ name: '', calories_total: 10 }, 1);
+  assert.equal(badName.ok, false);
+  assert.equal(badName.error.statusCode, 400);
+  assert.equal(badName.error.message, 'Invalid external ingredient name');
+
+  const badCalories = buildExternalIngredientSnapshotRow({ name: 'x', calories_total: 'nope' }, 1);
+  assert.equal(badCalories.ok, false);
+  assert.equal(badCalories.error.statusCode, 400);
+  assert.equal(badCalories.error.message, 'Invalid external ingredient calories_total');
+});
+

--- a/backend/test/my-foods-utils.test.js
+++ b/backend/test/my-foods-utils.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  MY_FOOD_NAME_MAX_LENGTH,
+  SERVING_UNIT_LABEL_MAX_LENGTH,
+  createHttpError,
+  isHttpError,
+  normalizeMyFoodName,
+  normalizeOptionalString,
+  normalizeServingUnitLabel
+} = require('../src/routes/myFoodsUtils');
+
+test('myFoodsUtils: normalizeServingUnitLabel trims and collapses whitespace', () => {
+  assert.equal(normalizeServingUnitLabel('  fl   oz  '), 'fl oz');
+  assert.equal(normalizeServingUnitLabel(''), null);
+  assert.equal(normalizeServingUnitLabel('   '), null);
+  assert.equal(normalizeServingUnitLabel(null), null);
+});
+
+test('myFoodsUtils: normalizeServingUnitLabel enforces max length', () => {
+  assert.equal(normalizeServingUnitLabel('a'.repeat(SERVING_UNIT_LABEL_MAX_LENGTH)), 'a'.repeat(SERVING_UNIT_LABEL_MAX_LENGTH));
+  assert.equal(normalizeServingUnitLabel('a'.repeat(SERVING_UNIT_LABEL_MAX_LENGTH + 1)), null);
+});
+
+test('myFoodsUtils: normalizeMyFoodName trims and collapses whitespace', () => {
+  assert.equal(normalizeMyFoodName('  Peanut   butter  '), 'Peanut butter');
+  assert.equal(normalizeMyFoodName(''), null);
+  assert.equal(normalizeMyFoodName(undefined), null);
+});
+
+test('myFoodsUtils: normalizeMyFoodName enforces max length', () => {
+  assert.equal(normalizeMyFoodName('a'.repeat(MY_FOOD_NAME_MAX_LENGTH)), 'a'.repeat(MY_FOOD_NAME_MAX_LENGTH));
+  assert.equal(normalizeMyFoodName('a'.repeat(MY_FOOD_NAME_MAX_LENGTH + 1)), null);
+});
+
+test('myFoodsUtils: normalizeOptionalString trims and treats empty as missing', () => {
+  assert.equal(normalizeOptionalString('  Brand  '), 'Brand');
+  assert.equal(normalizeOptionalString(''), null);
+  assert.equal(normalizeOptionalString('   '), null);
+  assert.equal(normalizeOptionalString(123), null);
+});
+
+test('myFoodsUtils: createHttpError and isHttpError provide lightweight status codes', () => {
+  const err = createHttpError(400, 'Bad request');
+  assert.equal(err.message, 'Bad request');
+  assert.equal(err.statusCode, 400);
+  assert.equal(isHttpError(err), true);
+
+  assert.equal(isHttpError(new Error('oops')), false);
+  assert.equal(isHttpError(null), false);
+});
+

--- a/backend/test/profile-image-utils.test.js
+++ b/backend/test/profile-image-utils.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ALLOWED_PROFILE_IMAGE_MIME_TYPES,
+  buildBase64DataUrl,
+  parseBase64DataUrl
+} = require('../src/utils/profileImage');
+
+test('profileImage: allowed MIME types include the expected image formats', () => {
+  assert.equal(ALLOWED_PROFILE_IMAGE_MIME_TYPES.has('image/png'), true);
+  assert.equal(ALLOWED_PROFILE_IMAGE_MIME_TYPES.has('image/jpeg'), true);
+  assert.equal(ALLOWED_PROFILE_IMAGE_MIME_TYPES.has('image/webp'), true);
+
+  assert.equal(ALLOWED_PROFILE_IMAGE_MIME_TYPES.has('image/gif'), false);
+  assert.equal(ALLOWED_PROFILE_IMAGE_MIME_TYPES.has('IMAGE/PNG'), false);
+});
+
+test('profileImage: parseBase64DataUrl rejects malformed strings', () => {
+  const invalidInputs = [
+    '',
+    'not-a-data-url',
+    'data:image/png;base64', // missing comma + payload
+    'data:image/png;base64,', // empty payload -> empty bytes
+    'data:image/png;base64,***', // invalid base64 chars
+    'data:image/gif;base64,R0lGODlhAQABAAAAACw=' // unsupported MIME type
+  ];
+
+  for (const input of invalidInputs) {
+    assert.equal(parseBase64DataUrl(input), null);
+  }
+});
+
+test('profileImage: parseBase64DataUrl parses supported base64 data URLs (trimming whitespace)', () => {
+  const dataUrl = '  data:image/png;base64,AQID  ';
+  const parsed = parseBase64DataUrl(dataUrl);
+  assert.ok(parsed);
+  assert.equal(parsed.mimeType, 'image/png');
+  assert.deepEqual(Array.from(parsed.bytes), [1, 2, 3]);
+});
+
+test('profileImage: buildBase64DataUrl encodes bytes and round-trips with parseBase64DataUrl', () => {
+  const bytes = new Uint8Array([0, 255, 16, 32]);
+  const dataUrl = buildBase64DataUrl({ mimeType: 'image/png', bytes });
+
+  assert.equal(dataUrl, 'data:image/png;base64,AP8QIA==');
+
+  const parsed = parseBase64DataUrl(dataUrl);
+  assert.ok(parsed);
+  assert.equal(parsed.mimeType, 'image/png');
+  assert.deepEqual(Array.from(parsed.bytes), Array.from(bytes));
+});
+

--- a/backend/test/routes-auth.test.js
+++ b/backend/test/routes-auth.test.js
@@ -1,0 +1,223 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadAuthRouter({ prismaStub, passportStub, bcryptStub }) {
+  const dbPath = require.resolve('../src/config/database');
+  const passportPath = require.resolve('passport');
+  const bcryptPath = require.resolve('bcryptjs');
+  const authPath = require.resolve('../src/routes/auth');
+
+  const previousDbModule = require.cache[dbPath];
+  const previousPassportModule = require.cache[passportPath];
+  const previousBcryptModule = require.cache[bcryptPath];
+
+  delete require.cache[authPath];
+
+  stubModule(dbPath, prismaStub);
+  stubModule(passportPath, passportStub);
+  stubModule(bcryptPath, bcryptStub);
+
+  const loaded = require('../src/routes/auth');
+
+  if (previousDbModule) require.cache[dbPath] = previousDbModule;
+  else delete require.cache[dbPath];
+
+  if (previousPassportModule) require.cache[passportPath] = previousPassportModule;
+  else delete require.cache[passportPath];
+
+  if (previousBcryptModule) require.cache[bcryptPath] = previousBcryptModule;
+  else delete require.cache[bcryptPath];
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getRouteHandlers(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  return layer.route.stack.map((stackLayer) => stackLayer.handle);
+}
+
+test('auth route: POST /register returns 400 when the email already exists', async () => {
+  const prismaStub = {
+    user: {
+      findUnique: async () => ({ id: 1 }),
+      create: async () => {
+        throw new Error('should not be called');
+      }
+    }
+  };
+  const passportStub = { authenticate: () => () => {} };
+  const bcryptStub = { genSalt: async () => 'salt', hash: async () => 'hash' };
+
+  const router = loadAuthRouter({ prismaStub, passportStub, bcryptStub });
+  const [handler] = getRouteHandlers(router, 'post', '/register');
+
+  const req = { body: { email: 'test@example.com', password: 'password123' } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'User already exists' });
+});
+
+test('auth route: POST /register creates a user and logs them in', async () => {
+  const createdUser = {
+    id: 42,
+    email: 'test@example.com',
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    weight_unit: 'KG',
+    height_unit: 'CM',
+    timezone: 'UTC',
+    date_of_birth: null,
+    sex: null,
+    height_mm: null,
+    activity_level: null,
+    profile_image: null,
+    profile_image_mime_type: null
+  };
+
+  const prismaStub = {
+    user: {
+      findUnique: async () => null,
+      create: async () => createdUser
+    }
+  };
+  const passportStub = { authenticate: () => () => {} };
+  const bcryptStub = { genSalt: async () => 'salt', hash: async () => 'hash' };
+
+  const router = loadAuthRouter({ prismaStub, passportStub, bcryptStub });
+  const [handler] = getRouteHandlers(router, 'post', '/register');
+
+  const req = {
+    body: { email: createdUser.email, password: 'password123' },
+    login: (_user, cb) => cb(null)
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    user: {
+      id: createdUser.id,
+      email: createdUser.email,
+      created_at: createdUser.created_at,
+      weight_unit: createdUser.weight_unit,
+      height_unit: createdUser.height_unit,
+      timezone: createdUser.timezone,
+      date_of_birth: createdUser.date_of_birth,
+      sex: createdUser.sex,
+      height_mm: createdUser.height_mm,
+      activity_level: createdUser.activity_level,
+      profile_image_url: null
+    }
+  });
+});
+
+test('auth route: POST /login uses passport middleware and returns the serialized user', async () => {
+  const authedUser = {
+    id: 7,
+    email: 'test@example.com',
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    weight_unit: 'KG',
+    height_unit: 'CM',
+    timezone: 'UTC',
+    date_of_birth: null,
+    sex: null,
+    height_mm: null,
+    activity_level: null,
+    profile_image: null,
+    profile_image_mime_type: null
+  };
+
+  const prismaStub = { user: {} };
+  const passportStub = {
+    authenticate: () => (req, _res, next) => {
+      req.user = authedUser;
+      next();
+    }
+  };
+  const bcryptStub = { genSalt: async () => 'salt', hash: async () => 'hash' };
+
+  const router = loadAuthRouter({ prismaStub, passportStub, bcryptStub });
+  const [passportMiddleware, handler] = getRouteHandlers(router, 'post', '/login');
+
+  const req = {};
+  const res = createRes();
+
+  await new Promise((resolve, reject) => {
+    passportMiddleware(req, res, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+
+  handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.user.id, authedUser.id);
+  assert.equal(res.body.user.email, authedUser.email);
+});
+
+test('auth route: POST /logout forwards errors from req.logout', async () => {
+  const prismaStub = { user: {} };
+  const passportStub = { authenticate: () => () => {} };
+  const bcryptStub = { genSalt: async () => 'salt', hash: async () => 'hash' };
+
+  const router = loadAuthRouter({ prismaStub, passportStub, bcryptStub });
+  const [handler] = getRouteHandlers(router, 'post', '/logout');
+
+  const req = {
+    logout: (cb) => cb(new Error('boom'))
+  };
+  const res = createRes();
+
+  let nextError = null;
+  handler(req, res, (err) => {
+    nextError = err;
+  });
+
+  assert.ok(nextError);
+  assert.equal(nextError.message, 'boom');
+});
+
+test('auth route: GET /me returns 401 when not authenticated', async () => {
+  const prismaStub = { user: {} };
+  const passportStub = { authenticate: () => () => {} };
+  const bcryptStub = { genSalt: async () => 'salt', hash: async () => 'hash' };
+
+  const router = loadAuthRouter({ prismaStub, passportStub, bcryptStub });
+  const [handler] = getRouteHandlers(router, 'get', '/me');
+
+  const req = { isAuthenticated: () => false };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: 'Not authenticated' });
+});
+

--- a/backend/test/routes-food.test.js
+++ b/backend/test/routes-food.test.js
@@ -1,0 +1,333 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadFoodRouter({ prismaStub, foodDataStub }) {
+  const dbPath = require.resolve('../src/config/database');
+  const foodDataPath = require.resolve('../src/services/foodData');
+  const foodRoutePath = require.resolve('../src/routes/food');
+
+  const previousDbModule = require.cache[dbPath];
+  const previousFoodDataModule = require.cache[foodDataPath];
+
+  delete require.cache[foodRoutePath];
+
+  stubModule(dbPath, prismaStub);
+  stubModule(foodDataPath, foodDataStub);
+
+  const loaded = require('../src/routes/food');
+
+  if (previousDbModule) require.cache[dbPath] = previousDbModule;
+  else delete require.cache[dbPath];
+
+  if (previousFoodDataModule) require.cache[foodDataPath] = previousFoodDataModule;
+  else delete require.cache[foodDataPath];
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getIsAuthenticatedMiddleware(router) {
+  const layer = router.stack.find((candidate) => !candidate.route);
+  assert.ok(layer, 'Expected router.use(isAuthenticated) middleware to exist');
+  return layer.handle;
+}
+
+function getRouteHandler(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  assert.equal(layer.route.stack.length, 1);
+  return layer.route.stack[0].handle;
+}
+
+test('food route: rejects unauthenticated requests via router.use middleware', async () => {
+  const router = loadFoodRouter({
+    prismaStub: {},
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const isAuthenticated = getIsAuthenticatedMiddleware(router);
+
+  const req = { isAuthenticated: () => false };
+  const res = createRes();
+
+  let nextCalled = false;
+  await isAuthenticated(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: 'Not authenticated' });
+});
+
+test('food route: GET /search requires query or barcode', async () => {
+  const router = loadFoodRouter({
+    prismaStub: {},
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+
+  const handler = getRouteHandler(router, 'get', '/search');
+  const req = { query: {}, headers: {} };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Provide a search query or barcode.' });
+});
+
+test('food route: GET /search calls provider.searchFoods and returns provider metadata', async () => {
+  let receivedRequest = null;
+
+  const providerStub = {
+    name: 'openFoodFacts',
+    supportsBarcodeLookup: true,
+    searchFoods: async (request) => {
+      receivedRequest = request;
+      return { items: [{ id: '1', source: 'openFoodFacts', description: 'Test', availableMeasures: [] }] };
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub: {},
+    foodDataStub: { getFoodDataProvider: () => providerStub }
+  });
+
+  const handler = getRouteHandler(router, 'get', '/search');
+  const req = {
+    query: { q: 'apple', page: '2', pageSize: '10', grams: '50', lc: 'en' },
+    headers: { 'accept-language': 'fr-FR,fr;q=0.9' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.deepEqual(receivedRequest, {
+    query: 'apple',
+    barcode: undefined,
+    page: 2,
+    pageSize: 10,
+    quantityInGrams: 50,
+    languageCode: 'en'
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.provider, 'openFoodFacts');
+  assert.equal(res.body.supportsBarcodeLookup, true);
+  assert.equal(Array.isArray(res.body.items), true);
+});
+
+test('food route: GET / validates local_date/date query params', async () => {
+  const prismaStub = {
+    foodLog: {
+      findMany: async () => {
+        throw new Error('should not be called');
+      }
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub,
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = { user: { id: 7 }, query: { date: 'not-a-date' } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Invalid date' });
+});
+
+test('food route: GET / passes local_date filter through to Prisma', async () => {
+  let receivedWhere = null;
+  const prismaStub = {
+    foodLog: {
+      findMany: async ({ where }) => {
+        receivedWhere = where;
+        return [{ id: 1, name: 'Test' }];
+      }
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub,
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = { user: { id: 7 }, query: { local_date: '2025-01-01' } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, [{ id: 1, name: 'Test' }]);
+
+  assert.equal(receivedWhere.user_id, 7);
+  assert.equal(receivedWhere.local_date.toISOString(), '2025-01-01T00:00:00.000Z');
+});
+
+test('food route: POST / creates a manual log after validating inputs', async () => {
+  let receivedData = null;
+  const createdLog = { id: 1, user_id: 7, name: 'Apple', calories: 12 };
+
+  const prismaStub = {
+    myFood: {},
+    foodLog: {
+      create: async ({ data }) => {
+        receivedData = data;
+        return createdLog;
+      }
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub,
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, timezone: 'UTC' },
+    body: { meal_period: 'BREAKFAST', name: '  Apple ', calories: '12.4', date: '2025-01-01' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, createdLog);
+  assert.equal(receivedData.user_id, 7);
+  assert.equal(receivedData.name, 'Apple');
+  assert.equal(receivedData.calories, 12);
+  assert.equal(receivedData.meal_period, 'BREAKFAST');
+});
+
+test('food route: POST / can create a my_food-backed log with snapshots', async () => {
+  const myFoodRow = {
+    id: 123,
+    user_id: 7,
+    name: 'Granola bar',
+    serving_size_quantity: 1,
+    serving_unit_label: 'bar',
+    calories_per_serving: 100
+  };
+
+  let receivedCreateData = null;
+  const createdLog = { id: 9, user_id: 7, name: 'Granola bar', calories: 150 };
+
+  const prismaStub = {
+    myFood: {
+      findFirst: async () => myFoodRow
+    },
+    foodLog: {
+      create: async ({ data }) => {
+        receivedCreateData = data;
+        return createdLog;
+      }
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub,
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, timezone: 'UTC' },
+    body: { meal_period: 'LUNCH', my_food_id: '123', servings_consumed: '1.5', date: '2025-01-01' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, createdLog);
+
+  assert.equal(receivedCreateData.my_food_id, 123);
+  assert.equal(receivedCreateData.servings_consumed, 1.5);
+  assert.equal(receivedCreateData.calories, 150);
+  assert.equal(receivedCreateData.calories_per_serving_snapshot, 100);
+});
+
+test('food route: PATCH /:id validates and computes updateData', async () => {
+  const existingRow = {
+    id: 1,
+    user_id: 7,
+    calories_per_serving_snapshot: 110,
+    servings_consumed: 1
+  };
+
+  let receivedUpdateData = null;
+  const updatedRow = { id: 1, user_id: 7, calories: 220, servings_consumed: 2 };
+
+  const prismaStub = {
+    foodLog: {
+      findFirst: async () => existingRow,
+      update: async ({ data }) => {
+        receivedUpdateData = data;
+        return updatedRow;
+      }
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub,
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const handler = getRouteHandler(router, 'patch', '/:id');
+
+  const req = { user: { id: 7 }, params: { id: '1' }, body: { servings_consumed: 2 } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, updatedRow);
+  assert.deepEqual(receivedUpdateData, { servings_consumed: 2, calories: 220, calories_per_serving_snapshot: 110 });
+});
+
+test('food route: DELETE /:id validates ids and returns 204 on delete', async () => {
+  const prismaStub = {
+    foodLog: {
+      deleteMany: async () => ({ count: 1 })
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub,
+    foodDataStub: { getFoodDataProvider: () => ({}) }
+  });
+  const handler = getRouteHandler(router, 'delete', '/:id');
+
+  const res = createRes();
+  await handler({ user: { id: 7 }, params: { id: '123' } }, res);
+  assert.equal(res.statusCode, 204);
+});
+

--- a/backend/test/routes-goals.test.js
+++ b/backend/test/routes-goals.test.js
@@ -1,0 +1,229 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadGoalsRouter(prismaStub) {
+  const dbPath = require.resolve('../src/config/database');
+  const goalsPath = require.resolve('../src/routes/goals');
+
+  const previousDbModule = require.cache[dbPath];
+  delete require.cache[goalsPath];
+
+  stubModule(dbPath, prismaStub);
+  const loaded = require('../src/routes/goals');
+
+  if (previousDbModule) {
+    require.cache[dbPath] = previousDbModule;
+  } else {
+    delete require.cache[dbPath];
+  }
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getIsAuthenticatedMiddleware(router) {
+  const layer = router.stack.find((candidate) => !candidate.route);
+  assert.ok(layer, 'Expected router.use(isAuthenticated) middleware to exist');
+  return layer.handle;
+}
+
+function getRouteHandler(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  assert.equal(layer.route.stack.length, 1);
+  return layer.route.stack[0].handle;
+}
+
+test('goals route: rejects unauthenticated requests via router.use middleware', async () => {
+  const prismaStub = { goal: {} };
+  const router = loadGoalsRouter(prismaStub);
+  const isAuthenticated = getIsAuthenticatedMiddleware(router);
+
+  const req = { isAuthenticated: () => false };
+  const res = createRes();
+
+  let nextCalled = false;
+  await isAuthenticated(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: 'Not authenticated' });
+});
+
+test('goals route: GET / returns null when the user has no goal', async () => {
+  const prismaStub = {
+    goal: {
+      findFirst: async () => null
+    }
+  };
+  const router = loadGoalsRouter(prismaStub);
+  const isAuthenticated = getIsAuthenticatedMiddleware(router);
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = {
+    isAuthenticated: () => true,
+    user: { id: 7, weight_unit: 'KG' }
+  };
+  const res = createRes();
+
+  let nextCalled = false;
+  await isAuthenticated(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, true);
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body, null);
+});
+
+test('goals route: GET / maps stored gram weights into the user unit', async () => {
+  const goalRow = {
+    id: 1,
+    user_id: 7,
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    start_weight_grams: 82000,
+    target_weight_grams: 76000,
+    target_date: null,
+    daily_deficit: 500
+  };
+
+  const prismaStub = {
+    goal: {
+      findFirst: async () => goalRow
+    }
+  };
+  const router = loadGoalsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    id: goalRow.id,
+    user_id: goalRow.user_id,
+    created_at: goalRow.created_at,
+    target_date: goalRow.target_date,
+    daily_deficit: goalRow.daily_deficit,
+    start_weight: 82,
+    target_weight: 76
+  });
+});
+
+test('goals route: POST / validates daily_deficit and weight inputs before writing', async () => {
+  const prismaStub = {
+    goal: {
+      create: async () => {
+        throw new Error('should not be called');
+      }
+    }
+  };
+  const router = loadGoalsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG' },
+    body: { start_weight: 82, target_weight: 76, daily_deficit: 123 }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    message: 'daily_deficit must be one of 0, ±250, ±500, ±750, or ±1000'
+  });
+});
+
+test('goals route: POST / rejects incoherent start/target weights for loss goals', async () => {
+  const prismaStub = {
+    goal: {
+      create: async () => {
+        throw new Error('should not be called');
+      }
+    }
+  };
+  const router = loadGoalsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG' },
+    body: { start_weight: 70, target_weight: 80, daily_deficit: 500 }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    message: 'For a weight loss goal, target weight must be less than start weight.'
+  });
+});
+
+test('goals route: POST / creates a goal and returns weights in user units', async () => {
+  const createdGoalRow = {
+    id: 99,
+    user_id: 7,
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    start_weight_grams: 82000,
+    target_weight_grams: 76000,
+    target_date: null,
+    daily_deficit: 500
+  };
+
+  const prismaStub = {
+    goal: {
+      create: async () => createdGoalRow
+    }
+  };
+  const router = loadGoalsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG' },
+    body: { start_weight: 82, target_weight: 76, daily_deficit: 500, target_date: null }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    id: createdGoalRow.id,
+    user_id: createdGoalRow.user_id,
+    created_at: createdGoalRow.created_at,
+    target_date: createdGoalRow.target_date,
+    daily_deficit: createdGoalRow.daily_deficit,
+    start_weight: 82,
+    target_weight: 76
+  });
+});
+

--- a/backend/test/routes-metrics.test.js
+++ b/backend/test/routes-metrics.test.js
@@ -1,0 +1,315 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadMetricsRouter(prismaStub) {
+  const dbPath = require.resolve('../src/config/database');
+  const metricsPath = require.resolve('../src/routes/metrics');
+
+  const previousDbModule = require.cache[dbPath];
+  delete require.cache[metricsPath];
+
+  stubModule(dbPath, prismaStub);
+  const loaded = require('../src/routes/metrics');
+
+  if (previousDbModule) {
+    require.cache[dbPath] = previousDbModule;
+  } else {
+    delete require.cache[dbPath];
+  }
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getIsAuthenticatedMiddleware(router) {
+  const layer = router.stack.find((candidate) => !candidate.route);
+  assert.ok(layer, 'Expected router.use(isAuthenticated) middleware to exist');
+  return layer.handle;
+}
+
+function getRouteHandler(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  assert.equal(layer.route.stack.length, 1);
+  return layer.route.stack[0].handle;
+}
+
+test('metrics route: rejects unauthenticated requests via router.use middleware', async () => {
+  const prismaStub = { bodyMetric: {} };
+  const router = loadMetricsRouter(prismaStub);
+  const isAuthenticated = getIsAuthenticatedMiddleware(router);
+
+  const req = { isAuthenticated: () => false };
+  const res = createRes();
+
+  let nextCalled = false;
+  await isAuthenticated(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: 'Not authenticated' });
+});
+
+test('metrics route: GET / validates start/end query params when provided', async () => {
+  const prismaStub = {
+    bodyMetric: {
+      findMany: async () => {
+        throw new Error('should not be called');
+      }
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG' },
+    query: { start: 'not-a-date' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Invalid date range' });
+});
+
+test('metrics route: GET / returns metrics with weight converted to the user unit', async () => {
+  const rows = [
+    {
+      id: 1,
+      user_id: 7,
+      date: new Date('2025-01-02T00:00:00Z'),
+      weight_grams: 68039,
+      body_fat_percent: null
+    },
+    {
+      id: 2,
+      user_id: 7,
+      date: new Date('2025-01-01T00:00:00Z'),
+      weight_grams: 1000,
+      body_fat_percent: 20.5
+    }
+  ];
+
+  const prismaStub = {
+    bodyMetric: {
+      findMany: async () => rows
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'LB' },
+    query: {}
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, [
+    {
+      id: 1,
+      user_id: 7,
+      date: rows[0].date,
+      body_fat_percent: null,
+      weight: 150
+    },
+    {
+      id: 2,
+      user_id: 7,
+      date: rows[1].date,
+      body_fat_percent: 20.5,
+      weight: 2.2
+    }
+  ]);
+});
+
+test('metrics route: POST / rejects invalid date values', async () => {
+  const prismaStub = { bodyMetric: {} };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG', timezone: 'UTC' },
+    body: { date: 'bad-date', weight: 70 }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Invalid date' });
+});
+
+test('metrics route: POST / rejects empty updates', async () => {
+  const prismaStub = { bodyMetric: {} };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG', timezone: 'UTC' },
+    body: { date: '2025-01-01' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'No fields to update' });
+});
+
+test('metrics route: POST / requires weight when creating a new day via body_fat_percent-only update', async () => {
+  const prismaStub = {
+    bodyMetric: {
+      findUnique: async () => null
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG', timezone: 'UTC' },
+    body: { date: '2025-01-01', body_fat_percent: 20 }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Weight is required for a new day' });
+});
+
+test('metrics route: POST / updates existing metrics when weight is omitted', async () => {
+  const updatedRow = {
+    id: 5,
+    user_id: 7,
+    date: new Date('2025-01-01T00:00:00Z'),
+    weight_grams: 82000,
+    body_fat_percent: 18.2
+  };
+
+  const prismaStub = {
+    bodyMetric: {
+      findUnique: async () => ({ id: 5 }),
+      update: async () => updatedRow
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'KG', timezone: 'UTC' },
+    body: { date: '2025-01-01', body_fat_percent: 18.2 }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    id: 5,
+    user_id: 7,
+    date: updatedRow.date,
+    body_fat_percent: 18.2,
+    weight: 82
+  });
+});
+
+test('metrics route: POST / upserts metrics when weight is provided', async () => {
+  const upsertedRow = {
+    id: 9,
+    user_id: 7,
+    date: new Date('2025-01-01T00:00:00Z'),
+    weight_grams: 68039,
+    body_fat_percent: null
+  };
+
+  const prismaStub = {
+    bodyMetric: {
+      upsert: async () => upsertedRow
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/');
+
+  const req = {
+    user: { id: 7, weight_unit: 'LB', timezone: 'UTC' },
+    body: { date: '2025-01-01', weight: 150 }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    id: upsertedRow.id,
+    user_id: upsertedRow.user_id,
+    date: upsertedRow.date,
+    body_fat_percent: upsertedRow.body_fat_percent,
+    weight: 150
+  });
+});
+
+test('metrics route: DELETE /:id validates ids and handles not-found deletes', async () => {
+  const prismaStub = {
+    bodyMetric: {
+      deleteMany: async () => ({ count: 0 })
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'delete', '/:id');
+
+  const invalidReq = { user: { id: 7 }, params: { id: 'abc' } };
+  const invalidRes = createRes();
+  await handler(invalidReq, invalidRes);
+  assert.equal(invalidRes.statusCode, 400);
+  assert.deepEqual(invalidRes.body, { message: 'Invalid metric id' });
+
+  const missingReq = { user: { id: 7 }, params: { id: '123' } };
+  const missingRes = createRes();
+  await handler(missingReq, missingRes);
+  assert.equal(missingRes.statusCode, 404);
+  assert.deepEqual(missingRes.body, { message: 'Metric not found' });
+});
+
+test('metrics route: DELETE /:id returns 204 when a row is deleted', async () => {
+  const prismaStub = {
+    bodyMetric: {
+      deleteMany: async () => ({ count: 1 })
+    }
+  };
+  const router = loadMetricsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'delete', '/:id');
+
+  const req = { user: { id: 7 }, params: { id: '123' } };
+  const res = createRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 204);
+});
+

--- a/backend/test/routes-my-foods.test.js
+++ b/backend/test/routes-my-foods.test.js
@@ -1,0 +1,272 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadMyFoodsRouter(prismaStub) {
+  const dbPath = require.resolve('../src/config/database');
+  const routePath = require.resolve('../src/routes/myFoods');
+
+  const previousDbModule = require.cache[dbPath];
+  delete require.cache[routePath];
+
+  stubModule(dbPath, prismaStub);
+  const loaded = require('../src/routes/myFoods');
+
+  if (previousDbModule) require.cache[dbPath] = previousDbModule;
+  else delete require.cache[dbPath];
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getIsAuthenticatedMiddleware(router) {
+  const layer = router.stack.find((candidate) => !candidate.route);
+  assert.ok(layer, 'Expected router.use(isAuthenticated) middleware to exist');
+  return layer.handle;
+}
+
+function getRouteHandler(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  assert.equal(layer.route.stack.length, 1);
+  return layer.route.stack[0].handle;
+}
+
+test('myFoods route: rejects unauthenticated requests via router.use middleware', async () => {
+  const router = loadMyFoodsRouter({});
+  const isAuthenticated = getIsAuthenticatedMiddleware(router);
+
+  const req = { isAuthenticated: () => false };
+  const res = createRes();
+
+  let nextCalled = false;
+  isAuthenticated(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: 'Not authenticated' });
+});
+
+test('myFoods route: GET / builds filters from q + type', async () => {
+  let receivedWhere = null;
+  const prismaStub = {
+    myFood: {
+      findMany: async ({ where }) => {
+        receivedWhere = where;
+        return [{ id: 1, name: 'Apple' }];
+      }
+    }
+  };
+
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'get', '/');
+
+  const req = { user: { id: 7 }, query: { q: 'app', type: 'food' } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, [{ id: 1, name: 'Apple' }]);
+
+  assert.deepEqual(receivedWhere, {
+    user_id: 7,
+    name: { contains: 'app', mode: 'insensitive' },
+    type: 'FOOD'
+  });
+});
+
+test('myFoods route: GET /:id validates ids and returns 404 when missing', async () => {
+  const prismaStub = {
+    myFood: {
+      findFirst: async () => null
+    }
+  };
+
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'get', '/:id');
+
+  const invalidRes = createRes();
+  await handler({ user: { id: 7 }, params: { id: 'abc' } }, invalidRes);
+  assert.equal(invalidRes.statusCode, 400);
+  assert.deepEqual(invalidRes.body, { message: 'Invalid my food id' });
+
+  const missingRes = createRes();
+  await handler({ user: { id: 7 }, params: { id: '123' } }, missingRes);
+  assert.equal(missingRes.statusCode, 404);
+  assert.deepEqual(missingRes.body, { message: 'My food not found' });
+});
+
+test('myFoods route: POST /foods validates inputs', async () => {
+  const router = loadMyFoodsRouter({ myFood: {} });
+  const handler = getRouteHandler(router, 'post', '/foods');
+
+  const res = createRes();
+  await handler({ user: { id: 7 }, body: { name: '', serving_size_quantity: 1, serving_unit_label: 'g', calories_per_serving: 10 } }, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Invalid name' });
+});
+
+test('myFoods route: POST /recipes validates ingredients array', async () => {
+  const router = loadMyFoodsRouter({ myFood: {}, $transaction: async () => ({}) });
+  const handler = getRouteHandler(router, 'post', '/recipes');
+
+  const res = createRes();
+  await handler(
+    {
+      user: { id: 7 },
+      body: {
+        name: 'Recipe',
+        serving_size_quantity: 1,
+        serving_unit_label: 'serving',
+        yield_servings: 2,
+        ingredients: []
+      }
+    },
+    res
+  );
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Recipe must include at least one ingredient' });
+});
+
+test('myFoods route: POST /recipes maps validation errors thrown in the transaction', async () => {
+  const prismaStub = {
+    $transaction: async (fn) => fn({ myFood: {}, recipeIngredient: {} })
+  };
+
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/recipes');
+
+  const res = createRes();
+  await handler(
+    {
+      user: { id: 7 },
+      body: {
+        name: 'Recipe',
+        serving_size_quantity: 1,
+        serving_unit_label: 'serving',
+        yield_servings: 2,
+        ingredients: [{ source: 'BAD' }]
+      }
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Invalid ingredient source' });
+});
+
+test('myFoods route: POST /recipes returns 404 when a MY_FOOD ingredient is missing', async () => {
+  const txStub = {
+    myFood: { findFirst: async () => null },
+    recipeIngredient: { createMany: async () => {} }
+  };
+
+  const prismaStub = {
+    $transaction: async (fn) => fn(txStub)
+  };
+
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/recipes');
+
+  const res = createRes();
+  await handler(
+    {
+      user: { id: 7 },
+      body: {
+        name: 'Recipe',
+        serving_size_quantity: 1,
+        serving_unit_label: 'serving',
+        yield_servings: 2,
+        ingredients: [{ source: 'MY_FOOD', my_food_id: 1, quantity_servings: 1 }]
+      }
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(res.body, { message: 'Ingredient my food not found' });
+});
+
+test('myFoods route: POST /recipes creates a recipe and ingredient snapshots', async () => {
+  let receivedRecipeData = null;
+  let receivedIngredientData = null;
+
+  const txStub = {
+    myFood: {
+      create: async ({ data }) => {
+        receivedRecipeData = data;
+        return { id: 55, ...data };
+      },
+      findFirst: async () => null
+    },
+    recipeIngredient: {
+      createMany: async ({ data }) => {
+        receivedIngredientData = data;
+      }
+    }
+  };
+
+  const prismaStub = {
+    $transaction: async (fn) => fn(txStub)
+  };
+
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'post', '/recipes');
+
+  const req = {
+    user: { id: 7 },
+    body: {
+      name: '  Pasta  ',
+      serving_size_quantity: 1,
+      serving_unit_label: 'serving',
+      yield_servings: 2,
+      ingredients: [{ source: 'EXTERNAL', name: ' Tomato  sauce ', calories_total: 100, brand: '  Brand ' }]
+    }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.id, 55);
+  assert.equal(receivedRecipeData.user_id, 7);
+  assert.equal(receivedRecipeData.type, 'RECIPE');
+  assert.equal(receivedRecipeData.name, 'Pasta');
+  assert.equal(receivedRecipeData.recipe_total_calories, 100);
+  assert.equal(receivedRecipeData.yield_servings, 2);
+  assert.equal(receivedRecipeData.calories_per_serving, 50);
+
+  assert.ok(Array.isArray(receivedIngredientData));
+  assert.equal(receivedIngredientData.length, 1);
+  assert.equal(receivedIngredientData[0].recipe_id, 55);
+  assert.equal(receivedIngredientData[0].source, 'EXTERNAL');
+  assert.equal(receivedIngredientData[0].name_snapshot, 'Tomato sauce');
+  assert.equal(receivedIngredientData[0].brand_snapshot, 'Brand');
+  assert.equal(receivedIngredientData[0].calories_total_snapshot, 100);
+});
+

--- a/backend/test/routes-user.test.js
+++ b/backend/test/routes-user.test.js
@@ -1,0 +1,272 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadUserRouter({ prismaStub, bcryptStub }) {
+  const dbPath = require.resolve('../src/config/database');
+  const bcryptPath = require.resolve('bcryptjs');
+  const userPath = require.resolve('../src/routes/user');
+
+  const previousDbModule = require.cache[dbPath];
+  const previousBcryptModule = require.cache[bcryptPath];
+
+  delete require.cache[userPath];
+
+  stubModule(dbPath, prismaStub);
+  stubModule(bcryptPath, bcryptStub);
+
+  const loaded = require('../src/routes/user');
+
+  if (previousDbModule) require.cache[dbPath] = previousDbModule;
+  else delete require.cache[dbPath];
+
+  if (previousBcryptModule) require.cache[bcryptPath] = previousBcryptModule;
+  else delete require.cache[bcryptPath];
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getIsAuthenticatedMiddleware(router) {
+  const layer = router.stack.find((candidate) => !candidate.route);
+  assert.ok(layer, 'Expected router.use(isAuthenticated) middleware to exist');
+  return layer.handle;
+}
+
+function getRouteHandler(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  assert.equal(layer.route.stack.length, 1);
+  return layer.route.stack[0].handle;
+}
+
+test('user route: rejects unauthenticated requests via router.use middleware', async () => {
+  const prismaStub = { user: {} };
+  const bcryptStub = {};
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const isAuthenticated = getIsAuthenticatedMiddleware(router);
+
+  const req = { isAuthenticated: () => false };
+  const res = createRes();
+
+  let nextCalled = false;
+  isAuthenticated(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { message: 'Not authenticated' });
+});
+
+test('user route: GET /me returns 404 when the user row is missing', async () => {
+  const prismaStub = {
+    user: {
+      findUnique: async () => null
+    }
+  };
+  const bcryptStub = {};
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'get', '/me');
+
+  const req = { user: { id: 7 } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(res.body, { message: 'User not found' });
+});
+
+test('user route: GET /me returns serialized user data', async () => {
+  const dbUser = {
+    id: 7,
+    email: 'user@example.com',
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    weight_unit: 'KG',
+    height_unit: 'CM',
+    timezone: 'UTC',
+    date_of_birth: null,
+    sex: null,
+    height_mm: null,
+    activity_level: null,
+    profile_image: new Uint8Array([1, 2, 3]),
+    profile_image_mime_type: 'image/png'
+  };
+
+  const prismaStub = {
+    user: {
+      findUnique: async () => dbUser
+    }
+  };
+  const bcryptStub = {};
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'get', '/me');
+
+  const req = { user: { id: 7 } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    user: {
+      id: dbUser.id,
+      email: dbUser.email,
+      created_at: dbUser.created_at,
+      weight_unit: dbUser.weight_unit,
+      height_unit: dbUser.height_unit,
+      timezone: dbUser.timezone,
+      date_of_birth: dbUser.date_of_birth,
+      sex: dbUser.sex,
+      height_mm: dbUser.height_mm,
+      activity_level: dbUser.activity_level,
+      profile_image_url: 'data:image/png;base64,AQID'
+    }
+  });
+});
+
+test('user route: PUT /profile-image validates data_url input', async () => {
+  const prismaStub = { user: {} };
+  const bcryptStub = {};
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'put', '/profile-image');
+
+  const req = { user: { id: 7 }, body: {} };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Missing data_url' });
+});
+
+test('user route: PUT /profile-image rejects invalid profile image payloads', async () => {
+  const prismaStub = { user: {} };
+  const bcryptStub = {};
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'put', '/profile-image');
+
+  const req = { user: { id: 7 }, body: { data_url: 'not-a-data-url' } };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { message: 'Invalid profile image payload' });
+});
+
+test('user route: PUT /profile-image stores bytes and returns a data URL', async () => {
+  const updatedUser = {
+    id: 7,
+    email: 'user@example.com',
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    weight_unit: 'KG',
+    height_unit: 'CM',
+    timezone: 'UTC',
+    date_of_birth: null,
+    sex: null,
+    height_mm: null,
+    activity_level: null,
+    profile_image: new Uint8Array([1, 2, 3]),
+    profile_image_mime_type: 'image/png'
+  };
+
+  const prismaStub = {
+    user: {
+      update: async () => updatedUser
+    }
+  };
+  const bcryptStub = {};
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'put', '/profile-image');
+
+  const req = {
+    user: { id: 7 },
+    body: { data_url: 'data:image/png;base64,AQID' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.user.profile_image_url, 'data:image/png;base64,AQID');
+});
+
+test('user route: PATCH /password validates request shape and rejects identical passwords', async () => {
+  const prismaStub = { user: {} };
+  const bcryptStub = { compare: async () => true, hash: async () => 'hash' };
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'patch', '/password');
+
+  const missingBodyRes = createRes();
+  await handler({ user: { id: 7 }, body: null }, missingBodyRes);
+  assert.equal(missingBodyRes.statusCode, 400);
+  assert.deepEqual(missingBodyRes.body, { message: 'Invalid request body' });
+
+  const samePasswordRes = createRes();
+  await handler(
+    { user: { id: 7 }, body: { current_password: 'password123', new_password: 'password123' } },
+    samePasswordRes
+  );
+  assert.equal(samePasswordRes.statusCode, 400);
+  assert.deepEqual(samePasswordRes.body, { message: 'New password must be different from current password' });
+});
+
+test('user route: PATCH /password updates password when current password matches', async () => {
+  let updated = false;
+
+  const prismaStub = {
+    user: {
+      findUnique: async () => ({ id: 7, password_hash: 'old-hash' }),
+      update: async () => {
+        updated = true;
+      }
+    }
+  };
+  const bcryptStub = {
+    compare: async () => true,
+    hash: async () => 'new-hash'
+  };
+
+  const router = loadUserRouter({ prismaStub, bcryptStub });
+  const handler = getRouteHandler(router, 'patch', '/password');
+
+  const req = {
+    user: { id: 7 },
+    body: { current_password: 'current', new_password: 'new-password' }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(updated, true);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { message: 'Password updated' });
+});
+

--- a/backend/test/user-serialization.test.js
+++ b/backend/test/user-serialization.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ActivityLevel, HeightUnit, Sex, WeightUnit } = require('@prisma/client');
+
+const { serializeUserForClient, USER_CLIENT_SELECT } = require('../src/utils/userSerialization');
+
+test('userSerialization: USER_CLIENT_SELECT does not include sensitive columns', () => {
+  assert.equal('password_hash' in USER_CLIENT_SELECT, false);
+});
+
+test('userSerialization: serializeUserForClient omits profile_image_url when bytes or mimeType are missing', () => {
+  const baseUser = {
+    id: 1,
+    email: 'someone@example.com',
+    created_at: new Date('2025-01-01T12:00:00Z'),
+    weight_unit: WeightUnit.KG,
+    height_unit: HeightUnit.CM,
+    timezone: 'UTC',
+    date_of_birth: null,
+    sex: Sex.MALE,
+    height_mm: 1750,
+    activity_level: ActivityLevel.MODERATE
+  };
+
+  assert.equal(
+    serializeUserForClient({ ...baseUser, profile_image: null, profile_image_mime_type: 'image/png' })
+      .profile_image_url,
+    null
+  );
+
+  assert.equal(
+    serializeUserForClient({ ...baseUser, profile_image: new Uint8Array([1, 2, 3]), profile_image_mime_type: null })
+      .profile_image_url,
+    null
+  );
+
+  assert.equal(serializeUserForClient(baseUser).profile_image_url, null);
+});
+
+test('userSerialization: serializeUserForClient builds a base64 data URL when image bytes and mimeType are present', () => {
+  const user = {
+    id: 42,
+    email: 'test@example.com',
+    created_at: new Date('2025-01-01T12:00:00Z'),
+    weight_unit: WeightUnit.LB,
+    height_unit: HeightUnit.FT_IN,
+    timezone: 'America/Los_Angeles',
+    date_of_birth: new Date('1990-01-15T00:00:00Z'),
+    sex: Sex.FEMALE,
+    height_mm: 1650,
+    activity_level: ActivityLevel.LIGHT,
+    profile_image: new Uint8Array([1, 2, 3]),
+    profile_image_mime_type: 'image/png'
+  };
+
+  const payload = serializeUserForClient(user);
+
+  assert.deepEqual(
+    payload,
+    {
+      id: user.id,
+      email: user.email,
+      created_at: user.created_at,
+      weight_unit: user.weight_unit,
+      height_unit: user.height_unit,
+      timezone: user.timezone,
+      date_of_birth: user.date_of_birth,
+      sex: user.sex,
+      height_mm: user.height_mm,
+      activity_level: user.activity_level,
+      profile_image_url: 'data:image/png;base64,AQID'
+    }
+  );
+});
+


### PR DESCRIPTION
Intent / problem
- Backend coverage was low (~47% lines) and most API routes had 0% coverage, leaving input validation and snapshot math untested.

High-level change summary
- Added unit-style route tests (no HTTP server, no DB) for auth/goals/metrics/user/food/my-foods.
- Extracted Prisma-free parsing/normalization helpers out of routes so validation logic is unit-testable.
- Added missing unit tests for profile image parsing, user serialization, dev seed math, and dev auto-login policy.

Technical design / tradeoffs
- Route tests stub Prisma/passport/bcrypt/food provider via require.cache to avoid DATABASE_URL/Postgres.
- This keeps tests fast and hermetic; tradeoff is tests depend on Express router stack shape and module load order.
- Helper extraction reduces handler complexity but adds a few small modules.

Testing performed
- npm test
- npm run test:coverage
- npm --prefix backend run build
- c8 coverage improved from ~47% lines to ~76% lines.

Risks / rollout / follow-ups
- Low risk: primarily additive tests + refactors.
- Behavior: some handlers now return 400 for malformed/non-object JSON bodies instead of throwing.
- Follow-up: add integration coverage for backend/src/index.ts + backend/src/config/database.ts and dev-only routes.

Code pointers
- backend/src/routes/foodUtils.ts - request parsing/validation helpers
- backend/src/routes/food.ts - delegates parsing to helpers; covered by backend/test/routes-food.test.js
- backend/src/routes/myFoodsUtils.ts - normalization + HttpError helpers
- backend/src/routes/myFoodsRecipeUtils.ts - recipe ingredient parsing helpers
- backend/src/routes/myFoods.ts - refactored + covered by backend/test/routes-my-foods.test.js
- backend/src/services/devTestDataUtils.ts - deterministic dev seed math helpers
- backend/src/utils/devAutoLoginPolicy.ts - deterministic auto-login decision helper
