### PR TITLE
Add persistent navbar install CTA for Chromium and iOS

### DIFF
--- a/frontend/src/hooks/useInstallState.ts
+++ b/frontend/src/hooks/useInstallState.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const IOS_USER_AGENT_REGEX = /iphone|ipad|ipod/i;
+const NON_SAFARI_IOS_BROWSER_REGEX = /CriOS|FxiOS|EdgiOS|OPiOS|YaBrowser/i;
+const CHROMIUM_USER_AGENT_REGEX = /Chrome|Chromium|Edg|OPR|SamsungBrowser/i;
+
+export type InstallPlatformHint = 'ios' | 'chromium' | 'other';
+export type InstallPromptResult = 'accepted' | 'dismissed' | 'unavailable';
+
+/**
+ * iOS/iPadOS Safari supports the Add to Home Screen flow; other iOS browsers have weaker support.
+ */
+function isIosSafari(): boolean {
+    if (typeof navigator === 'undefined') return false;
+
+    const userAgent = navigator.userAgent || '';
+    const isIos = IOS_USER_AGENT_REGEX.test(userAgent) || (userAgent.includes('Mac') && navigator.maxTouchPoints > 1);
+    if (!isIos) return false;
+    if (!userAgent.includes('Safari')) return false;
+    return !NON_SAFARI_IOS_BROWSER_REGEX.test(userAgent);
+}
+
+/**
+ * Use browser display mode signals to detect whether this session is already running as an installed app.
+ */
+function isStandaloneDisplayMode(): boolean {
+    if (typeof window === 'undefined') return false;
+    if (window.matchMedia('(display-mode: standalone)').matches) return true;
+    return (window.navigator as { standalone?: boolean }).standalone === true;
+}
+
+/**
+ * Distinguish install-capable platforms so the navbar can render the correct CTA behavior.
+ */
+function resolveInstallPlatformHint(): InstallPlatformHint {
+    if (isIosSafari()) return 'ios';
+    if (typeof navigator === 'undefined') return 'other';
+    const userAgent = navigator.userAgent || '';
+    return CHROMIUM_USER_AGENT_REGEX.test(userAgent) ? 'chromium' : 'other';
+}
+
+/**
+ * Track installability/runtime state and expose prompt actions for the navbar Install CTA.
+ */
+export function useInstallState() {
+    const [isInstalled, setIsInstalled] = useState(() => isStandaloneDisplayMode());
+    const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+    const platformHint = useMemo(() => resolveInstallPlatformHint(), []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+
+        const mediaQuery = window.matchMedia('(display-mode: standalone)');
+        const syncInstalledState = () => {
+            setIsInstalled(isStandaloneDisplayMode());
+        };
+
+        const handleBeforeInstallPrompt = (event: BeforeInstallPromptEvent) => {
+            event.preventDefault();
+            setDeferredPrompt(event);
+            syncInstalledState();
+        };
+
+        const handleAppInstalled = () => {
+            setDeferredPrompt(null);
+            setIsInstalled(true);
+        };
+
+        const supportsModernMediaQueryEvents = typeof mediaQuery.addEventListener === 'function';
+        syncInstalledState();
+        if (supportsModernMediaQueryEvents) {
+            mediaQuery.addEventListener('change', syncInstalledState);
+        } else {
+            mediaQuery.addListener(syncInstalledState);
+        }
+        window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+        window.addEventListener('appinstalled', handleAppInstalled);
+
+        return () => {
+            if (supportsModernMediaQueryEvents) {
+                mediaQuery.removeEventListener('change', syncInstalledState);
+            } else {
+                mediaQuery.removeListener(syncInstalledState);
+            }
+            window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+            window.removeEventListener('appinstalled', handleAppInstalled);
+        };
+    }, []);
+
+    const canInstallPrompt = Boolean(deferredPrompt) && !isInstalled;
+    const showInstallCta = !isInstalled && (canInstallPrompt || platformHint === 'ios');
+
+    const promptInstall = useCallback(async (): Promise<InstallPromptResult> => {
+        if (!deferredPrompt || isInstalled) return 'unavailable';
+
+        try {
+            await deferredPrompt.prompt();
+            const { outcome } = await deferredPrompt.userChoice;
+            setDeferredPrompt(null);
+            if (outcome === 'accepted') {
+                setIsInstalled(true);
+                return 'accepted';
+            }
+            return 'dismissed';
+        } catch {
+            setDeferredPrompt(null);
+            return 'unavailable';
+        }
+    }, [deferredPrompt, isInstalled]);
+
+    return {
+        isInstalled,
+        canInstallPrompt,
+        platformHint,
+        showInstallCta,
+        promptInstall
+    };
+}

