### PR TITLE
[codex] Speed up dev setup hot paths

### DIFF
--- a/.devcontainer/init-devcontainer-env.mjs
+++ b/.devcontainer/init-devcontainer-env.mjs
@@ -169,10 +169,10 @@ function buildNodeModulesVolumeName(packageName, lockfileRelativePath) {
   const manifestPath = path.join(path.dirname(lockfilePath), "package.json");
   const hash = crypto.createHash("sha256");
 
-  for (const filePath of [lockfilePath, manifestPath]) {
-    if (fs.existsSync(filePath)) {
-      hash.update(fs.readFileSync(filePath));
-    }
+  if (fs.existsSync(lockfilePath)) {
+    hash.update(fs.readFileSync(lockfilePath));
+  } else if (fs.existsSync(manifestPath)) {
+    hash.update(fs.readFileSync(manifestPath));
   }
 
   hash.update(`node-${process.versions.node.split(".")[0]}`);

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "db:migrate:dev": "prisma migrate dev",
     "db:reset": "prisma migrate reset",
     "db:push:reset": "prisma db push --force-reset",
-    "db:seed": "ts-node prisma/seed.ts",
+    "db:seed": "ts-node --transpile-only prisma/seed.ts",
     "db:studio": "prisma studio",
     "prisma:generate": "prisma generate",
     "start": "node dist/backend/src/index.js",

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,4 +1,4 @@
-import prisma from '../src/config/database';
+import { disconnectDatabase } from '../src/config/database';
 import { seedDevTestData } from '../src/services/devTestData';
 
 /**
@@ -8,7 +8,7 @@ import { seedDevTestData } from '../src/services/devTestData';
  * deterministic dev user and backfills several months of sample metrics.
  */
 const run = async (): Promise<void> => {
-  await seedDevTestData();
+  await seedDevTestData({ logTimings: true });
 };
 
 run()
@@ -17,5 +17,5 @@ run()
     process.exitCode = 1;
   })
   .finally(async () => {
-    await prisma.$disconnect();
+    await disconnectDatabase();
   });

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -22,4 +22,15 @@ const adapter = new PrismaPg(pgPool, { schema: prismaSchema });
 
 const prisma = new PrismaClient({ adapter });
 
+/**
+ * Close both Prisma and the owned node-postgres pool used by the Prisma adapter.
+ *
+ * Prisma does not own the pg Pool lifecycle when a driver adapter is supplied, so
+ * short-lived CLI scripts must close both handles or Node waits for the pool idle timeout.
+ */
+export async function disconnectDatabase(): Promise<void> {
+  await prisma.$disconnect();
+  await pgPool.end();
+}
+
 export default prisma;

--- a/backend/src/services/devTestData.ts
+++ b/backend/src/services/devTestData.ts
@@ -1,4 +1,3 @@
-import bcrypt from 'bcryptjs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import prisma from '../config/database';
@@ -17,7 +16,8 @@ import { refreshMaterializedWeightTrendsBestEffort } from './materializedWeightT
  * Deterministic dev seed data helpers (test user, goals, metrics, food logs).
  */
 const TEST_USER_EMAIL = 'test@calibratehealth.app';
-const TEST_USER_PASSWORD = 'password123';
+// Precomputed bcrypt hash for the deterministic dev password, "password123".
+const TEST_USER_PASSWORD_HASH = '$2b$10$24sOV1l/uVCwMwPmB4.2X.K6q10fTODGqeX7xEILbzcoM0zIgAwFC';
 const TEST_USER_TIMEZONE = 'America/Los_Angeles';
 
 const TEST_USER_DATE_OF_BIRTH = new Date('1990-01-15T00:00:00');
@@ -32,6 +32,10 @@ const PROFILE_PLACEHOLDER_IMAGE_MIME_TYPE = 'image/png';
 type SeedProfileImage = {
   mimeType: string;
   bytes: Uint8Array<ArrayBuffer>;
+};
+
+type SeedDevTestDataOptions = {
+  logTimings?: boolean;
 };
 
 let cachedProfilePlaceholderImage: SeedProfileImage | null | undefined;
