### PR TITLE
Fix RDS SSL handling and surface auth errors

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -26,12 +26,17 @@ router.post('/register', async (req, res) => {
         });
 
         req.login(newUser, (err) => {
-            if (err) throw err;
+            if (err) {
+                console.error('Auth register: unable to establish session:', err);
+                res.status(500).json({ message: 'Server error' });
+                return;
+            }
             res.json({
                 user: serializeUserForClient(newUser)
             });
         });
     } catch (err) {
+        console.error('Auth register failed:', err);
         res.status(500).json({ message: 'Server error' });
     }
 });
@@ -63,6 +68,7 @@ router.get('/me', async (req, res) => {
 
             res.json({ user: serializeUserForClient(dbUser) });
         } catch (err) {
+            console.error('Auth me failed:', err);
             res.status(500).json({ message: 'Server error' });
         }
     } else {


### PR DESCRIPTION
Intent / problem statement
- Prod/staging deployments were returning 500s for backend requests (notably POST /auth/register), while CloudWatch showed only successful startup logs.
- The auth routes were swallowing underlying exceptions (always responding with {"message":"Server error"}), making it hard to tell connectivity issues from runtime failures.
- Suspected cause: runtime DB queries (Prisma + @prisma/adapter-pg -> node-postgres) were failing TLS negotiation against RDS due to sslmode semantics differences vs libpq.

High-level change summary
- Make node-postgres TLS behavior match libpq for sslmode=require (encrypt without certificate verification).
- Add CloudWatch-visible error logs for auth failures and avoid throwing inside req.login callback.

Technical design and tradeoffs
- backend/src/config/database.ts
  - Add resolvePgSslConfig(databaseUrl) which reads sslmode from DB_SSLMODE or the DATABASE_URL query string.
  - sslmode=disable -> Pool ssl=false
  - sslmode=require -> Pool ssl={ rejectUnauthorized: false } to mirror libpq "require" semantics.
  - Other sslmodes (verify-ca/verify-full/etc) -> Pool ssl=true (default verification behavior).
- Tradeoff: rejectUnauthorized=false is intentionally less strict than verify-full. It matches libpq's sslmode=require, but a follow-up should support verify-full with an explicit CA bundle for stricter deployments.

Testing performed
- cd backend && npm test
- cd backend && npm run build

Risks / rollout notes / follow-ups
- Rollout: deploy the new image, then verify /api/healthz and register/login flows in staging/prod.
- If certificate verification is desired, switch to a verify-* sslmode and provide the RDS CA bundle; current sslmode=require behavior intentionally does not verify.
- Follow-up: consider adding basic production request logging middleware to make future incident triage easier.

Code pointers
- backend/src/config/database.ts: SSL mode parsing + Pool ssl config.
- backend/src/routes/auth.ts: auth/register error handling + logging.
