### PR TITLE
Make push subscription endpoint ownership atomic

### DIFF
--- a/backend/prisma/migrations/0021_push_subscription_endpoint_global_uniqueness/migration.sql
+++ b/backend/prisma/migrations/0021_push_subscription_endpoint_global_uniqueness/migration.sql
@@ -1,0 +1,18 @@
+-- Collapse duplicate endpoint rows created by per-user uniqueness so endpoint ownership can be global again.
+WITH ranked_subscriptions AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY endpoint
+            ORDER BY updated_at DESC, created_at DESC, id DESC
+        ) AS row_rank
+    FROM "PushSubscription"
+)
+DELETE FROM "PushSubscription" AS ps
+USING ranked_subscriptions AS ranked
+WHERE ps.id = ranked.id
+  AND ranked.row_rank > 1;
+
+-- Restore global endpoint uniqueness so pushes cannot fan out across multiple accounts on a shared browser.
+DROP INDEX "PushSubscription_user_id_endpoint_key";
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -290,8 +290,8 @@ model PushSubscription {
   id              Int      @id @default(autoincrement())
   user_id         Int
   user            User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
-  /// Browser-managed endpoint URL; unique per user so shared browsers can hold separate accounts.
-  endpoint        String
+  /// Browser-managed endpoint URL; globally unique so one browser endpoint maps to one account at a time.
+  endpoint        String   @unique
   /// Base64-encoded p256dh key for payload encryption.
   p256dh          String
   /// Base64-encoded auth key for payload encryption.
@@ -303,7 +303,6 @@ model PushSubscription {
   created_at      DateTime @default(now())
   updated_at      DateTime @updatedAt
 
-  @@unique([user_id, endpoint])
   @@index([user_id])
 }
 

--- a/backend/src/services/notificationDelivery.ts
+++ b/backend/src/services/notificationDelivery.ts
@@ -168,12 +168,10 @@ const resolvePushSubscriptions = async (
 ): Promise<NormalizedPushSubscription[]> => {
     const normalizedEndpoint = normalizeOptionalText(endpoint);
     if (normalizedEndpoint) {
-        const subscription = await prisma.pushSubscription.findUnique({
+        const subscription = await prisma.pushSubscription.findFirst({
             where: {
-                user_id_endpoint: {
-                    user_id: userId,
-                    endpoint: normalizedEndpoint
-                }
+                user_id: userId,
+                endpoint: normalizedEndpoint
             },
             select: {
                 id: true,

--- a/backend/test/notification-delivery.test.js
+++ b/backend/test/notification-delivery.test.js
@@ -55,7 +55,7 @@ test('deliverUserNotification creates one in-app notification and dedupes repeat
       }
     },
     pushSubscription: {
-      findUnique: async () => null,
+      findFirst: async () => null,
       findMany: async () => [],
       update: async () => {
         throw new Error('should not be called');
@@ -127,7 +127,7 @@ test('deliverUserNotification skips push when endpoint lookup fails', async () =
       }
     },
     pushSubscription: {
-      findUnique: async () => null,
+      findFirst: async () => null,
       findMany: async () => {
         throw new Error('should not be called');
       },
@@ -184,7 +184,7 @@ test('deliverUserNotification sends push and updates last sent date for successf
       }
     },
     pushSubscription: {
-      findUnique: async () => ({
+      findFirst: async () => ({
         id: 42,
         endpoint: 'https://example.test/push-endpoint',
         p256dh: 'p256dh-key',
@@ -252,7 +252,7 @@ test('deliverUserNotification skips push when local-day send already happened', 
       }
     },
     pushSubscription: {
-      findUnique: async () => ({
+      findFirst: async () => ({
         id: 11,
         endpoint: 'https://example.test/push-endpoint',
         p256dh: 'p256dh-key',

--- a/backend/test/routes-notifications.test.js
+++ b/backend/test/routes-notifications.test.js
@@ -1,0 +1,183 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadNotificationsRouter({ prismaStub, getWebPushPublicKeyStub }) {
+  const databasePath = require.resolve('../src/config/database');
+  const webPushPath = require.resolve('../src/services/webPush');
+  const inAppNotificationsPath = require.resolve('../src/services/inAppNotifications');
+  const notificationsRoutePath = require.resolve('../src/routes/notifications');
+
+  const previousDatabaseModule = require.cache[databasePath];
+  const previousWebPushModule = require.cache[webPushPath];
+  const previousInAppNotificationsModule = require.cache[inAppNotificationsPath];
+  delete require.cache[notificationsRoutePath];
+
+  stubModule(databasePath, prismaStub);
+  stubModule(webPushPath, {
+    getWebPushPublicKey: getWebPushPublicKeyStub || (() => ({ publicKey: 'test-public-key' }))
+  });
+  stubModule(inAppNotificationsPath, {
+    listActiveInAppNotificationsForUser: async () => ({ notifications: [], unreadCount: 0 }),
+    markInAppNotificationDismissed: async () => undefined,
+    markInAppNotificationRead: async () => undefined,
+    resolveInactiveReminderNotificationsForUser: async () => undefined
+  });
+
+  const loaded = require('../src/routes/notifications');
+
+  if (previousDatabaseModule) require.cache[databasePath] = previousDatabaseModule;
+  else delete require.cache[databasePath];
+
+  if (previousWebPushModule) require.cache[webPushPath] = previousWebPushModule;
+  else delete require.cache[webPushPath];
+
+  if (previousInAppNotificationsModule) require.cache[inAppNotificationsPath] = previousInAppNotificationsModule;
+  else delete require.cache[inAppNotificationsPath];
+
+  return loaded.default ?? loaded;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function getRouteHandlers(router, method, path) {
+  const layer = router.stack.find(
+    (candidate) => candidate.route && candidate.route.path === path && candidate.route.methods?.[method]
+  );
+  assert.ok(layer, `Expected ${method.toUpperCase()} ${path} route to exist`);
+  return layer.route.stack.map((stackLayer) => stackLayer.handle);
+}
+
+test('notifications route: POST /subscription uses one atomic write for ownership handoff + dedupe reset', async () => {
+  const executeRawCalls = [];
+  const router = loadNotificationsRouter({
+    prismaStub: {
+      $executeRaw: async (query, ...values) => {
+        executeRawCalls.push({ query, values });
+        return 1;
+      }
+    }
+  });
+
+  const [handler] = getRouteHandlers(router, 'post', '/subscription');
+  const req = {
+    isAuthenticated: () => true,
+    user: { id: 9 },
+    body: {
+      endpoint: 'https://example.test/browser-endpoint',
+      keys: {
+        p256dh: 'p256dh-key',
+        auth: 'auth-key'
+      }
+    }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(executeRawCalls.length, 1);
+  const sqlText = executeRawCalls[0].query.join(' ');
+  assert.match(sqlText, /ON CONFLICT \("endpoint"\)/);
+  assert.match(sqlText, /"last_sent_local_date" = CASE/);
+  assert.match(sqlText, /IS DISTINCT FROM/);
+  assert.match(sqlText, /ELSE "PushSubscription"\."last_sent_local_date"/);
+  assert.deepEqual(executeRawCalls[0].values, [
+    9,
+    'https://example.test/browser-endpoint',
+    'p256dh-key',
+    'auth-key',
+    null
+  ]);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { ok: true });
+});
+
+test('notifications route: POST /subscription forwards expirationTime to the atomic write', async () => {
+  const executeRawCalls = [];
+  const expirationTimeMs = Date.UTC(2026, 1, 20, 16, 5, 0, 0);
+  const router = loadNotificationsRouter({
+    prismaStub: {
+      $executeRaw: async (query, ...values) => {
+        executeRawCalls.push({ query, values });
+        return 1;
+      }
+    }
+  });
+
+  const [handler] = getRouteHandlers(router, 'post', '/subscription');
+  const req = {
+    isAuthenticated: () => true,
+    user: { id: 9 },
+    body: {
+      endpoint: 'https://example.test/browser-endpoint',
+      keys: {
+        p256dh: 'p256dh-key',
+        auth: 'auth-key'
+      },
+      expirationTime: expirationTimeMs
+    }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(executeRawCalls.length, 1);
+  assert.ok(executeRawCalls[0].values[4] instanceof Date);
+  assert.equal(executeRawCalls[0].values[4].getTime(), expirationTimeMs);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { ok: true });
+});
+
+test('notifications route: DELETE /subscription only removes endpoint rows for the authenticated user', async () => {
+  const deleteManyCalls = [];
+  const router = loadNotificationsRouter({
+    prismaStub: {
+      pushSubscription: {
+        deleteMany: async (args) => {
+          deleteManyCalls.push(args);
+          return { count: 0 };
+        }
+      }
+    }
+  });
+
+  const [handler] = getRouteHandlers(router, 'delete', '/subscription');
+  const req = {
+    isAuthenticated: () => true,
+    user: { id: 9 },
+    body: {
+      endpoint: 'https://example.test/browser-endpoint'
+    }
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(deleteManyCalls.length, 1);
+  assert.deepEqual(deleteManyCalls[0].where, {
+    user_id: 9,
+    endpoint: 'https://example.test/browser-endpoint'
+  });
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { ok: true });
+});


### PR DESCRIPTION
## Summary

- Enforces global push endpoint uniqueness so one browser endpoint maps to one account at a time.
- Makes `POST /api/notifications/subscription` ownership handoff and reminder dedupe reset atomic.
- Adds route-level regression tests for atomic subscription writes and scoped unsubscribe behavior.

## Technical Details

- **Schema + migration**
  - `backend/prisma/schema.prisma`: `PushSubscription.endpoint` is now `@unique`; the per-user composite uniqueness is removed.
  - `backend/prisma/migrations/0021_push_subscription_endpoint_global_uniqueness/migration.sql`: deduplicates existing endpoint rows, keeps the most recently updated row, drops the old composite index, and creates the endpoint-unique index.
- **Atomic ownership handoff**
  - `backend/src/routes/notifications.ts`: replaces the separate read/upsert flow with one `INSERT ... ON CONFLICT ("endpoint") DO UPDATE` statement via `prisma.$executeRaw`.
  - When endpoint ownership changes, `last_sent_local_date` is reset to avoid carrying reminder dedupe state across accounts.
- **Notification delivery compatibility**
  - `backend/src/services/notificationDelivery.ts`: endpoint-scoped lookup now uses `findFirst` with `{ user_id, endpoint }`.
  - `backend/test/notification-delivery.test.js`: updates stubs to match the new lookup shape.
- **API route tests**
  - `backend/test/routes-notifications.test.js`: covers SQL path content/parameters, expiration-time forwarding, and user-scoped `DELETE /subscription` behavior.

## Validation

- GitHub Actions on head `0460cad`: Lint, Builds, and Tests passed.
- Local: `git diff --check origin/master...notif/132-endpoint-ownership-guard` passed.

## Still Recommended

- Manually test re-subscribing across two accounts on the same browser endpoint to confirm same-day reminder dedupe resets on ownership handoff.