### PR TITLE
CI: Add post-deploy prod /api/healthz smoke test

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -304,3 +304,30 @@ jobs:
           }
 
           wait_for_stable
+
+  prod_smoke:
+    name: Prod Smoke Tests (E2E)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: deploy_prod
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Health check /api/healthz
+        shell: bash
+        env:
+          # Configure as a GitHub Actions variable, e.g. https://calibratehealth.app
+          E2E_BASE_URL: ${{ vars.PROD_BASE_URL }}
+          E2E_POLL_TIMEOUT_MS: "300000"
+          E2E_POLL_INTERVAL_MS: "5000"
+          E2E_REQUEST_TIMEOUT_MS: "10000"
+        run: node scripts/e2e/healthcheck.mjs

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -106,3 +106,30 @@ jobs:
           }
 
           wait_for_stable
+
+  prod_smoke:
+    name: Prod Smoke Tests (E2E)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: deploy
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Health check /api/healthz
+        shell: bash
+        env:
+          # Configure as a GitHub Actions variable, e.g. https://calibratehealth.app
+          E2E_BASE_URL: ${{ vars.PROD_BASE_URL }}
+          E2E_POLL_TIMEOUT_MS: "300000"
+          E2E_POLL_INTERVAL_MS: "5000"
+          E2E_REQUEST_TIMEOUT_MS: "10000"
+        run: node scripts/e2e/healthcheck.mjs


### PR DESCRIPTION
Intent
- Run the existing E2E smoke test against production after a prod deploy completes, so we immediately validate the live environment (not just ECS stability).

High-level change summary
- Add a new "prod_smoke" job to the release workflow that runs after the prod ECS deploy job.
- Add the same prod smoke job to the manual "Deploy Prod" workflow so ad-hoc prod deploys also get post-deploy validation.

Technical design and tradeoffs
- Reuses the existing dependency-free Node script (`scripts/e2e/healthcheck.mjs`) to poll GET /api/healthz until it returns {"ok": true}.
- Uses a GitHub Actions variable `PROD_BASE_URL` to select the prod host (keeps this self-hostable / domain-agnostic).
- Smoke runs as a separate job (not inside the deploy job) to keep AWS credentials out of the test step via least privilege.

Testing performed
- node --check scripts/e2e/healthcheck.mjs

Risks / rollout notes / follow-ups
- Repo owners must set the `PROD_BASE_URL` Actions variable (e.g. https://calibratehealth.app) or the new prod_smoke job will fail (after deploy).
- A failed smoke test does not roll back the deployment; it only flags the workflow as failed. If rollback is desired, we can add an automated rollback step later.
- If prod ingress is restricted, GitHub-hosted runners may not reach it; consider a self-hosted runner for smoke jobs.

Code pointers
- `.github/workflows/container.yml`: new prod_smoke job that runs after deploy_prod.
- `.github/workflows/deploy-prod.yml`: same prod_smoke job for manual prod deploys.
