### PR TITLE
Improve mobile landing scroll performance

### DIFF
--- a/frontend/src/components/landing/LandingAppPreview.tsx
+++ b/frontend/src/components/landing/LandingAppPreview.tsx
@@ -33,7 +33,15 @@ function LandingMockLogSummaryCard() {
     const remaining = dailyTarget - totalCalories;
 
     return (
-        <Card sx={{ width: '100%' }}>
+        <Card
+            sx={{
+                width: '100%',
+                // Promote the preview cards into their own composited layers so mobile browsers can scroll past them
+                // without re-rasterizing their shadows and SVG content every frame.
+                transform: 'translateZ(0)',
+                willChange: 'transform'
+            }}
+        >
             <CardContent>
                 <Typography variant="h6" gutterBottom>
                     Today&apos;s Log
@@ -57,8 +65,12 @@ function LandingMockLogSummaryCard() {
                         valueMax={dailyTarget}
                         innerRadius={GAUGE_INNER_RADIUS}
                         outerRadius={GAUGE_OUTER_RADIUS}
-                        text={() => ''}
+                        text={() => null}
                         sx={{
+                            // Keep the landing page preview smooth on mobile scroll by isolating gauge painting.
+                            contain: 'paint',
+                            willChange: 'transform',
+                            transform: 'translateZ(0)',
                             '& .MuiGauge-referenceArc': {
                                 fill: (theme) => theme.palette.grey[300]
                             },
@@ -96,7 +108,14 @@ function LandingMockGoalTrackerCard() {
     const progressPercent = 71;
 
     return (
-        <Card sx={{ width: '100%' }}>
+        <Card
+            sx={{
+                width: '100%',
+                // Keep the preview stack consistent: promote to its own layer for smoother mobile scrolling.
+                transform: 'translateZ(0)',
+                willChange: 'transform'
+            }}
+        >
             <CardContent>
                 <SectionHeader title="Goal tracker" sx={{ mb: 1.5 }} />
 

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -157,6 +157,12 @@ const Landing: React.FC = () => {
                                 ? 'none'
                                 : `heroBlobDrift ${Math.round(HERO_BLOB_ANIMATION_DURATION_MS * 1.15)}ms ease-in-out infinite alternate-reverse`,
                             pointerEvents: 'none'
+                        },
+                        // Mobile perf: large animated blur filters can force expensive repaints during scroll.
+                        // Keep the base gradients, but drop the drifting blob overlays on small screens.
+                        [theme.breakpoints.down('sm')]: {
+                            '&::before': { display: 'none' },
+                            '&::after': { display: 'none' }
                         }
                     })}
                 >

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -113,6 +113,15 @@ export function createAppTheme(mode: PaletteMode) {
             }
         },
         components: {
+            MuiChartsSurface: {
+                styleOverrides: {
+                    root: {
+                        // MUI X Charts defaults to `touch-action: none` on the root SVG, which prevents
+                        // native page scrolling when a swipe starts on top of a chart/gauge on mobile.
+                        touchAction: 'pan-y'
+                    }
+                }
+            },
             MuiCssBaseline: {
                 styleOverrides: (theme) => {
                     const accentA = alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.1);


### PR DESCRIPTION
## Intent / problem
- Mobile landing page scrolling stuttered when the app preview cards (Gauge) were on-screen, even on high-end devices.
- Behavior looked like scroll-thread jank: scrolling slows while the hero preview region is visible and recovers once it leaves the viewport.

## Changes
- Landing hero: disable the large blurred + drifting pseudo-element "blob" overlays on small screens to avoid expensive repaint work during scroll.
- Landing preview: promote the preview cards/gauge into composited layers and isolate gauge painting; remove the unused Gauge text node.
- In-app log summary: keep the dashboard summary static (no rAF tween) and consolidate the gauge + number tween into one rAF loop for /log date transitions; memoize derived values to reduce per-frame work.
- Theme: override MUI X Charts surface `touch-action` to `pan-y` so charts/gauges do not block vertical page scrolling gestures.

## Design notes / tradeoffs
- Dropping the blob overlays on xs sacrifices some hero motion but keeps the base gradients and removes a known mobile perf footgun (large animated blur filters).
- Layer promotion (`translateZ(0)` / `will-change`) trades a small amount of compositor memory for smoother scrolling past cards with shadows/SVG.
- Consolidating tweens keeps the same visual behavior while reducing render churn (one state update per animation frame instead of two).

## Testing
- `npm --prefix frontend exec -- tsc -b`
- `npm --prefix frontend run lint`
- Manual: verified mobile scroll smoothness on the landing page (local dev server).

## Risks / rollout / follow-ups
- If we later add interactive chart gestures (panning/zooming) we may need to scope the `touch-action` override to specific charts.
- If we want the hero blobs on mobile again, consider keeping them static (no blur animation) or using a lighter-weight effect.

## Code pointers
- frontend/src/pages/Landing.tsx: disables blurred drifting hero blob overlays on small screens.
- frontend/src/components/landing/LandingAppPreview.tsx: compositing and paint isolation tweaks for preview cards + gauge.
- frontend/src/components/LogSummaryCard.tsx: dashboard disables tween; consolidated rAF tween; gauge paint/layer hints.
- frontend/src/theme.ts: `MuiChartsSurface` touch-action override.
