### PR TITLE
[codex] Fix Windows Codex setup spawn

### DIFF
--- a/.codex/local-environment.setup.mjs
+++ b/.codex/local-environment.setup.mjs
@@ -8,7 +8,6 @@ const workspacePath = path.resolve(process.env.CODEX_WORKTREE_PATH || process.cw
 const sourceTreePath = process.env.CODEX_SOURCE_TREE_PATH
   ? path.resolve(process.env.CODEX_SOURCE_TREE_PATH)
   : "";
-const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
 
 /**
  * Run a setup command with inherited stdio so Codex shows actionable logs.
@@ -45,7 +44,8 @@ if (sourceTreePath && sourceTreePath !== workspacePath) {
 }
 
 const devcontainerCli = ensureDevcontainerCliCache(workspacePath);
+const codexWorktreeEnvScript = path.join(workspacePath, "scripts", "codex-worktree-env.mjs");
 
-run(npmBin, ["run", "codex:devcontainer:start"], {
+run(process.execPath, [codexWorktreeEnvScript, "devcontainer:start"], {
   DEVCONTAINER_CLI_JS: devcontainerCli.cliJs,
 });

--- a/scripts/devcontainer-cli-cache.mjs
+++ b/scripts/devcontainer-cli-cache.mjs
@@ -62,6 +62,27 @@ export function resolveDevcontainerCliCache(repoRoot = defaultRepoRoot) {
 }
 
 /**
+ * Run npm in a way that also works in Windows Codex-hosted Node processes.
+ * Directly spawning npm.cmd can fail with EINVAL in that environment.
+ * @param {string[]} args - npm arguments.
+ * @param {string} cwd - Working directory for npm.
+ * @returns {import("node:child_process").SpawnSyncReturns<Buffer>} Spawn result.
+ */
+function runNpm(args, cwd) {
+  if (process.platform === "win32") {
+    return spawnSync("cmd.exe", ["/d", "/s", "/c", "npm", ...args], {
+      cwd,
+      stdio: "inherit",
+    });
+  }
+
+  return spawnSync("npm", args, {
+    cwd,
+    stdio: "inherit",
+  });
+}
+
+/**
  * Install the devcontainers CLI into a user-level cache when it is missing.
  * @param {string} repoRoot - Repository root to inspect.
  * @returns {{ cacheDir: string, cliJs: string, version: string }} Cache paths.
@@ -73,9 +94,7 @@ export function ensureDevcontainerCliCache(repoRoot = defaultRepoRoot) {
   }
 
   fs.mkdirSync(cache.cacheDir, { recursive: true });
-  const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
-  const result = spawnSync(
-    npmBin,
+  const result = runNpm(
     [
       "install",
       "--prefix",
@@ -85,10 +104,7 @@ export function ensureDevcontainerCliCache(repoRoot = defaultRepoRoot) {
       "--no-audit",
       "--fund=false",
     ],
-    {
-      cwd: repoRoot,
-      stdio: "inherit",
-    }
+    repoRoot
   );
   if (result.error) {
     throw result.error;


### PR DESCRIPTION
## Summary
- avoid spawning `npm.cmd` directly from the Codex local setup hook on Windows
- call the Codex worktree environment script through `node` for automatic devcontainer startup
- route the first-time devcontainer CLI cache install through `cmd.exe /d /s /c npm ...` on Windows so fresh hosts do not hit the same `spawnSync npm.cmd EINVAL` failure

## Validation
- reproduced `spawnSync npm.cmd EINVAL` with a minimal Node spawn on Windows
- `node --check .codex/local-environment.setup.mjs`
- `node --check scripts/devcontainer-cli-cache.mjs`
- `node .codex/local-environment.setup.mjs`
- isolated first-time cache install with `CALIBRATE_TOOL_CACHE=.tmp-devcontainer-cli-cache-test node scripts/devcontainer-cli-cache.mjs`