### PR TITLE
Make drawer nav items rectangular and flush

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -46,6 +46,11 @@ const drawerWidth = 240;
 const SAFE_AREA_INSET_TOP = 'var(--safe-area-inset-top, 0px)';
 const SAFE_AREA_INSET_BOTTOM = 'var(--safe-area-inset-bottom, 0px)';
 const DEFAULT_TOOLBAR_MIN_HEIGHT_SPACING = 7; // MUI default toolbar height in spacing units (56px).
+const DRAWER_NAV_ITEM_BORDER_RADIUS = 0;
+/**
+ * Keep drawer navigation backgrounds rectangular and flush so adjacent states do not visually overlap.
+ */
+const drawerNavItemSx: SxProps<Theme> = { borderRadius: DRAWER_NAV_ITEM_BORDER_RADIUS };
 /**
  * Map the current pathname to a navigation value so nested routes keep the correct tab highlighted.
  */
@@ -121,11 +126,12 @@ const LayoutShell: React.FC = () => {
             <Toolbar sx={safeAreaToolbarSx} />
 
             <Box sx={{ flexGrow: 1 }}>
-                <List>
+                <List disablePadding>
                     <ListItemButton
                         selected={location.pathname.startsWith('/dashboard')}
                         component={RouterLink}
                         to="/dashboard"
+                        sx={drawerNavItemSx}
                     >
                         <ListItemIcon>
                             <DashboardIcon />
@@ -133,14 +139,24 @@ const LayoutShell: React.FC = () => {
                         <ListItemText primary={t('nav.dashboard')} />
                     </ListItemButton>
 
-                    <ListItemButton selected={location.pathname.startsWith('/log')} component={RouterLink} to="/log">
+                    <ListItemButton
+                        selected={location.pathname.startsWith('/log')}
+                        component={RouterLink}
+                        to="/log"
+                        sx={drawerNavItemSx}
+                    >
                         <ListItemIcon>
                             <ListAltIcon />
                         </ListItemIcon>
                         <ListItemText primary={t('nav.log')} />
                     </ListItemButton>
 
-                    <ListItemButton selected={location.pathname.startsWith('/goals')} component={RouterLink} to="/goals">
+                    <ListItemButton
+                        selected={location.pathname.startsWith('/goals')}
+                        component={RouterLink}
+                        to="/goals"
+                        sx={drawerNavItemSx}
+                    >
                         <ListItemIcon>
                             <ShowChartIcon />
                         </ListItemIcon>
@@ -151,6 +167,7 @@ const LayoutShell: React.FC = () => {
                         selected={location.pathname.startsWith('/profile')}
                         component={RouterLink}
                         to="/profile"
+                        sx={drawerNavItemSx}
                     >
                         <ListItemIcon>
                             <PersonIcon />
@@ -162,11 +179,12 @@ const LayoutShell: React.FC = () => {
 
             <Divider />
 
-            <List>
+            <List disablePadding>
                 <ListItemButton
                     selected={location.pathname.startsWith('/settings')}
                     component={RouterLink}
                     to="/settings"
+                    sx={drawerNavItemSx}
                 >
                     <ListItemIcon>
                         <SettingsIcon />
@@ -174,7 +192,7 @@ const LayoutShell: React.FC = () => {
                     <ListItemText primary={t('nav.settings')} />
                 </ListItemButton>
 
-                <ListItemButton onClick={handleLogout}>
+                <ListItemButton onClick={handleLogout} sx={drawerNavItemSx}>
                     <ListItemIcon>
                         <LogoutIcon />
                     </ListItemIcon>


### PR DESCRIPTION
## Summary
- Problem: Drawer nav items use rounded corners and default list padding, which creates gaps at the container edge and overlapping hover/selected backgrounds.
- Scope: Make drawer nav items rectangular and flush by removing list padding and overriding `ListItemButton` border radius in the drawer only.
- Outcome: Active and hover states are rectangular, align with the drawer edges, and do not visually overlap between adjacent items.

## Technical Details
- Approach: Apply a drawer-scoped `sx` override (`borderRadius: 0`) and set both drawer lists to `disablePadding`, avoiding global changes to `MuiListItemButton`.
- Code pointers: `frontend/src/components/Layout.tsx`: adds `drawerNavItemSx`, sets `disablePadding`, and applies the override to drawer nav buttons.
- Notes: `npm run build` failed locally due a Rollup optional-dependency issue unrelated to this change.

## Test Plan
### Executed
- Automated: `npm run lint` (passed).
- Automated: `npx tsc -b` run in `frontend/` (passed).

### Suggested
- Automated: `npm run build` after reinstalling frontend deps (validates Vite/Rollup bundling).
- Manual: On desktop width, verify drawer hover/selected states are rectangular, flush to edges, and non-overlapping when hovering adjacent items.
