### PR TITLE
chore(deps): update baseline-browser-mapping to 2.9.19 across repo

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4107,9 +4107,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.30",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
-      "integrity": "sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==",
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "baseline-browser-mapping": "^2.9.19",
         "typescript": "^5.0.0"
       }
     },
@@ -21,6 +22,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-    "scripts": {
-      "dev": "node scripts/dev.mjs",
-      "dev:pwa": "VITE_ENABLE_SW_DEV=1 node scripts/dev.mjs",
-      "dev:test": "AUTO_LOGIN_TEST_USER=true node scripts/dev.mjs",
+  "scripts": {
+    "dev": "node scripts/dev.mjs",
+    "dev:pwa": "VITE_ENABLE_SW_DEV=1 node scripts/dev.mjs",
+    "dev:test": "AUTO_LOGIN_TEST_USER=true node scripts/dev.mjs",
     "dev:reset-test-user-onboarding": "node scripts/reset-test-user-onboarding.mjs",
-      "dev:backend": "npm --prefix backend run dev",
-      "dev:frontend": "npm --prefix frontend run dev",
-      "preview": "node scripts/preview.mjs",
-      "prisma:generate": "npm --prefix backend run prisma:generate",
-      "db:migrate": "npm --prefix backend run db:migrate",
+    "dev:backend": "npm --prefix backend run dev",
+    "dev:frontend": "npm --prefix frontend run dev",
+    "preview": "node scripts/preview.mjs",
+    "prisma:generate": "npm --prefix backend run prisma:generate",
+    "db:migrate": "npm --prefix backend run db:migrate",
     "db:migrate:dev": "npm --prefix backend run db:migrate:dev",
     "db:reset": "npm --prefix backend run db:reset",
     "db:seed": "npm --prefix backend run db:seed",
@@ -41,7 +41,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^5.0.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "baseline-browser-mapping": "^2.9.19",
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Updates `baseline-browser-mapping` to the latest published version (`2.9.19`) in both install contexts used by this repo.
- Aligns root and frontend resolution so Baseline browser mapping data is current and stale-data warnings are reduced/avoided in tooling paths that use Browserslist Baseline queries.

## Technical Details

- Root:
  - Added/kept `baseline-browser-mapping` as a root dev dependency at `^2.9.19` in `package.json`.
  - Updated `package-lock.json` to include `baseline-browser-mapping@2.9.19`.
- Frontend:
  - Updated `frontend/package-lock.json` transitive resolution from `baseline-browser-mapping@2.8.30` to `2.9.19` (via `browserslist` chain).
- No runtime app logic was changed; this PR is dependency/lockfile-only.

## Test Plan

- Verified resolved versions:
  - `npm ls baseline-browser-mapping --depth=4` (root resolves `2.9.19`)
  - `npm --prefix frontend ls baseline-browser-mapping --depth=6` (frontend resolves `2.9.19`)
- Verified npm latest version:
  - `npm view baseline-browser-mapping version` -> `2.9.19`
- Not run:
  - Full frontend/backend test suites.
