### PR TITLE
CI: add SemVer cut-release workflow and gate prod deploy on vMAJOR.MINOR.PATCH

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,10 +19,41 @@ env:
   GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/calibratehealth
 
 jobs:
+  validate_release_tag:
+    name: Validate Release Tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      is_release_tag: ${{ steps.check.outputs.is_release_tag }}
+      release_tag: ${{ steps.check.outputs.release_tag }}
+
+    steps:
+      - name: Check strict SemVer tag (vMAJOR.MINOR.PATCH)
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REF_NAME="${GITHUB_REF_NAME}"
+          if [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
+            echo "release_tag=${REF_NAME}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
+
   build_and_push:
     name: Build and Push Image (GHCR + ECR)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      source_sha: ${{ steps.meta.outputs.source_sha }}
 
     steps:
       - name: Checkout
@@ -56,13 +88,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          # `HEAD` is always the checked-out commit, even when the workflow runs on an annotated tag.
+          SOURCE_SHA="$(git rev-parse HEAD)"
+
           ECR_IMAGE="${{ steps.ecr.outputs.registry }}/${IMAGE_NAME}"
           # Docker image refs require lowercase repository names (GH owner can be mixed-case).
           GHCR_IMAGE="${GHCR_IMAGE,,}"
 
           TAGS=()
-          TAGS+=("${GHCR_IMAGE}:sha-${GITHUB_SHA}")
-          TAGS+=("${ECR_IMAGE}:sha-${GITHUB_SHA}")
+          TAGS+=("${GHCR_IMAGE}:sha-${SOURCE_SHA}")
+          TAGS+=("${ECR_IMAGE}:sha-${SOURCE_SHA}")
 
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
             # Tag a human-friendly branch alias for convenience.
@@ -70,11 +105,17 @@ jobs:
             TAGS+=("${ECR_IMAGE}:staging")
           fi
 
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            TAGS+=("${GHCR_IMAGE}:${GITHUB_REF_NAME}")
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              TAGS+=("${GHCR_IMAGE}:${GITHUB_REF_NAME}")
+              TAGS+=("${ECR_IMAGE}:${GITHUB_REF_NAME}")
+            else
+              echo "Tag ${GITHUB_REF_NAME} is not a strict SemVer release tag; skipping version image tags."
+            fi
           fi
 
           {
+            echo "source_sha=${SOURCE_SHA}"
             echo "ecr_image=${ECR_IMAGE}"
             echo "ghcr_image=${GHCR_IMAGE}"
             echo "tags<<EOF"
@@ -111,6 +152,88 @@ jobs:
           set -euo pipefail
 
           ENVIRONMENT="staging"
+          ECS_CLUSTER="${IMAGE_NAME}-${ENVIRONMENT}-cluster"
+          ECS_SERVICE="${IMAGE_NAME}-${ENVIRONMENT}-service"
+
+          aws ecs update-service \
+            --cluster "${ECS_CLUSTER}" \
+            --service "${ECS_SERVICE}" \
+            --force-new-deployment \
+            >/dev/null
+
+          wait_for_stable() {
+            # awscli's `ecs wait services-stable` hard-codes a 10-minute deadline (40x15s).
+            # ECS deployments can take longer (cold starts, image pulls, migrations, etc.), so
+            # retry once before failing the workflow.
+            local attempt
+            for attempt in 1 2; do
+              if aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"; then
+                return 0
+              fi
+
+              echo "Timed out waiting for ECS to become stable (attempt ${attempt}/2). Recent service events:" >&2
+              aws ecs describe-services \
+                --cluster "${ECS_CLUSTER}" \
+                --services "${ECS_SERVICE}" \
+                --query 'services[0].events[0:10].[createdAt,message]' \
+                --output table \
+                || true
+            done
+
+            return 1
+          }
+
+          wait_for_stable
+
+  deploy_prod:
+    name: Deploy Prod (ECS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - build_and_push
+      - validate_release_tag
+    # Prod releases are only allowed for strict SemVer tags (vMAJOR.MINOR.PATCH).
+    if: needs.validate_release_tag.outputs.is_release_tag == 'true'
+    environment: production
+
+    steps:
+      - name: Configure AWS credentials (prod deploy)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_PROD }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Retag ECR image (sha-* -> prod)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SOURCE_TAG="sha-${{ needs.build_and_push.outputs.source_sha }}"
+
+          MANIFEST="$(aws ecr batch-get-image \
+            --repository-name "${IMAGE_NAME}" \
+            --image-ids imageTag="${SOURCE_TAG}" \
+            --query 'images[0].imageManifest' \
+            --output text)"
+
+          if [[ -z "${MANIFEST}" || "${MANIFEST}" == "None" ]]; then
+            echo "Image tag ${SOURCE_TAG} not found in ECR repo ${IMAGE_NAME}." >&2
+            echo "Ensure the image has been built/pushed before deploying to prod." >&2
+            exit 1
+          fi
+
+          aws ecr put-image \
+            --repository-name "${IMAGE_NAME}" \
+            --image-tag "prod" \
+            --image-manifest "${MANIFEST}" \
+            >/dev/null
+
+      - name: Force new deployment (ECS)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ENVIRONMENT="prod"
           ECS_CLUSTER="${IMAGE_NAME}-${ENVIRONMENT}-cluster"
           ECS_SERVICE="${IMAGE_NAME}-${ENVIRONMENT}-service"
 

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,140 @@
+name: Cut Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "SemVer bump for the next release tag"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: cut-release-tag
+
+jobs:
+  cut_tag:
+    name: Create and Push v* Tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/master" ]]; then
+            echo "This workflow must be run on the master branch (selected in the Actions UI)." >&2
+            echo "Current ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity (for annotated tags)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BUMP="${{ inputs.bump }}"
+
+          # We only treat fully-qualified SemVer tags (vMAJOR.MINOR.PATCH) as release tags.
+          LATEST_TAG="$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+
+          if [[ -z "${LATEST_TAG}" ]]; then
+            MAJOR=0
+            MINOR=0
+            PATCH=0
+          else
+            VERSION="${LATEST_TAG#v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<<"${VERSION}"
+          fi
+
+          for n in "${MAJOR}" "${MINOR}" "${PATCH}"; do
+            if ! [[ "${n}" =~ ^[0-9]+$ ]]; then
+              echo "Latest tag ${LATEST_TAG} is not parseable as vMAJOR.MINOR.PATCH." >&2
+              exit 1
+            fi
+          done
+
+          case "${BUMP}" in
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            *)
+              echo "Unknown bump type: ${BUMP}" >&2
+              exit 1
+              ;;
+          esac
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+
+          if git show-ref --tags --verify --quiet "refs/tags/${NEW_TAG}"; then
+            echo "Tag ${NEW_TAG} already exists." >&2
+            exit 1
+          fi
+
+          if [[ -n "${LATEST_TAG}" ]]; then
+            # Defense-in-depth: ensure the computed version actually increases (monotonic).
+            LATEST_VERSION="${LATEST_TAG#v}"
+            NEW_VERSION="${NEW_TAG#v}"
+            GREATEST="$(printf "%s\n%s\n" "${LATEST_VERSION}" "${NEW_VERSION}" | sort -V | tail -n 1)"
+            if [[ "${GREATEST}" != "${NEW_VERSION}" || "${NEW_VERSION}" == "${LATEST_VERSION}" ]]; then
+              echo "Computed version ${NEW_TAG} is not greater than latest ${LATEST_TAG}." >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "latest_tag=${LATEST_TAG}"
+            echo "new_tag=${NEW_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          git tag -a "${NEW_TAG}" -m "Release ${NEW_TAG}" "${GITHUB_SHA}"
+          git push origin "${NEW_TAG}"
+
+      - name: Trigger build/deploy workflow for new tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'container.yml',
+              ref: '${{ steps.version.outputs.new_tag }}',
+            });

