### PR TITLE
Add food log day completion endpoints

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import authRoutes from './routes/auth';
 import devRoutes from './routes/dev';
 import devTestRoutes from './routes/devTest';
 import foodRoutes from './routes/food';
+import foodDayRoutes from './routes/foodDays';
 import goalRoutes from './routes/goals';
 import importRoutes from './routes/imports';
 import metricRoutes from './routes/metrics';
@@ -317,6 +318,7 @@ const bootstrap = async (): Promise<void> => {
   apiRouter.use('/goals', goalRoutes);
   apiRouter.use('/metrics', metricRoutes);
   apiRouter.use('/food', foodRoutes);
+  apiRouter.use('/food-days', foodDayRoutes);
   apiRouter.use('/my-foods', myFoodsRoutes);
   apiRouter.use('/imports', importRoutes);
   apiRouter.use('/user', userRoutes);

--- a/backend/src/routes/foodDays.ts
+++ b/backend/src/routes/foodDays.ts
@@ -1,0 +1,117 @@
+import express from 'express';
+import prisma from '../config/database';
+import { parseLocalDateOnly } from '../utils/date';
+
+/**
+ * Daily food log completion status endpoints.
+ *
+ * Completion is stored per local-day using the user's timezone-derived date.
+ */
+const router = express.Router();
+
+/**
+ * Ensure the session is authenticated before accessing food log day data.
+ */
+const isAuthenticated = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (req.isAuthenticated()) {
+        return next();
+    }
+    res.status(401).json({ message: 'Not authenticated' });
+};
+
+router.use(isAuthenticated);
+
+function formatDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
+function parseRequestedDate(value: unknown): { ok: true; dateValue: Date; dateKey: string } | { ok: false } {
+    if (typeof value !== 'string') return { ok: false };
+
+    try {
+        const dateValue = parseLocalDateOnly(value);
+        return { ok: true, dateValue, dateKey: formatDateKey(dateValue) };
+    } catch {
+        return { ok: false };
+    }
+}
+
+router.get('/', async (req, res) => {
+    const user = req.user as any;
+    const dateParam =
+        typeof req.query.date === 'string'
+            ? req.query.date
+            : typeof req.query.local_date === 'string'
+              ? req.query.local_date
+              : undefined;
+
+    const parsedDate = parseRequestedDate(dateParam);
+    if (!parsedDate.ok) {
+        return res.status(400).json({ message: 'Invalid date' });
+    }
+
+    try {
+        const existing = await prisma.foodLogDay.findUnique({
+            where: { user_id_local_date: { user_id: user.id, local_date: parsedDate.dateValue } }
+        });
+
+        if (!existing) {
+            return res.json({ date: parsedDate.dateKey, is_complete: false, completed_at: null });
+        }
+
+        return res.json({
+            date: parsedDate.dateKey,
+            is_complete: existing.is_complete,
+            completed_at: existing.completed_at
+        });
+    } catch (err) {
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+router.patch('/', async (req, res) => {
+    const user = req.user as any;
+    if (typeof req.body !== 'object' || req.body === null) {
+        return res.status(400).json({ message: 'Invalid request body' });
+    }
+
+    const { date, local_date, is_complete } = req.body as {
+        date?: unknown;
+        local_date?: unknown;
+        is_complete?: unknown;
+    };
+
+    const parsedDate = parseRequestedDate(date ?? local_date);
+    if (!parsedDate.ok) {
+        return res.status(400).json({ message: 'Invalid date' });
+    }
+
+    if (typeof is_complete !== 'boolean') {
+        return res.status(400).json({ message: 'Invalid is_complete' });
+    }
+
+    const completedAt = is_complete ? new Date() : null;
+
+    try {
+        const updated = await prisma.foodLogDay.upsert({
+            where: { user_id_local_date: { user_id: user.id, local_date: parsedDate.dateValue } },
+            update: { is_complete, completed_at: completedAt },
+            create: {
+                user_id: user.id,
+                local_date: parsedDate.dateValue,
+                is_complete,
+                completed_at: completedAt
+            }
+        });
+
+        return res.json({
+            date: parsedDate.dateKey,
+            is_complete: updated.is_complete,
+            completed_at: updated.completed_at
+        });
+    } catch (err) {
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+export default router;


### PR DESCRIPTION
## Stack
* #144
* #145 :point_left:
* #146
* #147

## Summary
- Add authenticated /api/food-days endpoints for daily completion status.
- Support GET by local date and PATCH upserts for completion toggles.

## Technical notes
- `backend/src/routes/foodDays.ts` handles date parsing via `parseLocalDateOnly` and upserts by `[user_id, local_date]`.
- `backend/src/index.ts` mounts the new route under `/api/food-days`.

## Test plan
1. `npm test`
2. `npm run lint`
