### PR TITLE
Adding SessionStore model to unbreak db migrations

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -199,3 +199,13 @@ model RecipeIngredient {
 
   @@index([recipe_id])
 }
+
+model SessionStore {
+  /// Backing table for express-session; kept in the Prisma schema so db push and migrations create it.
+  sid    String   @id @db.Text
+  sess   Json
+  expire DateTime @db.Timestamptz(6)
+
+  @@map("session_store")
+  @@index([expire], map: "session_store_expire_idx")
+}


### PR DESCRIPTION
Added a SessionStore model to the Prisma schema so prisma db push (used by the devcontainer startup reset) creates the session_store table and stays aligned with the existing migration, which prevents the missing-table crash.