### PR TITLE
Fix: prevent PWA back-stack from returning to login (Issue #84)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,14 +12,17 @@ import Onboarding from './pages/Onboarding';
 import DevDashboard from './pages/DevDashboard';
 
 import ProtectedRoute from './components/ProtectedRoute';
+import PublicRoute from './components/PublicRoute';
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<Home />} />
-        <Route path="login" element={<Login />} />
-        <Route path="register" element={<Register />} />
+        <Route element={<PublicRoute />}>
+          <Route path="login" element={<Login />} />
+          <Route path="register" element={<Register />} />
+        </Route>
         {import.meta.env.DEV && <Route path="dev" element={<DevDashboard />} />}
 
         <Route element={<ProtectedRoute />}>

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { Box, CircularProgress } from '@mui/material';
+import { useAuth } from '../context/useAuth';
+
+/**
+ * PublicRoute
+ *
+ * Guard for routes intended for unauthenticated users (e.g., login/register).
+ * When a session exists, redirect into the app so the login page can't be reached
+ * from the browser/PWA back-stack after signing in.
+ */
+const PublicRoute: React.FC = () => {
+    const { user, isLoading } = useAuth();
+
+    if (isLoading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (user) {
+        return <Navigate to="/log" replace />;
+    }
+
+    return <Outlet />;
+};
+
+export default PublicRoute;
+

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -22,7 +22,8 @@ const Login: React.FC = () => {
             setError('');
             setIsSubmitting(true);
             await login(email, password);
-            navigate('/log');
+            // Replace so mobile/PWA back navigation can't return to the login form after signing in.
+            navigate('/log', { replace: true });
         } catch {
             setError(t('auth.invalidCredentials'));
         } finally {

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -618,7 +618,8 @@ const Onboarding: React.FC = () => {
     };
 
     const goToLog = useCallback(() => {
-        navigate('/log');
+        // Replace so the onboarding summary doesn't stay in the back-stack once setup is complete.
+        navigate('/log', { replace: true });
     }, [navigate]);
 
     const editSetupFromSummary = useCallback(() => {

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -22,7 +22,8 @@ const Register: React.FC = () => {
             setError('');
             setIsSubmitting(true);
             await register(email, password);
-            navigate('/onboarding');
+            // Replace so mobile/PWA back navigation can't return to registration after the account is created.
+            navigate('/onboarding', { replace: true });
         } catch {
             setError(t('auth.registrationFailed'));
         } finally {


### PR DESCRIPTION
Intent
- Fix Issue #84: on mobile PWA, back navigation can land on /login after signing in.
- Keep authenticated users inside the app when navigating the history stack.

High-level Summary
- Add a PublicRoute guard for /login and /register that redirects authenticated sessions to /log.
- Replace history entries when transitioning out of auth/onboarding flows so those pages do not remain in the back-stack.

Technical Design and Tradeoffs
- PublicRoute shows a loading spinner while auth state resolves to avoid redirect flicker during /auth/me.
- Redirects use history replacement (<Navigate replace /> and navigate(..., { replace: true })) so auth pages are not reachable via back.
- Tradeoff: authenticated users can no longer intentionally view /login or /register (they must log out first), which matches installed-app UX.

Testing Performed
- npm --prefix frontend run lint
- npm --prefix frontend run build (fails in this worktree due to pre-existing TS errors in frontend/src/components/BarcodeScannerDialog.tsx; unchanged by this PR)
- Manual: installed PWA -> login -> land on /log -> back gesture/button does not return to /login

Risks / Rollout Notes / Follow-ups
- Low risk: changes are isolated to client routing and navigation semantics.
- Follow-up: consider supporting redirect-to-original-route on login (e.g., ?next=/settings) if needed.

Code Pointers
- frontend/src/components/PublicRoute.tsx: new guard for unauth-only routes
- frontend/src/App.tsx: route wiring for PublicRoute
- frontend/src/pages/Login.tsx: post-login navigation uses replace
- frontend/src/pages/Register.tsx: post-register navigation uses replace
- frontend/src/pages/Onboarding.tsx: onboarding -> /log navigation uses replace

Fixes #84
