### PR TITLE
[codex] Fix Codex devcontainer worktree actions

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -7,3 +7,38 @@ script = '''
 node .codex/local-environment.setup.mjs
 
 '''
+
+[[actions]]
+name = "Dev"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs dev"
+
+[[actions]]
+name = "Dev test"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs dev:test"
+
+[[actions]]
+name = "Test"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs test"
+
+[[actions]]
+name = "Lint"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs lint"
+
+[[actions]]
+name = "Build"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs build"
+
+[[actions]]
+name = "Shell"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs shell"
+
+[[actions]]
+name = "Stop"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs down"

--- a/.codex/local-environment.md
+++ b/.codex/local-environment.md
@@ -6,22 +6,25 @@ Use this repo-owned setup script for Codex app worktrees:
 node .codex/local-environment.setup.mjs
 ```
 
-Recommended Codex app actions:
+Configured Codex app actions:
 
 | Name | Script |
 | --- | --- |
-| Devcontainer setup | `npm run codex:setup` |
-| Dev server | `npm run codex:dev` |
-| Dev server (test user) | `npm run codex:dev:test` |
-| Test | `npm run codex:test` |
-| Coverage | `npm run codex:test:coverage` |
-| Lint | `npm run codex:lint` |
-| Build | `npm run codex:build` |
-| Shell | `npm run codex:shell` |
-| Stop devcontainer | `npm run codex:down` |
+| Dev | `node scripts/codex-worktree-env.mjs dev` |
+| Dev test | `node scripts/codex-worktree-env.mjs dev:test` |
+| Test | `node scripts/codex-worktree-env.mjs test` |
+| Lint | `node scripts/codex-worktree-env.mjs lint` |
+| Build | `node scripts/codex-worktree-env.mjs build` |
+| Shell | `node scripts/codex-worktree-env.mjs shell` |
+| Stop | `node scripts/codex-worktree-env.mjs down` |
 
 The setup script uses `CODEX_WORKTREE_PATH` when Codex provides it and falls
 back to the current directory outside the app. It is host-platform neutral, so
 Windows Codex execution does not need WSL bash. It also copies the source
 checkout's ignored `.env` into the new worktree if that file exists and the
 worktree does not already have one.
+
+Setup streams devcontainer logs as they are produced. New worktrees still need
+to install backend/frontend dependencies and seed Postgres, but the devcontainer
+shares a Docker npm cache volume named `calibrate-health-npm-cache` so repeated
+setups can reuse downloaded packages.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ..:/workspaces/${WORKSPACE_FOLDER_NAME}:cached
       - ${GIT_DIR}:/workspaces/.git-dir:cached
       - ${GIT_COMMON_DIR}:/workspaces/.git-common:cached
+      - npm_cache:/home/node/.npm
       - ${CODEX_HOST_HOME}:/home/node/.codex-host:ro,cached
     ports:
       - "${BACKEND_PORT}:3000"
@@ -52,3 +53,5 @@ services:
 
 volumes:
   postgres_data:
+  npm_cache:
+    name: calibrate-health-npm-cache

--- a/scripts/devcontainer-worktree.mjs
+++ b/scripts/devcontainer-worktree.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -300,32 +300,36 @@ function redactSensitiveOutput(output) {
 }
 
 /**
- * Run `devcontainer up` and return the container id (if available).
+ * Run `devcontainer up`, stream redacted logs live, and return the container id.
  * @param {string[]} args - Arguments to pass to devcontainer.
- * @returns {string|null} Container id when reported by the CLI.
+ * @returns {Promise<string|null>} Container id when reported by the CLI.
  */
 function runDevcontainerUp(args) {
-  const result = spawnSync(DEVCONTAINER_COMMAND, [...DEVCONTAINER_BASE_ARGS, ...args], {
-    stdio: ["inherit", "pipe", "pipe"],
-    encoding: "utf8",
+  return new Promise((resolve, reject) => {
+    const child = spawn(DEVCONTAINER_COMMAND, [...DEVCONTAINER_BASE_ARGS, ...args], {
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    let stdout = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      process.stdout.write(redactSensitiveOutput(chunk));
+    });
+    child.stderr.on("data", (chunk) => {
+      process.stderr.write(redactSensitiveOutput(chunk));
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      if (status !== 0) {
+        reject(new Error("devcontainer up failed."));
+        return;
+      }
+      resolve(extractContainerId(stdout));
+    });
   });
-
-  if (result.stdout) {
-    process.stdout.write(redactSensitiveOutput(result.stdout));
-  }
-  if (result.stderr) {
-    process.stderr.write(redactSensitiveOutput(result.stderr));
-  }
-
-  if (result.error) {
-    throw result.error;
-  }
-
-  if (result.status !== 0) {
-    throw new Error("devcontainer up failed.");
-  }
-
-  return extractContainerId(result.stdout ?? "");
 }
 
 /**
@@ -389,7 +393,7 @@ const containerWorkspaceFolder = resolveContainerWorkspaceFolder(
 );
 
 if (subcommand === "up") {
-  runDevcontainerUp([
+  await runDevcontainerUp([
     "up",
     "--workspace-folder",
     target.workspacePath,
@@ -407,7 +411,7 @@ if (subcommand === "exec") {
     process.exit(1);
   }
 
-  const containerId = runDevcontainerUp([
+  const containerId = await runDevcontainerUp([
     "up",
     "--workspace-folder",
     target.workspacePath,
@@ -427,7 +431,7 @@ if (subcommand === "exec") {
 
 const shellCommand =
   target.commandArgs.length === 0 ? ["bash"] : target.commandArgs;
-const containerId = runDevcontainerUp([
+const containerId = await runDevcontainerUp([
   "up",
   "--workspace-folder",
   target.workspacePath,


### PR DESCRIPTION
## Summary
- Add explicit Codex local environment actions for dev, test, lint, build, shell, and stop workflows.
- Stream redacted devcontainer setup logs so long Docker/postCreate work is visible during worktree setup.
- Add a shared npm cache volume to speed repeated devcontainer package installs.

## Validation
- `node --check scripts\devcontainer-worktree.mjs`
- `node .devcontainer\init-devcontainer-env.mjs; docker compose --env-file .devcontainer\.env -f .devcontainer\docker-compose.yml config --services`

## Notes
- `gh` was not available on the local Windows PATH, so this PR was created through the GitHub connector after pushing the branch with local git.