### PR TITLE
[Notifications][4] Badging: helpers and dev badge controls (#129)

### DIFF
--- a/frontend/src/utils/badging.ts
+++ b/frontend/src/utils/badging.ts
@@ -1,0 +1,39 @@
+type BadgingNavigator = Navigator & {
+    setAppBadge?: (value?: number) => Promise<void>;
+    clearAppBadge?: () => Promise<void>;
+};
+
+/**
+ * Check whether the Badging API is available on this platform.
+ */
+export const isBadgingSupported = (): boolean => {
+    if (typeof navigator === 'undefined') return false;
+    const api = navigator as BadgingNavigator;
+    return typeof api.setAppBadge === 'function' && typeof api.clearAppBadge === 'function';
+};
+
+/**
+ * Set the app badge count if supported.
+ */
+export const setAppBadge = async (value: number): Promise<boolean> => {
+    const api = navigator as BadgingNavigator;
+    if (typeof api.setAppBadge !== 'function') {
+        return false;
+    }
+
+    await api.setAppBadge(value);
+    return true;
+};
+
+/**
+ * Clear the app badge if supported.
+ */
+export const clearAppBadge = async (): Promise<boolean> => {
+    const api = navigator as BadgingNavigator;
+    if (typeof api.clearAppBadge !== 'function') {
+        return false;
+    }
+
+    await api.clearAppBadge();
+    return true;
+};


### PR DESCRIPTION
## Stack
* #139
* #133
* #135
* #136 :point_left:
* #137
* #138

## Summary
- Add Badging API helpers for support checks and set/clear operations.
- Expose dev-only badge controls in `/dev` for manual validation.

## Technical notes
- `frontend/src/utils/badging.ts` wraps `navigator.setAppBadge`/`clearAppBadge` safely.
- `frontend/src/pages/DevDashboard.tsx` adds an App badge card with basic actions and messaging.

## Test plan
1. On a platform that supports the Badging API, open `/dev` and set badge to 1.
2. Clear the badge and confirm it disappears.
3. On an unsupported platform, verify the warning and disabled buttons.

<img width="73" height="81" alt="image" src="https://github.com/user-attachments/assets/22abd009-ff2f-4ebf-b1dd-e43f7629b3de" />
