### PR TITLE
Optimizing db reset on container start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,5 @@
 
   "onCreateCommand": "npm install -g @openai/codex",
   "postCreateCommand": "npm run setup && node .devcontainer/update-peacock-settings.mjs && bash .devcontainer/setup-codex.sh && bash .devcontainer/setup-github.sh",
-  "postStartCommand": "npm --prefix backend run db:reset -- --force && npm --prefix backend run db:seed"
+  "postStartCommand": "npm --prefix backend run db:push:reset && npm --prefix backend run db:seed"
 }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Full guide (including required secrets and exact commands): [infra/README.md](in
 ### Quickstart (devcontainer)
 
 The devcontainer runs `npm run setup` automatically (installs deps + generates the Prisma client). On start it also runs
-`npm run db:migrate` and `npm run db:seed`.
+`npm run db:push:reset` and `npm run db:seed`.
 
 This repo supports a repo-local `.env` file (gitignored) for devcontainer secrets. Start by copying `.env.example` to
 `.env`, then rebuild the devcontainer so `.devcontainer/.env` is regenerated and Docker can pass the values into the
@@ -163,6 +163,7 @@ More:
 
 - `npm run db:migrate:dev`: create/apply new migrations during local development.
 - `npm run db:reset`: destructive reset (drops data and recreates schema).
+- `npm run db:push:reset`: dev-only schema reset using `prisma db push` (fast, skips migrations).
 - `npm run db:studio`: Prisma Studio (DB browser).
 - `npm run build`: build the frontend.
 - `npm run lint`: lint the frontend.

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "db:migrate": "prisma migrate deploy",
     "db:migrate:dev": "prisma migrate dev",
     "db:reset": "prisma migrate reset",
+    "db:push:reset": "prisma db push --force-reset",
     "db:seed": "ts-node prisma/seed.ts",
     "db:studio": "prisma studio",
     "prisma:generate": "prisma generate",


### PR DESCRIPTION
Updated the devcontainer startup to reset the schema via prisma db push --force-reset and seed once, so it skips replaying all migrations on every rebuild.

Details and where:
  - Added a fast reset script in backend/package.json (db:push:reset) that runs prisma db push --force-reset, which builds the current schema in one shot.
  - Swapped the devcontainer post-start hook in .devcontainer/devcontainer.json to run db:push:reset + db:seed, avoiding the slower migrate reset and the implicit/duplicate seeding.
  - Updated the devcontainer note and script list in README.md to match the new behavior.

  Note: db push bypasses migration history and any raw SQL inside migrations, so keep db:migrate for prod/CI.