### PR TITLE
CI: run lint and tests only on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: Lint
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@ name: Tests
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
Intent
- Lint/tests already run on pull_request; running them again on push to master is redundant and can be too late (post-merge) to prevent issues landing.

Change summary
- Remove the `on.push` trigger from the Lint and Tests GitHub Actions workflows.
- Keep the existing job steps unchanged.

Technical design / tradeoffs
- Use `on: pull_request` as the single trigger for these checks.
- Tradeoff: direct pushes to `master` will not run lint/tests; this assumes branch protection enforces PR-only merges.
- If we ever need ad-hoc runs on default branch without reintroducing push triggers, we can add `workflow_dispatch` later.

Testing performed
- Not run (workflow trigger change only); verified the diffs are limited to workflow `on:` blocks.

Risks / rollout notes / follow-ups
- Ensure `master` branch protection requires these checks on PRs (if not already).
- Optional follow-up: add `workflow_dispatch` to allow manual runs when needed.

Code pointers
- `.github/workflows/lint.yml`: remove `push` trigger (PR-only).
- `.github/workflows/tests.yml`: remove `push` trigger (PR-only).
