### PR TITLE
Fix sm compact padding and date picker inset on /log

### DIFF
--- a/frontend/src/components/LogDatePickerControl.tsx
+++ b/frontend/src/components/LogDatePickerControl.tsx
@@ -1,8 +1,8 @@
 import React, { useRef } from 'react';
 import { Box, TextField } from '@mui/material';
 
-const LOG_DATE_CONTROL_HEIGHT_SPACING = { xs: 9, sm: 7 }; // Fixed block height for the date control (in theme spacing units).
-const LOG_DATE_CONTROL_TOP_PADDING_SPACING = 2; // Top padding keeps the floating label visible on full-bleed mobile layouts.
+const LOG_DATE_CONTROL_HEIGHT_SPACING = { xs: 9, sm: 9, md: 7 }; // Include top inset on compact layouts without shrinking the inner field height.
+const LOG_DATE_CONTROL_TOP_PADDING_SPACING = { xs: 2, sm: 2, md: 0 }; // Keep the floating label inside the control when page padding is minimal.
 const LOG_DATE_PICKER_OVERLAY_FOCUS_OUTLINE_PX = 2; // Thickness of the keyboard focus ring on the date control overlay.
 const LOG_DATE_PICKER_OVERLAY_FOCUS_OUTLINE_OFFSET_PX = 2; // Gap between the overlay outline and the field chrome.
 
@@ -43,7 +43,7 @@ function showNativeDatePicker(input: HTMLInputElement | null) {
  * LogDatePickerControl
  *
  * Self-contained date picker field with a fixed height so the Log page can render it as a normal block.
- * The control adds its own top inset on xs screens to keep the floating label visible under the app bar.
+ * The control adds its own top inset on compact layouts to keep the floating label visible under the app bar.
  */
 const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
     value,
@@ -64,9 +64,14 @@ const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
                 minWidth: 0,
                 height: {
                     xs: theme.spacing(LOG_DATE_CONTROL_HEIGHT_SPACING.xs),
-                    sm: theme.spacing(LOG_DATE_CONTROL_HEIGHT_SPACING.sm)
+                    sm: theme.spacing(LOG_DATE_CONTROL_HEIGHT_SPACING.sm),
+                    md: theme.spacing(LOG_DATE_CONTROL_HEIGHT_SPACING.md)
                 },
-                pt: { xs: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING), sm: 0 }
+                pt: {
+                    xs: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING.xs),
+                    sm: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING.sm),
+                    md: LOG_DATE_CONTROL_TOP_PADDING_SPACING.md
+                }
             })}
         >
             <TextField
@@ -112,7 +117,11 @@ const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
                 }}
                 sx={(theme) => ({
                     position: 'absolute',
-                    top: { xs: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING), sm: 0 },
+                    top: {
+                        xs: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING.xs),
+                        sm: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING.sm),
+                        md: LOG_DATE_CONTROL_TOP_PADDING_SPACING.md
+                    },
                     left: 0,
                     right: 0,
                     bottom: 0,
@@ -134,7 +143,11 @@ const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
                 onClick={() => showNativeDatePicker(datePickerInputRef.current)}
                 sx={(theme) => ({
                     position: 'absolute',
-                    top: { xs: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING), sm: 0 },
+                    top: {
+                        xs: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING.xs),
+                        sm: theme.spacing(LOG_DATE_CONTROL_TOP_PADDING_SPACING.sm),
+                        md: LOG_DATE_CONTROL_TOP_PADDING_SPACING.md
+                    },
                     left: 0,
                     right: 0,
                     bottom: 0,

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -6,6 +6,7 @@ import type {} from '@mui/x-charts/themeAugmentation';
 const worktreeColor = import.meta.env.VITE_WORKTREE_COLOR?.trim();
 const isMainWorktree = import.meta.env.VITE_WORKTREE_IS_MAIN === 'true';
 const appBarColor = !isMainWorktree && worktreeColor ? worktreeColor : undefined;
+const PAGE_SECTION_GAP_SPACING = 0.75; // Base vertical gap between stacked cards (theme spacing units).
 
 type ShadowRampOptions = {
     /** Base RGB hex used to tint shadows. */
@@ -92,11 +93,12 @@ export function createAppTheme(mode: PaletteMode) {
                 page: {
                     gutterX: { xs: 2, sm: 2, md: 3 },
                     paddingTop: { xs: 2, sm: 3, md: 3 },
-                    paddingTopCompact: { xs: 0, sm: 0, md: 3 },
+                    // Keep xs full-bleed, but add a small top inset on sm so rounded cards do not touch the app bar.
+                    paddingTopCompact: { xs: 0, sm: PAGE_SECTION_GAP_SPACING, md: 3 },
                     paddingBottom: { xs: 2, sm: 3, md: 3 },
                     paddingBottomWithBottomNav: 'calc(80px + var(--safe-area-inset-bottom, 0px))',
-                    sectionGap: 0.75,
-                    sectionGapCompact: 0.75
+                    sectionGap: PAGE_SECTION_GAP_SPACING,
+                    sectionGapCompact: PAGE_SECTION_GAP_SPACING
                 },
                 surface: {
                     padding: {


### PR DESCRIPTION
## Summary
- Problem: On the `sm` breakpoint, compact page padding made rounded cards and the Log date label sit flush against the app bar, causing visual clipping/regression.
- Scope: Adjust shared compact top padding at `sm`, and make the Log date picker fully own its compact-layout top inset.
- Outcome: `sm` now has consistent breathing room (matching `xs`/`md+` intent) without reintroducing extra gaps between stacked cards.

## Technical Details
- Approach: 
  - Promote the compact section gap to a shared theme constant and reuse it for `paddingTopCompact.sm`.
  - Move the top inset responsibility into `LogDatePickerControl` by:
    - making its top padding responsive on compact breakpoints (`xs`/`sm`)
    - increasing its container height on `sm` so the inner field height stays stable
    - aligning overlay and hidden input top offsets with the same inset.
- Code pointers:
  - `frontend/src/theme.ts`: restores a small `sm` top inset for compact layouts via `paddingTopCompact.sm`.
  - `frontend/src/components/LogDatePickerControl.tsx`: internalizes the compact top inset and keeps overlays aligned.
- Notes: No API or data model changes.

## Test Plan
### Executed
- Automated:
  - `npm run lint`: passed

- Manual:
  - Not executed here.

### Suggested
- Automated:
  - `npm run lint`: confirm no lint regressions locally
- Manual:
  - Verify `/log` at `sm` width: “Date” label is no longer clipped by the app bar.
  - Verify `/log` at `xs` and `md+`: date control spacing remains correct.
  - Verify other main routes at `sm`: top card is no longer flush with the app bar.
