### PR TITLE
[codex] Remove devcontainer stop action

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -37,8 +37,3 @@ command = "node scripts/codex-worktree-env.mjs build"
 name = "Shell"
 icon = "run"
 command = "node scripts/codex-worktree-env.mjs shell"
-
-[[actions]]
-name = "Stop"
-icon = "run"
-command = "node scripts/codex-worktree-env.mjs down"

--- a/.codex/local-environment.md
+++ b/.codex/local-environment.md
@@ -16,7 +16,6 @@ Configured Codex app actions:
 | Lint | `node scripts/codex-worktree-env.mjs lint` |
 | Build | `node scripts/codex-worktree-env.mjs build` |
 | Shell | `node scripts/codex-worktree-env.mjs shell` |
-| Stop | `node scripts/codex-worktree-env.mjs down` |
 
 The setup script uses `CODEX_WORKTREE_PATH` when Codex provides it and falls
 back to the current directory outside the app. It is host-platform neutral, so


### PR DESCRIPTION
## Summary
- Remove the `Stop` entry from Codex local environment actions.
- Update the local environment docs so only non-destructive actions are listed.

## Why
The Stop action runs `node scripts/codex-worktree-env.mjs down`, which tears down the worktree devcontainer stack. Keeping that in the action dropdown creates avoidable misclick risk, especially because normal Codex worktree cleanup does not document a repo-level teardown hook.

## Validation
- Confirmed `.codex/environments/environment.toml` no longer contains `name = "Stop"` or the `codex-worktree-env.mjs down` action command.
- Confirmed `.codex/local-environment.md` no longer lists the Stop action.