### PR TITLE
CI: Gate prod deploy on staging /api/healthz smoke test

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -195,6 +195,33 @@ jobs:
 
           wait_for_stable
 
+  staging_smoke:
+    name: Staging Smoke Tests (E2E)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: deploy_staging
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Health check /api/healthz
+        shell: bash
+        env:
+          # Configure as a GitHub Actions variable, e.g. https://staging.calibratehealth.app
+          E2E_BASE_URL: ${{ vars.STAGING_BASE_URL }}
+          E2E_POLL_TIMEOUT_MS: "300000"
+          E2E_POLL_INTERVAL_MS: "5000"
+          E2E_REQUEST_TIMEOUT_MS: "10000"
+        run: node scripts/e2e/healthcheck.mjs
+
   deploy_prod:
     name: Deploy Prod (ECS)
     runs-on: ubuntu-latest
@@ -202,6 +229,7 @@ jobs:
     needs:
       - build_and_push
       - validate_release_tag
+      - staging_smoke
     # Allow strict SemVer tag releases, or manual runs from the default branch (still approval-gated).
     if: needs.validate_release_tag.outputs.is_release_tag == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     environment: production

--- a/scripts/e2e/healthcheck.mjs
+++ b/scripts/e2e/healthcheck.mjs
@@ -1,0 +1,174 @@
+/**
+ * Simple E2E smoke check for a deployed environment.
+ *
+ * This is intentionally dependency-free so it can run in CI without `npm ci`.
+ * It polls the API health endpoint until it returns `{ ok: true }` or times out.
+ */
+
+/**
+ * Read a required environment variable.
+ * @param {string} name
+ * @returns {string}
+ */
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+/**
+ * Read an integer environment variable with a fallback.
+ * @param {string} name
+ * @param {number} fallback
+ * @returns {number}
+ */
+function readIntEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Env var ${name} must be a positive integer; got: ${raw}`);
+  }
+  return value;
+}
+
+/**
+ * Sleep for the specified duration.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Build a fully-qualified health check URL from a base URL and a path.
+ * @param {string} baseUrl
+ * @param {string} path
+ * @returns {URL}
+ */
+function buildHealthzUrl(baseUrl, path) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return new URL(normalizedPath, baseUrl);
+}
+
+/**
+ * Fetch JSON with a hard timeout.
+ * @param {URL} url
+ * @param {{ timeoutMs: number }} options
+ * @returns {Promise<{ status: number, json: unknown }>}
+ */
+async function fetchJson(url, { timeoutMs }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal
+    });
+
+    const status = response.status;
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      const snippet = text ? ` Body: ${text.slice(0, 300)}` : '';
+      throw new Error(`HTTP ${status}.${snippet}`);
+    }
+
+    const json = await response.json();
+    return { status, json };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Validate the /api/healthz response payload.
+ * @param {unknown} json
+ */
+function assertHealthzPayload(json) {
+  if (!json || typeof json !== 'object') {
+    throw new Error(`Expected JSON object response; got: ${typeof json}`);
+  }
+
+  // @ts-ignore - runtime shape check for a simple JSON payload.
+  if (json.ok !== true) {
+    throw new Error(`Expected response body to include {"ok": true}.`);
+  }
+}
+
+/**
+ * Poll /api/healthz until it passes or a deadline is reached.
+ * @param {{
+ *   baseUrl: string,
+ *   healthzPath: string,
+ *   pollTimeoutMs: number,
+ *   pollIntervalMs: number,
+ *   requestTimeoutMs: number,
+ * }} options
+ */
+async function pollHealthz({
+  baseUrl,
+  healthzPath,
+  pollTimeoutMs,
+  pollIntervalMs,
+  requestTimeoutMs
+}) {
+  const url = buildHealthzUrl(baseUrl, healthzPath);
+  const deadlineMs = Date.now() + pollTimeoutMs;
+
+  let attempt = 0;
+  /** @type {unknown} */
+  let lastError = null;
+
+  while (Date.now() < deadlineMs) {
+    attempt += 1;
+    try {
+      const { json } = await fetchJson(url, { timeoutMs: requestTimeoutMs });
+      assertHealthzPayload(json);
+      console.log(`Health check passed: ${url.toString()}`);
+      return;
+    } catch (err) {
+      lastError = err;
+      const message = err instanceof Error ? err.message : String(err);
+      console.log(`Health check not ready (attempt ${attempt}): ${message}`);
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  const lastMessage = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Health check failed after ${pollTimeoutMs}ms: ${url.toString()} (last error: ${lastMessage})`
+  );
+}
+
+/**
+ * CLI entrypoint for the staging smoke test.
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const baseUrl = requireEnv('E2E_BASE_URL');
+
+  const healthzPath = process.env.E2E_HEALTHZ_PATH ?? '/api/healthz';
+  const pollTimeoutMs = readIntEnv('E2E_POLL_TIMEOUT_MS', 5 * 60 * 1000);
+  const pollIntervalMs = readIntEnv('E2E_POLL_INTERVAL_MS', 5 * 1000);
+  const requestTimeoutMs = readIntEnv('E2E_REQUEST_TIMEOUT_MS', 10 * 1000);
+
+  await pollHealthz({
+    baseUrl,
+    healthzPath,
+    pollTimeoutMs,
+    pollIntervalMs,
+    requestTimeoutMs
+  });
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
Intent
- Add an automated staging validation step to the release pipeline so production deploy approval is only reachable after staging is confirmed healthy.

High-level change summary
- Add a dependency-free Node smoke test that polls GET /api/healthz until it returns {"ok": true} (or times out).
- Run the smoke test as a dedicated "staging_smoke" job after the staging ECS deploy.
- Gate the production deploy job on the staging smoke job, making staging health a prerequisite signal for prod readiness.

Technical design and tradeoffs
- Implemented as `scripts/e2e/healthcheck.mjs` with no npm dependencies so CI can run it without `npm ci` and with minimal moving parts.
- Uses Node 20's built-in `fetch` and a polling loop to tolerate ECS rollout + ALB propagation (avoids a single brittle request).
- Staging target is configured via a GitHub Actions variable `STAGING_BASE_URL` to keep this portable across self-hosted domains.

Testing performed
- node --check scripts/e2e/healthcheck.mjs

Risks / rollout notes / follow-ups
- Repo owners must set the `STAGING_BASE_URL` Actions variable (e.g. https://staging.calibratehealth.app) or the new staging_smoke job will fail and block prod.
- If staging ingress is restricted (ALB CIDR allowlist), GitHub-hosted runners may not reach it; consider a self-hosted runner or allow runner egress.
- Follow-up: grow this from a health check to real E2E flows (login, log food/weight) and consider adding build SHA/version to /api/healthz.

Code pointers
- `scripts/e2e/healthcheck.mjs`: retrying /api/healthz poll + JSON assertion logic.
- `.github/workflows/container.yml`: new staging_smoke job and deploy_prod gating.
