### PR TITLE
Fixing oauth scope for fatsecret provider

### DIFF
--- a/frontend/src/components/FoodEntryForm.tsx
+++ b/frontend/src/components/FoodEntryForm.tsx
@@ -66,6 +66,14 @@ type FoodSearchParams = {
     barcode?: string;
 };
 
+const normalizeBarcodeCandidate = (value: string): string => value.replace(/\D/g, '').trim();
+
+const isBarcodeCandidate = (value: string): boolean => {
+    const digits = normalizeBarcodeCandidate(value);
+    if (!digits) return false;
+    return digits.length === 8 || digits.length === 12 || digits.length === 13 || digits.length === 14;
+};
+
 /**
  * Choose a sensible default meal period based on the current local time.
  * Thresholds:
@@ -263,13 +271,17 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
 
             const trimmedQuery = request.query?.trim();
             const barcode = request.barcode?.trim();
-            if (!trimmedQuery && !barcode) {
+            const normalizedBarcode =
+                barcode || (trimmedQuery && isBarcodeCandidate(trimmedQuery) ? normalizeBarcodeCandidate(trimmedQuery) : '');
+            const resolvedQuery = barcode ? trimmedQuery : normalizedBarcode ? undefined : trimmedQuery;
+
+            if (!resolvedQuery && !normalizedBarcode) {
                 return;
             }
 
             const params: FoodSearchParams = {
-                query: trimmedQuery || undefined,
-                barcode: barcode || undefined
+                query: resolvedQuery || undefined,
+                barcode: normalizedBarcode || undefined
             };
 
             searchSessionRef.current += 1;


### PR DESCRIPTION
## Summary
Fixing issue where barcode search using fatsecret food provider was not working because, even though we were using an API key with Free Premier access, we did not specify "premier" and "barcode" oauth scopes. Including these in requests with this change to ensure we are able to search by barcode.

## Test Plan
Deploying to staging for testing: https://github.com/MChartier/calibrate-health/actions/runs/21234402283