--- a/infra/README.md
+++ b/infra/README.md
@@ -130,7 +130,10 @@ Also create a GitHub Environment named `production` and require reviewers.
 ## Deploying
 
 - Staging: push to `master` (builds multi-arch image, pushes to GHCR+ECR, forces a new ECS deployment of the `staging` tag).
-- Prod: run the "Deploy Prod" workflow (retags the chosen `sha-*` image to `prod` in ECR, then forces a new ECS deployment).
+- Prod (recommended): run the "Cut Release Tag" workflow to create a `vMAJOR.MINOR.PATCH` tag and trigger the build workflow. The prod deploy job will appear in the run gated behind the `production` Environment approval.
+- Prod (emergency/rollback): run the "Deploy Prod" workflow to retag a specific `sha-*` image to `prod` in ECR, then force a new ECS deployment.
+
+Tip: To enforce monotonically increasing releases, protect `v*` tags (GitHub ruleset/tag protection) so they can only be created via GitHub Actions (or a small maintainer set).
 
 ## Staging Access Control (Optional)
 


### PR DESCRIPTION
Intent
- Make production releases intentional and auditable by cutting a SemVer tag.
- Keep prod deploy in the same workflow run as the image build, but require manual approval.

High-level changes
- Add a "Cut Release Tag" workflow to bump patch/minor/major, create an annotated vMAJOR.MINOR.PATCH tag, and trigger the build workflow.
- Update the build workflow to:
  - accept workflow_dispatch (needed because tags pushed by GitHub Actions do not trigger push workflows)
  - tag images by commit sha consistently (works for annotated tags)
  - only enable the prod deploy job for strict SemVer tags (vMAJOR.MINOR.PATCH)
  - keep prod deploy gated behind the `production` GitHub Environment approval

Technical design / tradeoffs
- Use `actions.createWorkflowDispatch` to kick off `.github/workflows/container.yml` on the newly-created tag so releases work even when the tag is pushed by `GITHUB_TOKEN`.
- Add a small `validate_release_tag` job so accidental `v*` tags do not surface a prod approval gate or tag versioned images.
- Use `git rev-parse HEAD` to derive the commit SHA that was actually checked out/built (annotated tag runs can have a different `GITHUB_SHA`).

Testing performed
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/container.yml"); YAML.load_file(".github/workflows/cut-release.yml")'`

Risks / rollout notes
- Requires repo Actions "Workflow permissions" to allow write access so the release workflow can push tags and dispatch workflows.
- Ensure the `production` Environment has required reviewers; otherwise prod deploy will run automatically on release tags.
- Recommended: add a ruleset/tag protection for `v*` so only GitHub Actions (or maintainers) can create release tags.

Code pointers
- `.github/workflows/cut-release.yml`: computes next SemVer tag, pushes it, then dispatches the build workflow on that tag.
- `.github/workflows/container.yml`: tags images, validates strict release tags, and gates prod deploy behind the `production` Environment.
- `infra/README.md`: updated deploy docs for the release flow.
