### PR TITLE
Add food log day completion model

### DIFF
--- a/backend/prisma/migrations/0013_food_log_day_completion/migration.sql
+++ b/backend/prisma/migrations/0013_food_log_day_completion/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "FoodLogDay" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "local_date" DATE NOT NULL,
+    "is_complete" BOOLEAN NOT NULL DEFAULT false,
+    "completed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FoodLogDay_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FoodLogDay_user_id_local_date_key" ON "FoodLogDay"("user_id", "local_date");
+
+-- AddForeignKey
+ALTER TABLE "FoodLogDay" ADD CONSTRAINT "FoodLogDay_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -76,6 +76,7 @@ model User {
   goals         Goal[]
   metrics       BodyMetric[]
   food_logs     FoodLog[]
+  food_log_days FoodLogDay[]
   /// User-owned library of reusable foods and recipes for quick logging.
   my_foods      MyFood[]
 }
@@ -128,6 +129,22 @@ model FoodLog {
   created_at  DateTime @default(now())
 
   @@index([user_id, local_date])
+}
+
+model FoodLogDay {
+  id           Int      @id @default(autoincrement())
+  user_id      Int
+  user         User     @relation(fields: [user_id], references: [id])
+  /// Calendar day for grouping logs, derived from the user's timezone at write time.
+  local_date   DateTime @db.Date
+  /// Whether the user has marked the day's log as complete.
+  is_complete  Boolean  @default(false)
+  /// Timestamp of when the day was marked complete (cleared when toggled off).
+  completed_at DateTime?
+  created_at   DateTime @default(now())
+  updated_at   DateTime @updatedAt
+
+  @@unique([user_id, local_date])
 }
 
 model MyFood {


### PR DESCRIPTION
## Stack
* #144 :point_left:
* #145
* #146
* #147

## Summary
- Add a FoodLogDay Prisma model to track daily completion status.
- Store completion timestamps with user-local date keys.
- Introduce an ordinal migration for the new table.

## Technical notes
- `backend/prisma/schema.prisma` adds `FoodLogDay` with a unique `[user_id, local_date]` constraint.
- `backend/prisma/migrations/0013_food_log_day_completion/migration.sql` creates the table and FK.

## Test plan
1. `npm test`
2. `npm run lint`