@@ -59,10 +63,30 @@ const loadProfilePlaceholderImage = async (): Promise<SeedProfileImage | null> =
 };
 
 /**
+ * Optionally time seed phases when the standalone Prisma seed command is running.
+ */
+async function timedSeedPhase<T>(
+  options: SeedDevTestDataOptions,
+  label: string,
+  task: () => Promise<T>
+): Promise<T> {
+  if (!options.logTimings) {
+    return task();
+  }
+
+  const startedAt = Date.now();
+  try {
+    return await task();
+  } finally {
+    const elapsedSeconds = ((Date.now() - startedAt) / 1000).toFixed(1);
+    console.log(`[seed] ${label} finished in ${elapsedSeconds}s`);
+  }
+}
+
+/**
  * Ensure a deterministic test user exists (and always has the expected password).
  */
 const ensureTestUser = async (createdAt: Date): Promise<{ id: number }> => {
-  const passwordHash = await bcrypt.hash(TEST_USER_PASSWORD, 10);
   const placeholderImage = await loadProfilePlaceholderImage();
   const placeholderImageData = placeholderImage
     ? { profile_image: placeholderImage.bytes, profile_image_mime_type: placeholderImage.mimeType }
@@ -72,7 +96,7 @@ const ensureTestUser = async (createdAt: Date): Promise<{ id: number }> => {
     where: { email: TEST_USER_EMAIL },
     create: {
       email: TEST_USER_EMAIL,
-      password_hash: passwordHash,
+      password_hash: TEST_USER_PASSWORD_HASH,
       created_at: createdAt,
       timezone: TEST_USER_TIMEZONE,
       language: SUPPORTED_LANGUAGES.EN,
@@ -87,7 +111,7 @@ const ensureTestUser = async (createdAt: Date): Promise<{ id: number }> => {
     update: {
       // Keep the dev user deterministic so "invalid credentials" doesn't happen
       // if the account already existed with a different password.
-      password_hash: passwordHash,
+      password_hash: TEST_USER_PASSWORD_HASH,
       created_at: createdAt,
       timezone: TEST_USER_TIMEZONE,
       language: SUPPORTED_LANGUAGES.EN,
@@ -149,37 +173,49 @@ const ensureBodyMetrics = async (userId: number, days: Date[]): Promise<boolean>
  * Create daily food logs for the past week without duplicating existing entries.
  */
 const ensureFoodLogs = async (userId: number, days: Date[]): Promise<void> => {
-  for (const [dayIndex, day] of days.entries()) {
-    const existingCount = await prisma.foodLog.count({
-      where: {
-        user_id: userId,
-        local_date: day,
-      },
-    });
-    if (existingCount > 0) continue;
+  const existingLogs = await prisma.foodLog.findMany({
+    where: {
+      user_id: userId,
+      local_date: { in: days },
+    },
+    select: { local_date: true },
+  });
+  const existingDateKeys = new Set(existingLogs.map((log) => log.local_date.toISOString().slice(0, 10)));
+  const missingLogs = days.flatMap((day, dayIndex) => {
+    if (existingDateKeys.has(day.toISOString().slice(0, 10))) {
+      return [];
+    }
 
-    await prisma.foodLog.createMany({
-      data: buildMealLogsForDay(userId, day, dayIndex),
-    });
+    return buildMealLogsForDay(userId, day, dayIndex);
+  });
+
+  if (missingLogs.length > 0) {
+    await prisma.foodLog.createMany({ data: missingLogs });
   }
 };
 
 /**
  * Seed the local database with a deterministic test user and sample tracking history.
  */
-export const seedDevTestData = async (): Promise<void> => {
+export const seedDevTestData = async (options: SeedDevTestDataOptions = {}): Promise<void> => {
+  const startedAt = Date.now();
   const metricDays = getPastDateRangeDates(TEST_USER_TIMEZONE, TEST_METRIC_HISTORY_DAYS);
   const foodLogDays = getPastWeekDates(TEST_USER_TIMEZONE);
   const createdAt = getSeedUserCreatedAt(metricDays, TEST_USER_TIMEZONE);
 
-  const user = await ensureTestUser(createdAt);
+  const user = await timedSeedPhase(options, 'user', () => ensureTestUser(createdAt));
 
-  await ensureTestGoal(user.id);
-  const createdBodyMetrics = await ensureBodyMetrics(user.id, metricDays);
+  await timedSeedPhase(options, 'goal', () => ensureTestGoal(user.id));
+  const createdBodyMetrics = await timedSeedPhase(options, 'body metrics', () => ensureBodyMetrics(user.id, metricDays));
   if (createdBodyMetrics) {
-    await refreshMaterializedWeightTrendsBestEffort(user.id);
+    await timedSeedPhase(options, 'weight trends', () => refreshMaterializedWeightTrendsBestEffort(user.id));
   }
-  await ensureFoodLogs(user.id, foodLogDays);
+  await timedSeedPhase(options, 'food logs', () => ensureFoodLogs(user.id, foodLogDays));
+
+  if (options.logTimings) {
+    const elapsedSeconds = ((Date.now() - startedAt) / 1000).toFixed(1);
+    console.log(`[seed] DONE: Dev seed data is ready in ${elapsedSeconds}s.`);
+  }
 };
 
 /**

--- a/scripts/dev-env.mjs
+++ b/scripts/dev-env.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -35,6 +35,8 @@ const packages = [
     ],
   },
 ];
+const packageLockHashCache = new Map();
+let cachedNpmVersion = null;
 
 /**
  * Run a subprocess and inherit stdio so Codex actions show useful logs.
@@ -54,6 +56,34 @@ function run(command, args, options = {}) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+/**
+ * Run a subprocess asynchronously and inherit stdio so parallel setup work can overlap.
+ * @param {string} command - Executable to run.
+ * @param {string[]} args - Command arguments.
+ * @param {{ cwd?: string }} options - Spawn options.
+ * @returns {Promise<void>} Resolves when the command exits successfully.
+ */
+function runAsync(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const suffix = signal ? `signal ${signal}` : `exit code ${code ?? 1}`;
+      reject(new Error(`${command} ${args.join(" ")} failed with ${suffix}.`));
+    });
+  });
 }
 
 /**
@@ -98,6 +128,18 @@ function readCommand(command, args) {
 }
 
 /**
+ * Return the npm version once per process for dependency-cache metadata.
+ * @returns {string} npm version, or "unknown-npm" when unavailable.
+ */
+function npmVersion() {
+  if (cachedNpmVersion === null) {
+    cachedNpmVersion = readCommand("npm", ["--version"]) || "unknown-npm";
+  }
+
+  return cachedNpmVersion;
+}
+
+/**
  * Time a setup phase and print a compact duration line.
  * @template T
  * @param {string} label - Phase label.
@@ -139,17 +181,26 @@ function sleep(ms) {
  * @returns {string} Short hash for the package lock.
  */
 function packageLockHash(packageDirectory) {
+  const cached = packageLockHashCache.get(packageDirectory);
+  if (cached) {
+    return cached;
+  }
+
   const lockPath = path.join(packageDirectory, "package-lock.json");
   const manifestPath = path.join(packageDirectory, "package.json");
   const hash = crypto.createHash("sha256");
-  for (const filePath of [lockPath, manifestPath]) {
-    if (fs.existsSync(filePath)) {
-      hash.update(fs.readFileSync(filePath));
-    }
+
+  if (fs.existsSync(lockPath)) {
+    hash.update(fs.readFileSync(lockPath));
+  } else if (fs.existsSync(manifestPath)) {
+    hash.update(fs.readFileSync(manifestPath));
   }
+
   hash.update(process.versions.node.split(".")[0]);
-  hash.update(readCommand("npm", ["--version"]).split(".")[0] || "unknown-npm");
-  return hash.digest("hex").slice(0, 16);
+  hash.update(npmVersion().split(".")[0] || "unknown-npm");
+  const digest = hash.digest("hex").slice(0, 16);
+  packageLockHashCache.set(packageDirectory, digest);
+  return digest;
 }
 
 /**
@@ -159,6 +210,24 @@ function packageLockHash(packageDirectory) {
  */
 function installSentinelPath(packageDirectory) {
   return path.join(packageDirectory, "node_modules", ".calibrate-install-complete.json");
+}
+
+/**
+ * Read the dependency install sentinel from a shared node_modules volume.
+ * @param {string} packageDirectory - Package directory.
+ * @returns {Record<string, unknown> | null} Sentinel data when present and valid.
+ */
+function readInstallSentinel(packageDirectory) {
+  const sentinelPath = installSentinelPath(packageDirectory);
+  if (!fs.existsSync(sentinelPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(sentinelPath, "utf8"));
+  } catch (error) {
+    return null;
+  }
 }
 
 /**
@@ -182,21 +251,50 @@ function installLockDirectory(packageDirectory) {
  * @returns {boolean} True when install can be skipped.
  */
 function hasCurrentInstall(packageConfig) {
-  const sentinelPath = installSentinelPath(packageConfig.directory);
-  if (!fs.existsSync(sentinelPath)) {
-    return false;
+  return dependencyInstallStatus(packageConfig).current;
+}
+
+/**
+ * Describe whether a package's shared node_modules volume matches the current lockfile/runtime.
+ * @param {{ name: string, directory: string, installArgs: string[] }} packageConfig - Package config.
+ * @returns {{ current: boolean, reason: string }} Install-cache status.
+ */
+function dependencyInstallStatus(packageConfig) {
+  const sentinel = readInstallSentinel(packageConfig.directory);
+  if (!sentinel) {
+    return {
+      current: false,
+      reason: "no install sentinel was found in the shared node_modules volume",
+    };
   }
 
-  try {
-    const sentinel = JSON.parse(fs.readFileSync(sentinelPath, "utf8"));
-    return (
-      sentinel.package === packageConfig.name &&
-      sentinel.lockHash === packageLockHash(packageConfig.directory) &&
-      sentinel.installCommand === `npm ${packageConfig.installArgs.join(" ")}`
-    );
-  } catch (error) {
-    return false;
+  if (sentinel.package !== packageConfig.name) {
+    return {
+      current: false,
+      reason: `install sentinel belongs to ${String(sentinel.package) || "another package"}`,
+    };
   }
+
+  const expectedLockHash = packageLockHash(packageConfig.directory);
+  if (sentinel.lockHash !== expectedLockHash) {
+    return {
+      current: false,
+      reason: `lockfile/runtime hash changed (${String(sentinel.lockHash) || "missing"} -> ${expectedLockHash})`,
+    };
+  }
+
+  const expectedCommand = `npm ${packageConfig.installArgs.join(" ")}`;
+  if (sentinel.installCommand !== expectedCommand) {
+    return {
+      current: false,
+      reason: `install command changed (${String(sentinel.installCommand) || "missing"} -> ${expectedCommand})`,
+    };
+  }
+
+  return {
+    current: true,
+    reason: "shared node_modules volume cache hit",
+  };
 }
 
 /**
@@ -209,7 +307,7 @@ function writeInstallSentinel(packageConfig) {
     lockHash: packageLockHash(packageConfig.directory),
     installCommand: `npm ${packageConfig.installArgs.join(" ")}`,
     node: process.versions.node,
-    npm: readCommand("npm", ["--version"]),
+    npm: npmVersion(),
     installedAt: new Date().toISOString(),
   };
   fs.writeFileSync(installSentinelPath(packageConfig.directory), `${JSON.stringify(sentinel, null, 2)}\n`);
@@ -264,19 +362,23 @@ async function acquireInstallLock(packageConfig) {
  * @param {{ name: string, directory: string, installArgs: string[] }} packageConfig - Package config.
  */
 async function ensurePackageDependencies(packageConfig) {
-  if (hasCurrentInstall(packageConfig)) {
-    console.log(`[dev-env] ${packageConfig.name} dependencies are current.`);
+  const initialStatus = dependencyInstallStatus(packageConfig);
+  if (initialStatus.current) {
+    console.log(`[dev-env] ${packageConfig.name} dependencies are current (${initialStatus.reason}).`);
     return;
   }
 
+  console.log(`[dev-env] ${packageConfig.name} dependency cache miss: ${initialStatus.reason}.`);
   const release = await acquireInstallLock(packageConfig);
   try {
-    if (hasCurrentInstall(packageConfig)) {
-      console.log(`[dev-env] ${packageConfig.name} dependencies are current.`);
+    const lockedStatus = dependencyInstallStatus(packageConfig);
+    if (lockedStatus.current) {
+      console.log(`[dev-env] ${packageConfig.name} dependencies are current (${lockedStatus.reason}).`);
       return;
     }
 
-    run("npm", packageConfig.installArgs, { cwd: packageConfig.directory });
+    console.log(`[dev-env] Installing ${packageConfig.name} dependencies: npm ${packageConfig.installArgs.join(" ")}`);
+    await runAsync("npm", packageConfig.installArgs, { cwd: packageConfig.directory });
     writeInstallSentinel(packageConfig);
   } finally {
     release();
@@ -294,9 +396,11 @@ async function ensureDependencies() {
   }
 
   await timed("Install dependencies", async () => {
-    for (const packageConfig of packages) {
-      await ensurePackageDependencies(packageConfig);
-    }
+    await Promise.all(
+      packages.map((packageConfig) =>
+        timed(`${packageConfig.name} dependencies`, () => ensurePackageDependencies(packageConfig))
+      )
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- speed up standalone dev database seeding by closing the owned `pg.Pool` after Prisma disconnects
- avoid repeated bcrypt work for the fixed dev seed user by using a precomputed dev-only password hash
- batch food-log seed checks/inserts and add seed phase timing output
- run backend/frontend dependency installs in parallel and print per-package cache-hit/cache-miss timings
- key shared `node_modules` volumes and install sentinels from lockfiles rather than script-only `package.json` changes

## Benchmark Data
Seed benchmark, isolated fresh Postgres schema in the devcontainer:
- Before closing the adapter-owned `pg.Pool`: seed logic reported `0.2s`, but the full `db:seed` command took `10.8s` because Node waited for the pool idle timeout.
- After closing both Prisma and `pgPool`: seed logic still reported `0.2s`, and the full `db:seed` command took `711ms`.

Dependency setup benchmark:
- First run after the cache-key change reinstalled both shared volumes once: backend `8.1s`, frontend `23.9s`, total dependency phase `24.0s` because installs now run in parallel.
- Warm rerun with both shared `node_modules` volumes current: backend cache hit, frontend cache hit, total dependency phase `0.1s`.

User worktree smoke test after these changes:
- First worktree setup paid the cold frontend dependency cost: dependency phase `21.4s`, Prisma generate `1.0s`, migrate `1.5s`, seed `0.8s`.
- Second worktree with warm dependency volumes: dependency phase `0.1s`, Prisma generate `0.9s`, migrate `1.4s`, seed `0.9s`; setup preflight after container start was roughly `3.3s`.

## Validation
- `node --check scripts/dev-env.mjs`
- `node --check .devcontainer/init-devcontainer-env.mjs`
- `npm.cmd exec tsc -- -p tsconfig.build.json --noEmit` from `backend/`
- isolated fresh-schema seed benchmark inside devcontainer
- dependency setup cold/warm benchmark inside devcontainer
- `npm.cmd --prefix backend test` passed: 240/240