### PR TITLE
PWA shortcuts: reuse existing window and add preview workflow

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,10 @@ function isRunningInContainer() {
 
 const QUICK_ADD_SHORTCUT_ICON = 'pwa-192x192.png' // Icon used for quick-add PWA shortcuts.
 const QUICK_ADD_SHORTCUT_BASE_PATH = '/log' // Base route for quick-add shortcuts.
+// Reuse an existing app window so PWA shortcuts navigate instead of spawning a new instance.
+const PWA_LAUNCH_HANDLER = {
+  client_mode: 'navigate-existing',
+} as const
 
 /**
  * Build a log-route URL that triggers a quick-add dialog when opened from a PWA shortcut.
@@ -66,6 +70,7 @@ function getPwaOptions(): Partial<VitePWAOptions> {
       theme_color: '#111827',
       background_color: '#111827',
       display: 'standalone',
+      launch_handler: PWA_LAUNCH_HANDLER,
       start_url: '/',
       scope: '/',
       icons: [
@@ -142,6 +147,12 @@ const devServerPort =
   devServerPortValue > 0
     ? devServerPortValue
     : undefined
+const backendProxyTarget = 'http://localhost:3000' // Local backend origin for dev/preview proxies.
+const backendProxy = {
+  '/auth': backendProxyTarget,
+  '/api': backendProxyTarget,
+  '/dev/test': backendProxyTarget,
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -158,10 +169,9 @@ export default defineConfig({
     port: devServerPort,
     strictPort: devServerPort !== undefined,
     watch: usePolling ? { usePolling: true, interval: 100 } : undefined,
-    proxy: {
-      '/auth': 'http://localhost:3000',
-      '/api': 'http://localhost:3000',
-      '/dev/test': 'http://localhost:3000',
-    }
-  }
+    proxy: backendProxy,
+  },
+  preview: {
+    proxy: backendProxy,
+  },
 })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:reset-test-user-onboarding": "node scripts/reset-test-user-onboarding.mjs",
       "dev:backend": "npm --prefix backend run dev",
       "dev:frontend": "npm --prefix frontend run dev",
+      "preview": "node scripts/preview.mjs",
       "prisma:generate": "npm --prefix backend run prisma:generate",
       "db:migrate": "npm --prefix backend run db:migrate",
     "db:migrate:dev": "npm --prefix backend run db:migrate:dev",

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -1,0 +1,82 @@
+import { spawn, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const backendDir = path.join(repoRoot, 'backend');
+const frontendDir = path.join(repoRoot, 'frontend');
+
+// Build once so preview serves the latest PWA manifest and service worker.
+const buildResult = spawnSync(npmCmd, ['run', 'build'], {
+  cwd: frontendDir,
+  stdio: 'inherit',
+});
+
+if (buildResult.status !== 0) {
+  process.exit(buildResult.status ?? 1);
+}
+
+const services = [
+  { name: 'backend', cwd: backendDir, args: ['run', 'dev'] },
+  { name: 'frontend-preview', cwd: frontendDir, args: ['run', 'preview'] },
+];
+
+const states = new Map();
+let shuttingDown = false;
+let finalExitCode = 0;
+
+/**
+ * Stop any running child processes so preview doesn't leave orphaned servers.
+ */
+function killAll(signal) {
+  for (const { child } of states.values()) {
+    if (!child.killed) child.kill(signal);
+  }
+}
+
+/**
+ * Exit once all services have finished, preserving the first non-zero code.
+ */
+function maybeExit() {
+  const allExited = [...states.values()].every(({ exited }) => exited);
+  if (allExited) process.exit(finalExitCode);
+}
+
+/**
+ * Fan out shutdown signals so backend and preview exit together.
+ */
+function shutdown(exitCode, signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  finalExitCode = exitCode;
+  killAll(signal);
+  setTimeout(() => process.exit(finalExitCode), 10_000).unref();
+}
+
+for (const service of services) {
+  const child = spawn(npmCmd, service.args, {
+    cwd: service.cwd,
+    stdio: 'inherit',
+  });
+
+  states.set(service.name, { child, exited: false });
+
+  child.on('exit', (code, signal) => {
+    const state = states.get(service.name);
+    if (state) state.exited = true;
+
+    if (!shuttingDown) {
+      shutdown(code ?? 1, signal ?? 'SIGTERM');
+    } else if (typeof code === 'number' && code !== 0) {
+      finalExitCode = code;
+    }
+
+    maybeExit();
+  });
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => shutdown(0, signal));
+}


### PR DESCRIPTION
## Summary
- Add manifest launch_handler navigate-existing so PWA shortcuts reuse an open window.
- Share backend proxy config for preview so API and auth calls keep working against localhost:3000.
- Add npm run preview workflow that builds the frontend then runs backend dev with Vite preview for PWA validation.

## Testing
- Not run (not requested).
