### PR TITLE
Fix Prisma CLI DB URL resolution for ECS DB_* env vars

### DIFF
--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -15,20 +15,53 @@ import { defineConfig } from 'prisma/config';
  */
 function getDatabaseUrlForPrisma(): string {
   const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) {
-    const argv = process.argv.map((arg) => arg.toLowerCase());
-    const schemaOnlyCommands = new Set(['generate', 'format', 'validate']);
-    const isSchemaOnlyCommand = argv.some((arg) => schemaOnlyCommands.has(arg));
-    if (isSchemaOnlyCommand) {
-      // Prisma does not connect during `generate`, but it does validate that the datasource URL exists.
-      return 'postgresql://postgres:postgres@localhost:5432/postgres?schema=public';
-    }
+  if (databaseUrl) return databaseUrl;
 
+  const argv = process.argv.map((arg) => arg.toLowerCase());
+  const schemaOnlyCommands = new Set(['generate', 'format', 'validate']);
+  const isSchemaOnlyCommand = argv.some((arg) => schemaOnlyCommands.has(arg));
+  if (isSchemaOnlyCommand) {
+    // Prisma does not connect during `generate`, but it does validate that the datasource URL exists.
+    return 'postgresql://postgres:postgres@localhost:5432/postgres?schema=public';
+  }
+
+  return composeDatabaseUrlFromDbEnv();
+}
+
+/**
+ * Compose a Postgres connection string from DB_* environment variables.
+ *
+ * ECS-hosted deployments inject DB host/name as plaintext and DB credentials as secrets, avoiding
+ * the need to store a full DATABASE_URL string in Secrets Manager.
+ */
+function composeDatabaseUrlFromDbEnv(): string {
+  const host = process.env.DB_HOST;
+  const port = process.env.DB_PORT ?? '5432';
+  const dbName = process.env.DB_NAME;
+  const username = process.env.DB_USER ?? process.env.DB_USERNAME;
+  const password = process.env.DB_PASSWORD ?? process.env.DB_PASS;
+  const sslmode = process.env.DB_SSLMODE ?? 'require';
+  const schema = process.env.DB_SCHEMA ?? 'public';
+
+  const missing: string[] = [];
+  if (!host) missing.push('DB_HOST');
+  if (!dbName) missing.push('DB_NAME');
+  if (!username) missing.push('DB_USER');
+  if (!password) missing.push('DB_PASSWORD');
+
+  if (missing.length > 0) {
     throw new Error(
-      'DATABASE_URL is required. Create backend/.env (copy from backend/.env.example) or export DATABASE_URL before running Prisma commands.'
+      `DATABASE_URL is required for Prisma commands. Provide DATABASE_URL directly (e.g. via backend/.env) or set DB_* env vars so we can compose it (missing: ${missing.join(', ')}).`
     );
   }
-  return databaseUrl;
+
+  const encodedUser = encodeURIComponent(username);
+  const encodedPass = encodeURIComponent(password);
+  const encodedDbName = encodeURIComponent(dbName);
+  const encodedSchema = encodeURIComponent(schema);
+  const encodedSslMode = encodeURIComponent(sslmode);
+
+  return `postgresql://${encodedUser}:${encodedPass}@${host}:${port}/${encodedDbName}?schema=${encodedSchema}&sslmode=${encodedSslMode}`;
 }
 
 export default defineConfig({


### PR DESCRIPTION
Intent / problem statement
- ECS tasks created by Terraform inject Postgres connection info via DB_* env vars + Secrets Manager (DB_USER/DB_PASSWORD), not a single DATABASE_URL value.
- Prisma CLI commands (notably `prisma migrate deploy`) currently require DATABASE_URL via `backend/prisma.config.ts`, which can break migrations in ECS and crash the app on startup when migrations run.

High-level change summary
- Update `backend/prisma.config.ts` to compose a Postgres connection string from DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD when DATABASE_URL is absent for non-schema-only Prisma commands.
- Preserve the existing placeholder URL behavior for schema-only commands (generate/format/validate) so CI and local workflows can run Prisma codegen without a live database.

Technical design and tradeoffs
- This intentionally duplicates URL-composition logic that exists elsewhere (runtime DB client + prod entrypoint) so Prisma CLI remains correct even when those layers are bypassed (e.g. running `npm run db:migrate` directly in ECS).
- Values are URL-encoded with `encodeURIComponent` to safely support special characters in Secrets Manager credentials.

Testing performed
- `npm test`
- `cd backend && npx prisma validate`

Risks / rollout notes / follow-ups
- Behavior changes only for Prisma commands that require a datasource URL when DATABASE_URL is unset; partial DB_* config now yields a clearer "missing: ..." error.
- Rollout: merge + deploy; confirm ECS task startup logs show successful migrations and normal service health checks.
- Follow-up: consider extracting a shared DB URL helper to avoid drift between Prisma config, runtime DB init, and container entrypoints.

Code pointers
- `backend/prisma.config.ts`: new DB_* -> DATABASE_URL composition helper
- `infra/envs/prod/main.tf`: Terraform model for DB_* + secret injection this change supports
