### PR TITLE
Fix PWA session persistence by setting persistent session cookie maxAge

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,10 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const isProduction = process.env.NODE_ENV === 'production';
 
+// Use a persistent session cookie so installed PWAs (notably Firefox on Android)
+// keep the login session when the app/browser process is closed and reopened.
+const SESSION_COOKIE_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
 /**
  * Serve the built frontend SPA from disk in production deployments.
  *
@@ -66,7 +70,8 @@ app.use(session({
     cookie: {
         httpOnly: true,
         sameSite: 'lax',
-        secure: isProduction
+        secure: isProduction,
+        maxAge: SESSION_COOKIE_MAX_AGE_MS
     }
 }));
 app.use(passport.initialize());


### PR DESCRIPTION
Intent / problem statement
- Installed PWA sessions on Android (Firefox) did not persist across app/process restarts, forcing users to re-authenticate.
- Root cause: the backend used a session cookie (no Max-Age/Expires), which some mobile PWA contexts discard when the app is closed.

High-level change summary
- Issue a persistent session cookie by setting `cookie.maxAge` on the express-session middleware (30 days).

Technical design and tradeoffs
- Add `SESSION_COOKIE_MAX_AGE_MS` and wire it into `express-session`'s `cookie.maxAge`, keeping existing cookie flags (`httpOnly`, `sameSite=lax`, `secure` in production).
- Tradeoff: longer-lived cookies increase the window for session reuse on shared devices; logout removes the user from the session.
- Note: the session store is unchanged; if the server restarts, sessions may still be lost depending on the configured store (follow-up: use a persistent store for production).

Testing performed
- `npm test`

Risks / rollout notes / follow-ups
- Consider making the cookie TTL configurable via env var if some deployments want a shorter session lifetime.
- Consider moving off the default in-memory session store for production robustness.

Code pointers
- `backend/src/index.ts`: express-session configuration; adds the persistent cookie maxAge.