--- a/frontend/src/i18n/resources.ts
+++ b/frontend/src/i18n/resources.ts
@@ -24,6 +24,13 @@ export const en = {
     'nav.github': 'GitHub',
     'nav.openRepoAria': 'Open the source repository on GitHub',
     'nav.openSettingsAria': 'Open settings',
+    'nav.install': 'Install',
+    'nav.openInstallAria': 'Install app',
+    'install.ios.title': 'Install on iPhone',
+    'install.ios.body': 'Add calibrate to your home screen from Safari:',
+    'install.ios.step1': 'Tap the Share button in Safari.',
+    'install.ios.step2': 'Choose Add to Home Screen.',
+    'install.ios.step3': 'Tap Add to finish installing.',
 
     'legal.privacyPolicy': 'Privacy policy',
 
@@ -499,6 +506,13 @@ export const es: Record<TranslationKey, string> = {
     'nav.github': 'GitHub',
     'nav.openRepoAria': 'Abrir el repositorio de código fuente en GitHub',
     'nav.openSettingsAria': 'Abrir ajustes',
+    'nav.install': 'Instalar',
+    'nav.openInstallAria': 'Instalar app',
+    'install.ios.title': 'Instalar en iPhone',
+    'install.ios.body': 'Agrega calibrate a tu pantalla de inicio desde Safari:',
+    'install.ios.step1': 'Toca el boton Compartir en Safari.',
+    'install.ios.step2': 'Elige Agregar a pantalla de inicio.',
+    'install.ios.step3': 'Toca Agregar para terminar la instalacion.',
 
     'legal.privacyPolicy': 'Política de privacidad',
 
@@ -972,6 +986,13 @@ export const fr: Record<TranslationKey, string> = {
     'nav.github': 'GitHub',
     'nav.openRepoAria': 'Ouvrir le dépôt source sur GitHub',
     'nav.openSettingsAria': 'Ouvrir les paramètres',
+    'nav.install': 'Installer',
+    'nav.openInstallAria': "Installer l'application",
+    'install.ios.title': 'Installer sur iPhone',
+    'install.ios.body': "Ajoutez calibrate a l'ecran d'accueil depuis Safari :",
+    'install.ios.step1': 'Touchez le bouton Partager dans Safari.',
+    'install.ios.step2': "Choisissez Ajouter a l'ecran d'accueil.",
+    'install.ios.step3': "Touchez Ajouter pour terminer l'installation.",
 
     'legal.privacyPolicy': 'Politique de confidentialité',
 
@@ -1445,6 +1466,13 @@ export const ru: Record<TranslationKey, string> = {
     'nav.github': 'GitHub',
     'nav.openRepoAria': 'Открыть репозиторий исходного кода на GitHub',
     'nav.openSettingsAria': 'Открыть настройки',
+    'nav.install': 'Установить',
+    'nav.openInstallAria': 'Установить приложение',
+    'install.ios.title': 'Установка на iPhone',
+    'install.ios.body': 'Добавьте calibrate на экран домой через Safari:',
+    'install.ios.step1': 'Нажмите кнопку Поделиться в Safari.',
+    'install.ios.step2': 'Выберите На экран Домой.',
+    'install.ios.step3': 'Нажмите Добавить для завершения установки.',
 
     'legal.privacyPolicy': 'Политика конфиденциальности',
 

--- a/frontend/src/types/pwa-install.d.ts
+++ b/frontend/src/types/pwa-install.d.ts
@@ -1,0 +1,18 @@
+export {};
+
+declare global {
+    interface BeforeInstallPromptChoiceResult {
+        outcome: 'accepted' | 'dismissed';
+        platform: string;
+    }
+
+    interface BeforeInstallPromptEvent extends Event {
+        readonly platforms: string[];
+        readonly userChoice: Promise<BeforeInstallPromptChoiceResult>;
+        prompt: () => Promise<void>;
+    }
+
+    interface WindowEventMap {
+        beforeinstallprompt: BeforeInstallPromptEvent;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds install-state detection for the web app so install UX is shown only when relevant.
- Shows a persistent `Install` CTA in the top navbar when the app is not installed and install is actionable.
- Routes install actions by platform:
  - Chromium: uses captured `beforeinstallprompt` to trigger the native install prompt.
  - iOS Safari: opens an Add to Home Screen instruction dialog.
- Keeps install state reactive by listening to both `appinstalled` and display-mode changes.

## Technical Details

- Added `useInstallState()` in `frontend/src/hooks/useInstallState.ts` to centralize:
  - installed state detection (`display-mode: standalone`, `navigator.standalone`)
  - deferred prompt capture (`beforeinstallprompt`)
  - install completion updates (`appinstalled`)
  - platform hinting (`ios` / `chromium` / `other`)
- Added install prompt event typings in `frontend/src/types/pwa-install.d.ts` for strict TypeScript support.
- Updated navbar rendering and click behavior in `frontend/src/components/Layout.tsx`:
  - responsive install CTA (icon button on xs, outlined button on larger screens)
  - iOS instruction dialog branch
  - CTA hidden when installed or not actionable
- Added i18n keys in `frontend/src/i18n/resources.ts` for `en`, `es`, `fr`, and `ru`.

## Test Plan

- Automatically validated:
  - `npm --prefix frontend run lint`
  - `npm --prefix frontend run build`
- Not yet manually validated:
  - Windows/Android Chromium prompt behavior
  - iOS Safari Add to Home Screen instructions flow
  - installed-state transitions on target devices
