### PR TITLE
[codex] Upgrade frontend to MUI v9

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^7.3.5",
-        "@mui/material": "^7.3.5",
-        "@mui/x-charts": "^7.0.0",
+        "@mui/icons-material": "^9.0.0",
+        "@mui/material": "^9.0.0",
+        "@mui/x-charts": "^9.0.2",
         "@tanstack/react-query": "^5.90.10",
         "@zxing/library": "^0.21.3",
         "axios": "^1.13.2",
@@ -1502,9 +1502,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2048,9 +2048,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.5.tgz",
-      "integrity": "sha512-kOLwlcDPnVz2QMhiBv0OQ8le8hTCqKM9cRXlfVPL91l3RGeOsxrIhNRsUt3Xb8wb+pTVUolW+JXKym93vRKxCw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.0.tgz",
+      "integrity": "sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2058,12 +2058,12 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.5.tgz",
-      "integrity": "sha512-LciL1GLMZ+VlzyHAALSVAR22t8IST4LCXmljcUSx2NOutgO2XnxdIp8ilFbeNf9wpo0iUFbAuoQcB7h+HHIf3A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.0.tgz",
+      "integrity": "sha512-oDwyvI6LgjWRC9MBcSGvLkPud9S9ELgSBQFYxa1rYcZn6Br55dn22SyvsPDMsn0G8OndFk53iMT45W5mNqrogw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4"
+        "@babel/runtime": "^7.29.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2073,7 +2073,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^7.3.5",
+        "@mui/material": "^9.0.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -2084,22 +2084,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.5.tgz",
-      "integrity": "sha512-8VVxFmp1GIm9PpmnQoCoYo0UWHoOrdA57tDL62vkpzEgvb/d71Wsbv4FRg7r1Gyx7PuSo0tflH34cdl/NvfHNQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.0.tgz",
+      "integrity": "sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/core-downloads-tracker": "^7.3.5",
-        "@mui/system": "^7.3.5",
-        "@mui/types": "^7.4.8",
-        "@mui/utils": "^7.3.5",
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.0.0",
+        "@mui/system": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.0",
+        "react-is": "^19.2.4",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -2112,7 +2112,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.5",
+        "@mui/material-pigment-css": "^9.0.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2133,13 +2133,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.5.tgz",
-      "integrity": "sha512-cTx584W2qrLonwhZLbEN7P5pAUu0nZblg8cLBlTrZQ4sIiw8Fbvg7GvuphQaSHxPxrCpa7FDwJKtXdbl2TSmrA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.0.tgz",
+      "integrity": "sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.0.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -2160,16 +2160,16 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.5.tgz",
-      "integrity": "sha512-zbsZ0uYYPndFCCPp2+V3RLcAN6+fv4C8pdwRx6OS3BwDkRCN8WBehqks7hWyF3vj1kdQLIWrpdv/5Y0jHRxYXQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.29.2",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.1.3",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -2194,18 +2194,18 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.5.tgz",
-      "integrity": "sha512-yPaf5+gY3v80HNkJcPi6WT+r9ebeM4eJzrREXPxMt7pNTV/1eahyODO4fbH3Qvd8irNxDFYn5RQ3idHW55rA6g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.0.tgz",
+      "integrity": "sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/private-theming": "^7.3.5",
-        "@mui/styled-engine": "^7.3.5",
-        "@mui/types": "^7.4.8",
-        "@mui/utils": "^7.3.5",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.0.0",
+        "@mui/styled-engine": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.0",
         "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -2234,12 +2234,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.8.tgz",
-      "integrity": "sha512-ZNXLBjkPV6ftLCmmRCafak3XmSn8YV0tKE/ZOhzKys7TZXUiE0mZxlH8zKDo6j6TTUaDnuij68gIG+0Ucm7Xhw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2251,17 +2251,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.5.tgz",
-      "integrity": "sha512-jisvFsEC3sgjUjcPnR4mYfhzjCDIudttSGSbe1o/IXFNu0kZuR+7vqQI0jg8qtcVZBHWrwTfvAZj9MNMumcq1g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
+      "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/types": "^7.4.8",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.0"
+        "react-is": "^19.2.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2281,19 +2281,21 @@
       }
     },
     "node_modules/@mui/x-charts": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-7.29.1.tgz",
-      "integrity": "sha512-5s9PX51HWhpMa+DCDa4RgjtODSaMe+PlTZUqoGIil2vaW/+4ouDLREXvyuVvIF93KfZwrPKAL2SJKSQS4YYB2w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-9.0.2.tgz",
+      "integrity": "sha512-bKgjGD+uJbDN/g7tMjVmlNdm+iM4UkCJoYruQmgpQ0l+cip8Kn4kmn1iD//rZ35an+LdWaUZ4MHvMzV76D6EJw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
-        "@mui/x-charts-vendor": "7.20.0",
-        "@mui/x-internals": "7.29.0",
-        "@react-spring/rafz": "^9.7.5",
-        "@react-spring/web": "^9.7.5",
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "9.0.0",
+        "@mui/x-charts-vendor": "^9.0.0",
+        "@mui/x-internal-gestures": "^9.0.2",
+        "@mui/x-internals": "^9.0.0",
+        "bezier-easing": "^2.1.0",
         "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
+        "prop-types": "^15.8.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2301,8 +2303,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -2316,96 +2318,55 @@
       }
     },
     "node_modules/@mui/x-charts-vendor": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-7.20.0.tgz",
-      "integrity": "sha512-pzlh7z/7KKs5o0Kk0oPcB+sY0+Dg7Q7RzqQowDQjpy5Slz6qqGsgOB5YUzn0L+2yRmvASc4Pe0914Ao3tMBogg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-9.0.0.tgz",
+      "integrity": "sha512-Do91i+fZiNj/4LN5oaGpJoutolzDBDwdfw6tHrx2LKXDMCRlaImCfreLbdbkk7dFsi9fuIP7hWiMV4vDJKPJTA==",
       "license": "MIT AND ISC",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
+        "@babel/runtime": "^7.28.6",
+        "@types/d3-array": "^3.2.2",
         "@types/d3-color": "^3.1.3",
-        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-format": "^3.0.4",
         "@types/d3-interpolate": "^3.0.4",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-shape": "^3.1.6",
-        "@types/d3-time": "^3.0.3",
+        "@types/d3-path": "^3.1.1",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-shape": "^3.1.8",
+        "@types/d3-time": "^3.0.4",
+        "@types/d3-time-format": "^4.0.3",
+        "@types/d3-timer": "^3.0.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-delaunay": "^6.0.4",
+        "d3-format": "^3.1.2",
         "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
         "d3-scale": "^4.0.2",
         "d3-shape": "^3.2.0",
         "d3-time": "^3.1.0",
-        "delaunator": "^5.0.1",
-        "robust-predicates": "^3.0.2"
+        "d3-time-format": "^4.1.0",
+        "d3-timer": "^3.0.1",
+        "flatqueue": "^3.0.0",
+        "internmap": "^2.0.3"
       }
     },
-    "node_modules/@mui/x-charts/node_modules/@react-spring/web": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
-      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+    "node_modules/@mui/x-internal-gestures": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-9.0.2.tgz",
+      "integrity": "sha512-xCp99a7cSb7iH1bj4G524ooMOFe92H8m/rONCUiKyj7LvV1YUGzTfHgJysQgDCZJqHYaW7YAGLvwMUyEMZVzqQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/core": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@mui/x-charts/node_modules/@react-spring/web/node_modules/@react-spring/animated": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
-      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@mui/x-charts/node_modules/@react-spring/web/node_modules/@react-spring/core": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
-      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-spring/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@mui/x-charts/node_modules/@react-spring/web/node_modules/@react-spring/shared": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
-      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/rafz": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@babel/runtime": "^7.28.6"
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
-      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.0.0.tgz",
+      "integrity": "sha512-E/4rdg69JjhyybpPGypCjAKSKLLnSdCFM+O6P/nkUg47+qt3uftxQEhjQO53rcn6ahHl6du/uNZ9BLgeY6kYxQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "9.0.0",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2492,18 +2453,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
-    },
-    "node_modules/@react-spring/rafz": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
-      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/types": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
-      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
-      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -2886,16 +2835,22 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -2923,9 +2878,9 @@
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -2935,6 +2890,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3583,6 +3550,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3917,22 +3890,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4007,6 +3968,15 @@
       "dependencies": {
         "d3-time": "1 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -4133,15 +4103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -4750,6 +4711,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.0.0.tgz",
+      "integrity": "sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==",
+      "license": "ISC"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -6773,9 +6740,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
     "node_modules/react-router": {
@@ -6980,6 +6947,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -7019,12 +6992,6 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "license": "Unlicense"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
@@ -8161,6 +8128,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^7.3.5",
-    "@mui/material": "^7.3.5",
-    "@mui/x-charts": "^7.0.0",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
+    "@mui/x-charts": "^9.0.2",
     "@tanstack/react-query": "^5.90.10",
     "@zxing/library": "^0.21.3",
     "axios": "^1.13.2",

--- a/frontend/src/components/AccountSecurityCard.tsx
+++ b/frontend/src/components/AccountSecurityCard.tsx
@@ -165,7 +165,9 @@ const AccountSecurityCard: React.FC<Props> = ({
 
                 <Stack spacing={2}>
                     <Stack spacing={1.5}>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('account.email')}
                         </Typography>
                         <Box
@@ -193,7 +195,6 @@ const AccountSecurityCard: React.FC<Props> = ({
                     </Button>
                 </Stack>
             </AppCard>
-
             <Dialog
                 open={isPasswordDialogOpen}
                 onClose={handlePasswordDialogClose}
@@ -230,9 +231,11 @@ const AccountSecurityCard: React.FC<Props> = ({
                             onChange={(e) => setNewPassword(e.target.value)}
                             helperText={t('account.passwordHint', { min: MIN_PASSWORD_LENGTH })}
                             disabled={isChangingPassword}
-                            inputProps={{ minLength: MIN_PASSWORD_LENGTH }}
                             required
                             fullWidth
+                            slotProps={{
+                                htmlInput: { minLength: MIN_PASSWORD_LENGTH }
+                            }}
                         />
 
                         <TextField
@@ -242,9 +245,11 @@ const AccountSecurityCard: React.FC<Props> = ({
                             value={confirmPassword}
                             onChange={(e) => setConfirmPassword(e.target.value)}
                             disabled={isChangingPassword}
-                            inputProps={{ minLength: MIN_PASSWORD_LENGTH }}
                             required
                             fullWidth
+                            slotProps={{
+                                htmlInput: { minLength: MIN_PASSWORD_LENGTH }
+                            }}
                         />
                     </Stack>
                 </DialogContent>

--- a/frontend/src/components/BarcodeScannerDialog.tsx
+++ b/frontend/src/components/BarcodeScannerDialog.tsx
@@ -395,7 +395,9 @@ const BarcodeScannerDialog: React.FC<Props> = ({ open, onClose, onDetected }) =>
             <DialogTitle>Scan UPC Barcode</DialogTitle>
             <DialogContent>
                 <Stack spacing={2}>
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         Align the barcode within the frame. If scanning is unavailable, enter the UPC/EAN digits
                         manually.
                     </Typography>
@@ -448,12 +450,14 @@ const BarcodeScannerDialog: React.FC<Props> = ({ open, onClose, onDetected }) =>
                             fullWidth
                             value={manualBarcode}
                             onChange={(event) => setManualBarcode(event.target.value)}
-                            inputProps={{ inputMode: 'numeric' }}
                             onKeyDown={(event) => {
                                 if (event.key === 'Enter') {
                                     event.preventDefault();
                                     submitBarcode(manualBarcode);
                                 }
+                            }}
+                            slotProps={{
+                                htmlInput: { inputMode: 'numeric' }
                             }}
                         />
                         <Button

--- a/frontend/src/components/CalorieTargetBanner.tsx
+++ b/frontend/src/components/CalorieTargetBanner.tsx
@@ -85,7 +85,9 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
                 <Box>
                     <Typography variant="body2">{t('calorieTarget.breakdown.bmr.title')}</Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography variant="caption" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('calorieTarget.breakdown.bmr.caption')}
                     </Typography>
                 </Box>
@@ -99,7 +101,9 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
                 <Box>
                     <Typography variant="body2">{t('calorieTarget.breakdown.activity.title')}</Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography variant="caption" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('calorieTarget.breakdown.activity.caption', {
                             level: activityLevelTitle ?? '—',
                             multiplier: activityMultiplier ?? '—'
@@ -116,7 +120,9 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
                 <Box>
                     <Typography variant="body2">{t('calorieTarget.breakdown.goal.title')}</Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography variant="caption" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('calorieTarget.breakdown.goal.caption')}
                     </Typography>
                 </Box>
@@ -133,10 +139,19 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
                 </Typography>
             </Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                <Typography variant="body2" fontWeight={600}>
+                <Typography variant="body2" sx={{
+                    fontWeight: 600
+                }}>
                     {t('calorieTarget.breakdown.target.title')}
                 </Typography>
-                <Typography variant="body2" fontWeight={600} color="text.primary" sx={{ textAlign: 'right', minWidth: 96 }}>
+                <Typography
+                    variant="body2"
+                    sx={{
+                        fontWeight: 600,
+                        color: "text.primary",
+                        textAlign: 'right',
+                        minWidth: 96
+                    }}>
                     {dailyTarget !== undefined ? `${Math.round(dailyTarget)} kcal` : '—'}
                 </Typography>
             </Box>
@@ -166,7 +181,9 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
                         </Typography>
                     )}
                     {missing.some((field) => field !== 'latest_weight') && (
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('calorieTarget.missing.fillProfileHint')}
                         </Typography>
                     )}
@@ -211,7 +228,9 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
                 <Typography variant="h4" color="primary">
                     {Math.round(dailyTarget!)} kcal/day
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     {t('calorieTarget.summaryLine', { tdee: tdee ?? '—', deficit: deficit ?? '—' })}
                     {!isDashboard && (
                         <>
@@ -270,7 +289,12 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
                 </AccordionSummary>
                 <AccordionDetails>
                     <Box sx={{ maxWidth: INLINE_DETAILS_MAX_WIDTH_PX }}>
-                        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mb: 1
+                            }}>
                             {t('calorieTarget.details.accordionCaption')}
                         </Typography>
                         {breakdownDetails}
@@ -308,7 +332,9 @@ const CalorieTargetBanner: React.FC<CalorieTargetBannerProps> = ({ isDashboard =
                 {cardBody}
 
                 {!hasTarget && !isLoading && !isError && missing.length > 0 && (
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('calorieTarget.missingFieldsLine', { fields: missing.join(', ') })}
                     </Typography>
                 )}

--- a/frontend/src/components/FoodEntryForm.tsx
+++ b/frontend/src/components/FoodEntryForm.tsx
@@ -504,7 +504,9 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
         }
 
         searchResultsContent = (
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{
+                color: "text.secondary"
+            }}>
                 {emptyMessage}
             </Typography>
         );
@@ -521,7 +523,9 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                     onLoadMore={() => void loadMoreSearchResults()}
                     onSelect={selectSearchResult}
                 />
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" sx={{
+                    color: "text.secondary"
+                }}>
                     {t('foodEntry.search.results.tapHint')}
                 </Typography>
             </Stack>
@@ -583,11 +587,15 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                     value={quantity}
                     onChange={(e) => setQuantity(parseFloat(e.target.value) || 0)}
                     disabled={!selectedMeasure || isSubmitting}
-                    inputProps={{ min: 0, step: 0.5 }}
+                    slotProps={{
+                        htmlInput: { min: 0, step: 0.5 }
+                    }}
                 />
 
                 <Box>
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {selectedItem.nutrientsPer100g
                             ? t('foodEntry.search.caloriesEstimated')
                             : t('foodEntry.search.caloriesUnavailable')}
@@ -605,7 +613,9 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
         );
     } else {
         searchResultsContent = (
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{
+                color: "text.secondary"
+            }}>
                 {t('foodEntry.search.selectToContinue')}
             </Typography>
         );
@@ -653,25 +663,29 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                         void performFoodSearch({ query: searchQuery });
                                     }
                                 }}
-                                InputProps={{
-                                    endAdornment: canUseBarcodeScanner ? (
-                                        <InputAdornment position="end">
-                                            <IconButton
-                                                aria-label={t('foodEntry.search.scanBarcode')}
-                                                title={t('foodEntry.search.scanBarcode')}
-                                                onClick={() => setIsScannerOpen(true)}
-                                                size="small"
-                                                edge="end"
-                                                disabled={isSearching || isSubmitting}
-                                            >
-                                                <QrCodeScannerIcon />
-                                            </IconButton>
-                                        </InputAdornment>
-                                    ) : undefined
+                                slotProps={{
+                                    input: {
+                                        endAdornment: canUseBarcodeScanner ? (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label={t('foodEntry.search.scanBarcode')}
+                                                    title={t('foodEntry.search.scanBarcode')}
+                                                    onClick={() => setIsScannerOpen(true)}
+                                                    size="small"
+                                                    edge="end"
+                                                    disabled={isSearching || isSubmitting}
+                                                >
+                                                    <QrCodeScannerIcon />
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ) : undefined
+                                    }
                                 }}
                             />
                             {providerName && (
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography variant="caption" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('foodEntry.search.providerLabel', { provider: providerName })}
                                     {providerLookupNote}
                                 </Typography>
@@ -703,7 +717,9 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                             <Stack
                                 direction={{ xs: 'column', sm: 'row' }}
                                 spacing={1}
-                                alignItems={{ xs: 'stretch', sm: 'center' }}
+                                sx={{
+                                    alignItems: { xs: 'stretch', sm: 'center' }
+                                }}
                             >
                                 <Button
                                     variant="outlined"
@@ -715,7 +731,9 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                 </Button>
                             </Stack>
 
-                            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'flex-end' }}>
+                            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{
+                                alignItems: { sm: 'flex-end' }
+                            }}>
                                 <TextField
                                     label={t('foodEntry.myFoods.searchLabel')}
                                     placeholder={t('foodEntry.myFoods.searchPlaceholder')}
@@ -727,18 +745,26 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                             </Stack>
 
                             {myFoodsQuery.isLoading ? (
-                                <Stack direction="row" spacing={1} alignItems="center">
+                                <Stack direction="row" spacing={1} sx={{
+                                    alignItems: "center"
+                                }}>
                                     <CircularProgress size={18} />
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         {t('common.loading')}
                                     </Typography>
                                 </Stack>
                             ) : myFoodsQuery.isError ? (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('foodEntry.myFoods.error.unableToLoad')}
                                 </Typography>
                             ) : myFoods.length === 0 ? (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('foodEntry.myFoods.empty', { newFood: t('foodEntry.myFoods.newFood') })}
                                 </Typography>
                             ) : (
@@ -765,9 +791,10 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                                     <ListItemText
                                                         primary={food.name}
                                                         secondary={secondary}
-                                                        primaryTypographyProps={{ variant: 'body2' }}
-                                                        secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
-                                                    />
+                                                        slotProps={{
+                                                            primary: { variant: 'body2' },
+                                                            secondary: { variant: 'caption', color: 'text.secondary' }
+                                                        }} />
                                                 </ListItemButton>
                                             );
                                         })}
@@ -786,12 +813,16 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                                 value={myFoodServingsConsumed}
                                                 onChange={(e) => setMyFoodServingsConsumed(e.target.value)}
                                                 disabled={isSubmitting}
-                                                inputProps={{ min: 0, step: 0.1 }}
+                                                slotProps={{
+                                                    htmlInput: { min: 0, step: 0.1 }
+                                                }}
                                             />
                                         );
                                     })()}
                                     {myFoodCaloriesPreview !== null && (
-                                        <Typography variant="body2" color="text.secondary">
+                                        <Typography variant="body2" sx={{
+                                            color: "text.secondary"
+                                        }}>
                                             {t('foodEntry.myFoods.caloriesPreview', { calories: myFoodCaloriesPreview })}
                                         </Typography>
                                     )}
@@ -819,7 +850,9 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                             <Stack
                                 direction={{ xs: 'column', sm: 'row' }}
                                 spacing={1}
-                                alignItems={{ xs: 'stretch', sm: 'center' }}
+                                sx={{
+                                    alignItems: { xs: 'stretch', sm: 'center' }
+                                }}
                             >
                                 <Button
                                     variant="outlined"
@@ -841,18 +874,26 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                             />
 
                             {myFoodsQuery.isLoading ? (
-                                <Stack direction="row" spacing={1} alignItems="center">
+                                <Stack direction="row" spacing={1} sx={{
+                                    alignItems: "center"
+                                }}>
                                     <CircularProgress size={18} />
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         {t('common.loading')}
                                     </Typography>
                                 </Stack>
                             ) : myFoodsQuery.isError ? (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('foodEntry.myRecipes.error.unableToLoad')}
                                 </Typography>
                             ) : myFoods.length === 0 ? (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('foodEntry.myRecipes.empty', { newRecipe: t('foodEntry.myRecipes.newRecipe') })}
                                 </Typography>
                             ) : (
@@ -879,9 +920,10 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                                     <ListItemText
                                                         primary={recipe.name}
                                                         secondary={secondary}
-                                                        primaryTypographyProps={{ variant: 'body2' }}
-                                                        secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
-                                                    />
+                                                        slotProps={{
+                                                            primary: { variant: 'body2' },
+                                                            secondary: { variant: 'caption', color: 'text.secondary' }
+                                                        }} />
                                                 </ListItemButton>
                                             );
                                         })}
@@ -900,12 +942,16 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                                 value={myFoodServingsConsumed}
                                                 onChange={(e) => setMyFoodServingsConsumed(e.target.value)}
                                                 disabled={isSubmitting}
-                                                inputProps={{ min: 0, step: 0.1 }}
+                                                slotProps={{
+                                                    htmlInput: { min: 0, step: 0.1 }
+                                                }}
                                             />
                                         );
                                     })()}
                                     {myFoodCaloriesPreview !== null && (
-                                        <Typography variant="body2" color="text.secondary">
+                                        <Typography variant="body2" sx={{
+                                            color: "text.secondary"
+                                        }}>
                                             {t('foodEntry.myFoods.caloriesPreview', { calories: myFoodCaloriesPreview })}
                                         </Typography>
                                     )}
@@ -970,14 +1016,15 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
                                     value={quickEntryCalories}
                                     onChange={(e) => setQuickEntryCalories(e.target.value)}
                                     disabled={isSubmitting}
-                                    inputProps={{ min: 0, step: 1 }}
+                                    slotProps={{
+                                        htmlInput: { min: 0, step: 1 }
+                                    }}
                                 />
                             </Stack>
                         </>
                     )}
                 </Stack>
             </DialogContent>
-
             <DialogActions>
                 {mode === 'myFoods' && (
                     <Button

--- a/frontend/src/components/FoodLogMeals.tsx
+++ b/frontend/src/components/FoodLogMeals.tsx
@@ -386,7 +386,9 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                             {isLoading ? (
                                 <Skeleton width={FOOD_LOG_SKELETON_TOTAL_WIDTH_PX} height={FOOD_LOG_SKELETON_TOTAL_HEIGHT_PX} />
                             ) : (
-                                <Typography color="text.secondary">
+                                <Typography sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('foodLog.totalCalories', { calories: total })}
                                 </Typography>
                             )}
@@ -416,7 +418,9 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                                     ))}
                                 </Stack>
                             ) : entries.length === 0 ? (
-                                <Typography color="text.secondary">{t('foodLog.noEntries')}</Typography>
+                                <Typography sx={{
+                                    color: "text.secondary"
+                                }}>{t('foodLog.noEntries')}</Typography>
                             ) : (
                                 <Stack divider={<Divider flexItem />} spacing={1}>
                                     {entries.map((entry) => (
@@ -434,14 +438,20 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                                                     });
                                                     if (!servingLabel) return null;
                                                     return (
-                                                        <Typography variant="caption" color="text.secondary" noWrap>
+                                                        <Typography variant="caption" noWrap sx={{
+                                                            color: "text.secondary"
+                                                        }}>
                                                             {servingLabel}
                                                         </Typography>
                                                     );
                                                 })()}
                                             </Box>
                                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                                                <Typography color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+                                                <Typography
+                                                    sx={{
+                                                        color: "text.secondary",
+                                                        whiteSpace: 'nowrap'
+                                                    }}>
                                                     {t('foodLog.entryCalories', {
                                                         calories: typeof entry.calories === 'number' ? entry.calories : '-'
                                                     })}
@@ -469,7 +479,6 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                     </Accordion>
                 );
             })}
-
             <Dialog open={!!editEntry} onClose={handleCloseEdit} fullWidth maxWidth="xs">
                 <DialogTitle>{t('foodLog.editDialog.title')}</DialogTitle>
                 <DialogContent>
@@ -487,8 +496,10 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                             type="number"
                             value={editCalories}
                             onChange={(e) => setEditCalories(e.target.value)}
-                            inputProps={{ min: 0, step: 1 }}
                             fullWidth
+                            slotProps={{
+                                htmlInput: { min: 0, step: 1 }
+                            }}
                         />
                         {editEntry?.serving_unit_label_snapshot && (
                             <TextField
@@ -496,8 +507,10 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                                 type="number"
                                 value={editServingsConsumed}
                                 onChange={(e) => setEditServingsConsumed(e.target.value)}
-                                inputProps={{ min: 0, step: 0.1 }}
                                 fullWidth
+                                slotProps={{
+                                    htmlInput: { min: 0, step: 0.1 }
+                                }}
                             />
                         )}
                         <FormControl fullWidth>
@@ -526,7 +539,6 @@ const FoodLogMeals: React.FC<FoodLogMealsProps> = ({ logs, isLoading = false }) 
                     </Button>
                 </DialogActions>
             </Dialog>
-
             <Dialog open={!!deleteEntry} onClose={handleCloseDelete} fullWidth maxWidth="xs">
                 <DialogTitle>{t('foodLog.deleteDialog.title')}</DialogTitle>
                 <DialogContent>

--- a/frontend/src/components/FoodSearchResultsList.tsx
+++ b/frontend/src/components/FoodSearchResultsList.tsx
@@ -117,9 +117,10 @@ const FoodSearchResultsList: React.FC<Props> = ({
                             <ListItemText
                                 primary={item.description}
                                 secondary={secondary || undefined}
-                                primaryTypographyProps={{ variant: 'body2' }}
-                                secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
-                            />
+                                slotProps={{
+                                    primary: { variant: 'body2' },
+                                    secondary: { variant: 'caption', color: 'text.secondary' }
+                                }} />
                         </ListItemButton>
                     );
                 })}
@@ -135,9 +136,13 @@ const FoodSearchResultsList: React.FC<Props> = ({
                     }}
                 >
                     {isLoadingMore ? (
-                        <Stack direction="row" spacing={1} alignItems="center">
+                        <Stack direction="row" spacing={1} sx={{
+                            alignItems: "center"
+                        }}>
                             <CircularProgress size={18} />
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography variant="caption" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Loading more...
                             </Typography>
                         </Stack>
@@ -146,7 +151,9 @@ const FoodSearchResultsList: React.FC<Props> = ({
                             Load more
                         </Button>
                     ) : (
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography variant="caption" sx={{
+                            color: "text.secondary"
+                        }}>
                             End of results
                         </Typography>
                     )}

--- a/frontend/src/components/GoalEditor.tsx
+++ b/frontend/src/components/GoalEditor.tsx
@@ -175,9 +175,11 @@ const GoalEditor: React.FC<GoalEditorProps> = ({
                         setStartWeightInput(e.target.value);
                         setAlert(null);
                     }}
-                    inputProps={{ step: 0.1 }}
                     required
                     fullWidth
+                    slotProps={{
+                        htmlInput: { step: 0.1 }
+                    }}
                 />
                 <TextField
                     label={t('goalEditor.targetWeightLabel', { unit: weightUnitLabel })}
@@ -187,9 +189,11 @@ const GoalEditor: React.FC<GoalEditorProps> = ({
                         setTargetWeightInput(e.target.value);
                         setAlert(null);
                     }}
-                    inputProps={{ step: 0.1 }}
                     required
                     fullWidth
+                    slotProps={{
+                        htmlInput: { step: 0.1 }
+                    }}
                 />
 
                 <FormControl fullWidth>
@@ -242,7 +246,6 @@ const GoalEditor: React.FC<GoalEditorProps> = ({
                     </Button>
                 </Box>
             </Stack>
-
             {alert && (
                 <Alert severity={alert.severity} sx={{ mt: 2 }}>
                     {alert.message}

--- a/frontend/src/components/GoalTrackerCard.tsx
+++ b/frontend/src/components/GoalTrackerCard.tsx
@@ -133,14 +133,23 @@ const GoalTrackerBody: React.FC<{
         return (
             <Box>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 0.5, gap: 1 }}>
-                    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            color: "text.secondary",
+                            fontWeight: 600
+                        }}>
                         {t('goalTracker.label.target', { value: targetWeight.toFixed(1), unit: unitLabel })}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            color: "text.secondary",
+                            fontWeight: 600
+                        }}>
                         {t('goalTracker.label.tolerance', { value: tolerance.toFixed(1), unit: unitLabel })}
                     </Typography>
                 </Box>
-
                 <Box sx={{ position: 'relative' }}>
                     <Box
                         sx={{
@@ -201,10 +210,14 @@ const GoalTrackerBody: React.FC<{
                         </Box>
                     )}
                 </Box>
-
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mt: 1, gap: 1 }}>
                     <Typography variant="body2">{t('goalTracker.label.current', { weight: currentWeightLabel })}</Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            color: "text.secondary",
+                            fontWeight: 600
+                        }}>
                         {statusLabel}
                     </Typography>
                 </Box>
@@ -227,14 +240,23 @@ const GoalTrackerBody: React.FC<{
     return (
         <Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 0.5, gap: 1 }}>
-                <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+                <Typography
+                    variant="body2"
+                    sx={{
+                        color: "text.secondary",
+                        fontWeight: 600
+                    }}>
                     {t('goalTracker.label.start', { value: startWeight.toFixed(1), unit: unitLabel })}
                 </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+                <Typography
+                    variant="body2"
+                    sx={{
+                        color: "text.secondary",
+                        fontWeight: 600
+                    }}>
                     {t('goalTracker.label.goal', { value: targetWeight.toFixed(1), unit: unitLabel })}
                 </Typography>
             </Box>
-
             <Box sx={{ position: 'relative' }}>
                 {progress && (
                     <Box
@@ -278,25 +300,29 @@ const GoalTrackerBody: React.FC<{
                     )}
                 </Box>
             </Box>
-
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mt: 1, gap: 1 }}>
                 <Typography variant="body2">{t('goalTracker.label.current', { weight: currentWeightLabel })}</Typography>
                 {progress ? (
                     <Typography
                         variant="body2"
-                        color="text.secondary"
-                        sx={{ fontWeight: 600 }}
                         aria-label={t('goalTracker.aria.progressPercent')}
-                    >
+                        sx={{
+                            color: "text.secondary",
+                            fontWeight: 600
+                        }}>
                         {progress.percent.toFixed(0)}%
                     </Typography>
                 ) : (
-                    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            color: "text.secondary",
+                            fontWeight: 600
+                        }}>
                         {t('goalTracker.status.logWeighIn')}
                     </Typography>
                 )}
             </Box>
-
             <Typography
                 variant="subtitle2"
                 sx={{ fontWeight: 800, mt: 1 }}
@@ -410,7 +436,9 @@ const GoalTrackerCard: React.FC<GoalTrackerCardProps> = ({ isDashboard = false }
     } else if (isError) {
         cardBody = (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     {t('goalTracker.error.unableToLoad')}
                 </Typography>
                 {isDashboard && (
@@ -423,10 +451,14 @@ const GoalTrackerCard: React.FC<GoalTrackerCardProps> = ({ isDashboard = false }
     } else if (!goal || !goalMode) {
         cardBody = (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     {t('goalTracker.empty.noGoal')}
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     {t('goalTracker.empty.setTargetHint')}
                 </Typography>
                 {isDashboard && (

--- a/frontend/src/components/InAppNotificationsDrawer.tsx
+++ b/frontend/src/components/InAppNotificationsDrawer.tsx
@@ -144,7 +144,9 @@ const InAppNotificationsDrawer: React.FC<InAppNotificationsDrawerProps> = ({
         );
     } else if (notificationRows.length === 0) {
         bodyContent = (
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{
+                color: "text.secondary"
+            }}>
                 {t('notifications.empty')}
             </Typography>
         );
@@ -176,19 +178,31 @@ const InAppNotificationsDrawer: React.FC<InAppNotificationsDrawerProps> = ({
                                     opacity: 1
                                 }}
                             >
-                                <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+                                <Stack
+                                    direction="row"
+                                    spacing={1}
+                                    sx={{
+                                        alignItems: "center",
+                                        justifyContent: "space-between"
+                                    }}>
                                     <Typography variant="subtitle2">{copy.title}</Typography>
-                                    <Stack direction="row" spacing={0.75} alignItems="center">
+                                    <Stack direction="row" spacing={0.75} sx={{
+                                        alignItems: "center"
+                                    }}>
                                         <Chip size="small" label={t('notifications.unreadBadge')} />
                                         {timestamp ? (
-                                            <Typography variant="caption" color="text.secondary">
+                                            <Typography variant="caption" sx={{
+                                                color: "text.secondary"
+                                            }}>
                                                 {timestamp}
                                             </Typography>
                                         ) : null}
                                     </Stack>
                                 </Stack>
 
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {copy.body}
                                 </Typography>
 
@@ -222,7 +236,12 @@ const InAppNotificationsDrawer: React.FC<InAppNotificationsDrawerProps> = ({
         <Drawer anchor="right" open={open} onClose={onClose}>
             <Box sx={{ width: PANEL_WIDTH_PX, px: PANEL_PADDING, py: PANEL_PADDING }}>
                 <Stack spacing={1.5}>
-                    <Stack direction="row" alignItems="center" justifyContent="space-between">
+                    <Stack
+                        direction="row"
+                        sx={{
+                            alignItems: "center",
+                            justifyContent: "space-between"
+                        }}>
                         <Typography variant="h6">{t('notifications.panelTitle')}</Typography>
                         <Chip
                             size="small"

--- a/frontend/src/components/LogDatePickerControl.tsx
+++ b/frontend/src/components/LogDatePickerControl.tsx
@@ -325,18 +325,19 @@ const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
                 label={label}
                 value={controlDisplayValue}
                 size={isNavbarPlacement ? 'small' : undefined}
-                InputLabelProps={label ? { shrink: true } : undefined}
-                inputProps={{
-                    readOnly: true,
-                    tabIndex: -1
-                }}
                 sx={{
                     width: '100%',
                     ...(isNavbarPlacement ? { '& .MuiInputLabel-root': { display: 'none' } } : null),
                     '& input': { textAlign: 'center' }
                 }}
-            />
+                slotProps={{
+                    htmlInput: {
+                        readOnly: true,
+                        tabIndex: -1
+                    },
 
+                    inputLabel: label ? { shrink: true } : undefined
+                }} />
             {/*
                 Overlay button: keeps a large click/tap target and avoids text-selection interactions
                 inside the read-only input field.
@@ -373,7 +374,6 @@ const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
                     }
                 })}
             />
-
             <Popover
                 open={calendarOpen}
                 anchorEl={anchorElement}
@@ -551,13 +551,17 @@ const LogDatePickerControl: React.FC<LogDatePickerControlProps> = ({
                                 flexShrink: 0
                             }}
                         />
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography variant="caption" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('log.datePicker.completeLegend')}
                         </Typography>
                     </Box>
 
                     {monthCompletionQuery.isError && (
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography variant="caption" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('log.completion.actionUnavailable')}
                         </Typography>
                     )}

--- a/frontend/src/components/LogQuickAddFab.tsx
+++ b/frontend/src/components/LogQuickAddFab.tsx
@@ -75,23 +75,30 @@ const LogQuickAddFab: React.FC<LogQuickAddFabProps> = ({ date }) => {
                 <SpeedDialAction
                     key="add-food"
                     icon={<RestaurantIcon />}
-                    tooltipTitle={t('log.speedDial.addFood')}
                     onClick={() => {
                         haptic.tap();
                         dialogs.openFoodDialog();
+                    }}
+                    slotProps={{
+                        tooltip: {
+                            title: t('log.speedDial.addFood')
+                        }
                     }}
                 />
                 <SpeedDialAction
                     key="add-weight"
                     icon={<MonitorWeightIcon />}
-                    tooltipTitle={t('log.speedDial.addWeight')}
                     onClick={() => {
                         haptic.tap();
                         openWeightDialogFromFab();
                     }}
+                    slotProps={{
+                        tooltip: {
+                            title: t('log.speedDial.addWeight')
+                        }
+                    }}
                 />
             </SpeedDial>
-
             <Dialog
                 open={dialogs.isFoodDialogOpen}
                 onClose={dialogs.closeFoodDialog}
@@ -99,14 +106,16 @@ const LogQuickAddFab: React.FC<LogQuickAddFabProps> = ({ date }) => {
                 fullWidth={!isFoodDialogFullScreen}
                 maxWidth={isFoodDialogFullScreen ? false : 'sm'}
                 scroll="paper"
-                PaperProps={{
-                    sx: {
-                        height: isFoodDialogFullScreen ? '100dvh' : 'min(90dvh, 860px)',
-                        maxHeight: isFoodDialogFullScreen ? '100dvh' : 'min(90dvh, 860px)',
-                        m: isFoodDialogFullScreen ? 0 : 2,
-                        borderRadius: isFoodDialogFullScreen ? 0 : 2,
-                        display: 'flex',
-                        flexDirection: 'column'
+                slotProps={{
+                    paper: {
+                        sx: {
+                            height: isFoodDialogFullScreen ? '100dvh' : 'min(90dvh, 860px)',
+                            maxHeight: isFoodDialogFullScreen ? '100dvh' : 'min(90dvh, 860px)',
+                            m: isFoodDialogFullScreen ? 0 : 2,
+                            borderRadius: isFoodDialogFullScreen ? 0 : 2,
+                            display: 'flex',
+                            flexDirection: 'column'
+                        }
                     }
                 }}
             >
@@ -131,12 +140,16 @@ const LogQuickAddFab: React.FC<LogQuickAddFabProps> = ({ date }) => {
                     }}
                 />
             </Dialog>
-
             <Dialog open={dialogs.isWeightDialogOpen} onClose={dialogs.closeWeightDialog} fullWidth maxWidth="sm">
                 <DialogTitle sx={{ position: 'relative', pr: 6 }}>
                     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                         <Box component="span">{t('log.dialog.trackWeight')}</Box>
-                        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mt: 0.25
+                            }}>
                             {t(subtitleKey, { date: weightDateLabel })}
                         </Typography>
                     </Box>

--- a/frontend/src/components/LogSummaryCard.tsx
+++ b/frontend/src/components/LogSummaryCard.tsx
@@ -300,7 +300,7 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
                     checked={isCompletionComplete}
                     onChange={(_event, checked) => void handleCompletionToggle(checked)}
                     disabled={isCompletionLoading || completionStatus === 'unknown' || isCompletionPending}
-                    inputProps={{ 'aria-label': completionActionLabel }}
+                    slotProps={{ input: { 'aria-label': completionActionLabel } }}
                 />
             )
             : (isCompletionLoading ? <Skeleton width={LOG_SUMMARY_COMPLETION_CHIP_MIN_WIDTH_PX} height={24} /> : statusChip);
@@ -321,7 +321,9 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
                         isCompletionLoading ? (
                             <Skeleton width="45%" height={16} />
                         ) : (
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography variant="caption" sx={{
+                                color: "text.secondary"
+                            }}>
                                 {completionStatusLabel}
                             </Typography>
                         )
@@ -375,7 +377,9 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
                     <Typography variant="subtitle1">{t('logSummary.caloriesRemaining')}</Typography>
                     <Skeleton width="40%" height={SUMMARY_SKELETON_VALUE_HEIGHT} />
                     <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('logSummary.loggedLabel')}
                         </Typography>
                         <Skeleton width="55%" height={20} />
@@ -392,7 +396,9 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
     } else if (isError) {
         cardBody = (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     {t('logSummary.error.unableToLoad')}
                 </Typography>
                 {dashboardMode && (
@@ -454,7 +460,9 @@ const LogSummaryCard: React.FC<LogSummaryCardProps> = ({ dashboardMode = false, 
                             ? t('logSummary.caloriesValue', { value: displayedRemainingCaloriesLabel })
                             : '—'}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {loggedLine}
                     </Typography>
                     {completionControl}

--- a/frontend/src/components/NewMyFoodDialog.tsx
+++ b/frontend/src/components/NewMyFoodDialog.tsx
@@ -144,10 +144,12 @@ const NewMyFoodDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                             type="number"
                             value={servingSizeQuantity}
                             onChange={(e) => setServingSizeQuantity(e.target.value)}
-                            inputProps={{ min: 0, step: 0.1 }}
                             fullWidth
                             disabled={isSubmitting}
                             required
+                            slotProps={{
+                                htmlInput: { min: 0, step: 0.1 }
+                            }}
                         />
 
                         <Autocomplete
@@ -175,10 +177,12 @@ const NewMyFoodDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                         type="number"
                         value={caloriesPerServing}
                         onChange={(e) => setCaloriesPerServing(e.target.value)}
-                        inputProps={{ min: 0, step: 1 }}
                         fullWidth
                         disabled={isSubmitting}
                         required
+                        slotProps={{
+                            htmlInput: { min: 0, step: 1 }
+                        }}
                     />
                 </Stack>
             </DialogContent>

--- a/frontend/src/components/NewRecipeDialog.tsx
+++ b/frontend/src/components/NewRecipeDialog.tsx
@@ -456,10 +456,12 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                             type="number"
                             value={servingSizeQuantity}
                             onChange={(e) => setServingSizeQuantity(e.target.value)}
-                            inputProps={{ min: 0, step: 0.1 }}
                             fullWidth
                             disabled={isSubmitting}
                             required
+                            slotProps={{
+                                htmlInput: { min: 0, step: 0.1 }
+                            }}
                         />
                         <Autocomplete
                             freeSolo
@@ -476,10 +478,12 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                             type="number"
                             value={yieldServings}
                             onChange={(e) => setYieldServings(e.target.value)}
-                            inputProps={{ min: 0, step: 0.1 }}
                             fullWidth
                             disabled={isSubmitting}
                             required
+                            slotProps={{
+                                htmlInput: { min: 0, step: 0.1 }
+                            }}
                         />
                     </Stack>
 
@@ -493,7 +497,9 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                     >
                         <Typography variant="subtitle2">Ingredients</Typography>
                         {ingredients.length === 0 ? (
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Add ingredients from your My Foods library or by searching the food database.
                             </Typography>
                         ) : (
@@ -523,7 +529,13 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                                                 primary={ing.source === 'MY_FOOD' ? ing.name_snapshot : ing.name}
                                                 secondary={secondary}
                                             />
-                                            <Typography variant="body2" color="text.secondary" sx={{ ml: 2, whiteSpace: 'nowrap' }}>
+                                            <Typography
+                                                variant="body2"
+                                                sx={{
+                                                    color: "text.secondary",
+                                                    ml: 2,
+                                                    whiteSpace: 'nowrap'
+                                                }}>
                                                 {Math.round(ing.calories_total)} kcal
                                             </Typography>
                                         </ListItem>
@@ -537,12 +549,21 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                         <Stack
                             direction={{ xs: 'column', sm: 'row' }}
                             spacing={1}
-                            alignItems={{ xs: 'stretch', sm: 'center' }}
+                            sx={{
+                                alignItems: { xs: 'stretch', sm: 'center' }
+                            }}
                         >
-                            <Typography variant="body2" color="text.secondary" sx={{ flexGrow: 1 }}>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    color: "text.secondary",
+                                    flexGrow: 1
+                                }}>
                                 Total: {Math.round(recipeTotals.totalCalories)} kcal
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 {recipeTotals.caloriesPerServing !== null
                                     ? `${Math.round(recipeTotals.caloriesPerServing)} kcal/serving`
                                     : '—'}
@@ -576,15 +597,19 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                                         />
                                     )}
                                 />
-                                <Stack direction="row" spacing={1} alignItems="center">
+                                <Stack direction="row" spacing={1} sx={{
+                                    alignItems: "center"
+                                }}>
                                     <TextField
                                         label="Quantity (servings)"
                                         type="number"
                                         value={myFoodQuantityServings}
                                         onChange={(e) => setMyFoodQuantityServings(e.target.value)}
-                                        inputProps={{ min: 0, step: 0.1 }}
                                         disabled={isSubmitting || !selectedMyFood}
                                         fullWidth
+                                        slotProps={{
+                                            htmlInput: { min: 0, step: 0.1 }
+                                        }}
                                     />
                                     <Button
                                         variant="outlined"
@@ -596,7 +621,9 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                                     </Button>
                                 </Stack>
                                 {selectedMyFood && myFoodIngredientCaloriesTotal !== null && (
-                                    <Typography variant="caption" color="text.secondary">
+                                    <Typography variant="caption" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         Adds {Math.round(myFoodIngredientCaloriesTotal)} kcal
                                     </Typography>
                                 )}
@@ -620,7 +647,9 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                                 />
 
                                 {searchResults.length === 0 ? (
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         {isSearching
                                             ? 'Searching...'
                                             : 'Type a search term to find an ingredient and add it to the recipe.'}
@@ -670,12 +699,22 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                                                 value={measureQuantity}
                                                 onChange={(e) => setMeasureQuantity(parseFloat(e.target.value) || 0)}
                                                 disabled={externalPanelDisabled || !selectedMeasure}
-                                                inputProps={{ min: 0, step: 0.5 }}
+                                                slotProps={{
+                                                    htmlInput: { min: 0, step: 0.5 }
+                                                }}
                                             />
 
                                             {computedExternal ? (
-                                                <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
-                                                    <Typography variant="body2" color="text.secondary">
+                                                <Stack
+                                                    direction="row"
+                                                    spacing={1}
+                                                    sx={{
+                                                        alignItems: "center",
+                                                        justifyContent: "space-between"
+                                                    }}>
+                                                    <Typography variant="body2" sx={{
+                                                        color: "text.secondary"
+                                                    }}>
                                                         Adds {Math.round(computedExternal.calories)} kcal
                                                     </Typography>
                                                     <Button
@@ -687,7 +726,9 @@ const NewRecipeDialog: React.FC<Props> = ({ open, date, mealPeriod, onClose, onS
                                                     </Button>
                                                 </Stack>
                                             ) : (
-                                                <Typography variant="body2" color="text.secondary">
+                                                <Typography variant="body2" sx={{
+                                                    color: "text.secondary"
+                                                }}>
                                                     Calories unavailable for this item.
                                                 </Typography>
                                             )}

--- a/frontend/src/components/ProfilePhotoCard.tsx
+++ b/frontend/src/components/ProfilePhotoCard.tsx
@@ -89,7 +89,9 @@ const ProfilePhotoCard: React.FC<Props> = ({
                 <Stack spacing={2}>
                     <Box>
                         <Typography variant="h6">{resolvedTitle}</Typography>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {resolvedDescription}
                         </Typography>
                     </Box>
@@ -97,7 +99,9 @@ const ProfilePhotoCard: React.FC<Props> = ({
                     {error && <Alert severity="error">{error}</Alert>}
                     {success && <Alert severity="success">{success}</Alert>}
 
-                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }}>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{
+                        alignItems: { sm: 'center' }
+                    }}>
                         <Avatar
                             src={user?.profile_image_url ?? undefined}
                             sx={{
@@ -111,7 +115,9 @@ const ProfilePhotoCard: React.FC<Props> = ({
                             {avatarLabel}
                         </Avatar>
 
-                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        <Stack direction="row" spacing={1} useFlexGap sx={{
+                            flexWrap: "wrap"
+                        }}>
                             <Button
                                 variant={hasPhoto ? 'outlined' : 'contained'}
                                 component="label"
@@ -146,7 +152,6 @@ const ProfilePhotoCard: React.FC<Props> = ({
                     </Stack>
                 </Stack>
             </AppCard>
-
             <ProfilePhotoCropDialog
                 open={cropOpen}
                 imageUrl={selectedImageUrl}

--- a/frontend/src/components/ProfilePhotoCropDialog.tsx
+++ b/frontend/src/components/ProfilePhotoCropDialog.tsx
@@ -172,7 +172,9 @@ const ProfilePhotoCropDialog: React.FC<Props> = ({ open, imageUrl, onCancel, onC
             <DialogContent>
                 <Stack spacing={2}>
                     {error && <Alert severity="error">{error}</Alert>}
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {helperText}
                     </Typography>
 

--- a/frontend/src/components/WeightEntryForm.tsx
+++ b/frontend/src/components/WeightEntryForm.tsx
@@ -200,13 +200,17 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
                         <Alert severity="warning">{t('weightEntry.error.loadExistingFailed')}</Alert>
                     )}
                     {existingMetric && (
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('weightEntry.existingEntryNotice', { date: entryDateLabel })}
                         </Typography>
                     )}
 
                     {!existingMetric && prefillMetric && (
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('weightEntry.prefilledNotice', {
                                 date: prefillDateLabel ?? toDatePart(prefillMetric.date)
                             })}
@@ -219,44 +223,48 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
                         value={weight}
                         onChange={(e) => setWeight(e.target.value)}
                         autoFocus
-                        inputProps={{ min: WEIGHT_ENTRY_MIN, step: WEIGHT_ENTRY_STEP, inputMode: 'decimal' }}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <IconButton
-                                        aria-label={t('weightEntry.stepper.decrease', {
-                                            step: WEIGHT_ENTRY_STEP,
-                                            unit: weightUnitLabel
-                                        })}
-                                        size="small"
-                                        edge="end"
-                                        onClick={() => handleStepWeight(-WEIGHT_ENTRY_STEP)}
-                                        disabled={isBusy || stepperBase === null}
-                                    >
-                                        <RemoveIcon fontSize="small" />
-                                    </IconButton>
-                                    <IconButton
-                                        aria-label={t('weightEntry.stepper.increase', {
-                                            step: WEIGHT_ENTRY_STEP,
-                                            unit: weightUnitLabel
-                                        })}
-                                        size="small"
-                                        edge="end"
-                                        onClick={() => handleStepWeight(WEIGHT_ENTRY_STEP)}
-                                        disabled={isBusy || stepperBase === null}
-                                    >
-                                        <AddIcon fontSize="small" />
-                                    </IconButton>
-                                </InputAdornment>
-                            )
-                        }}
                         error={Boolean(weightFieldError)}
                         helperText={weightFieldError ?? ' '}
                         disabled={isBusy}
                         required
-                    />
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <IconButton
+                                            aria-label={t('weightEntry.stepper.decrease', {
+                                                step: WEIGHT_ENTRY_STEP,
+                                                unit: weightUnitLabel
+                                            })}
+                                            size="small"
+                                            edge="end"
+                                            onClick={() => handleStepWeight(-WEIGHT_ENTRY_STEP)}
+                                            disabled={isBusy || stepperBase === null}
+                                        >
+                                            <RemoveIcon fontSize="small" />
+                                        </IconButton>
+                                        <IconButton
+                                            aria-label={t('weightEntry.stepper.increase', {
+                                                step: WEIGHT_ENTRY_STEP,
+                                                unit: weightUnitLabel
+                                            })}
+                                            size="small"
+                                            edge="end"
+                                            onClick={() => handleStepWeight(WEIGHT_ENTRY_STEP)}
+                                            disabled={isBusy || stepperBase === null}
+                                        >
+                                            <AddIcon fontSize="small" />
+                                        </IconButton>
+                                    </InputAdornment>
+                                )
+                            },
 
-                    <Typography variant="caption" color="text.secondary">
+                            htmlInput: { min: WEIGHT_ENTRY_MIN, step: WEIGHT_ENTRY_STEP, inputMode: 'decimal' }
+                        }} />
+
+                    <Typography variant="caption" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('weightEntry.unitsHint.prefix')}{' '}
                         <Link component={RouterLink} to="/settings">
                             {t('nav.settings')}
@@ -265,7 +273,6 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
                     </Typography>
                 </Stack>
             </DialogContent>
-
             <DialogActions>
                 {existingMetric && (
                     <Button
@@ -287,7 +294,6 @@ const WeightEntryFormContent: React.FC<WeightEntryFormContentProps> = ({
                     {submitLabel}
                 </Button>
             </DialogActions>
-
             <Dialog open={isDeleteConfirmOpen} onClose={() => setIsDeleteConfirmOpen(false)} fullWidth maxWidth="xs">
                 <DialogTitle>{t('weightEntry.deleteDialog.title')}</DialogTitle>
                 <DialogContent>

--- a/frontend/src/components/WeightSummaryCard.tsx
+++ b/frontend/src/components/WeightSummaryCard.tsx
@@ -134,7 +134,9 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25, flexGrow: 1, minWidth: 0 }}>
                         <Skeleton width="40%" height={32} />
                         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 {t('weightSummary.asOf')}
                             </Typography>
                             <Skeleton width="35%" height={20} />
@@ -190,7 +192,9 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
                         <Typography variant={valueVariant} sx={{ lineHeight: 1.1 }}>
                             {displayedWeightLabel}
                         </Typography>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('weightSummary.asOfWithDate', { date: asOfLabel })}
                         </Typography>
                     </Box>

--- a/frontend/src/components/imports/LoseItImportCard.tsx
+++ b/frontend/src/components/imports/LoseItImportCard.tsx
@@ -36,14 +36,15 @@ const LoseItImportCard: React.FC = () => {
             <SectionHeader title={t('settings.importTitle')} sx={{ mb: 0.5 }} />
             <InlineStatusLine status={status} sx={{ mb: 1 }} />
             <Stack spacing={CARD_CONTENT_SPACING}>
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     {t('settings.importDescription')}
                 </Typography>
                 <Button variant="outlined" onClick={() => setOpen(true)}>
                     {t('import.loseit.openButton')}
                 </Button>
             </Stack>
-
             <LoseItImportDialog
                 open={open}
                 onClose={() => setOpen(false)}

--- a/frontend/src/components/imports/LoseItImportDialog.tsx
+++ b/frontend/src/components/imports/LoseItImportDialog.tsx
@@ -225,7 +225,9 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
     if (step === 'select') {
         dialogBody = (
             <Stack spacing={DIALOG_CONTENT_SPACING}>
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     {t('import.loseit.dialogDescription')}
                 </Typography>
                 <Box>
@@ -257,7 +259,9 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                             })}
                         </Typography>
                         {preview.summary.startDate && preview.summary.endDate && (
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 {t('import.loseit.dateRange', {
                                     start: preview.summary.startDate,
                                     end: preview.summary.endDate
@@ -274,12 +278,16 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                         </Typography>
                         <Stack spacing={0.5}>
                             {preview.conflicts.foodLogDays > 0 && (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('import.loseit.conflicts.foodDays', { count: preview.conflicts.foodLogDays })}
                                 </Typography>
                             )}
                             {preview.conflicts.weightDays > 0 && (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('import.loseit.conflicts.weightDays', { count: preview.conflicts.weightDays })}
                                 </Typography>
                             )}
@@ -340,7 +348,13 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                                 <ToggleButton value={WEIGHT_UNITS.KG}>kg</ToggleButton>
                             </ToggleButtonGroup>
                             {weightUnitHint && (
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                                <Typography
+                                    variant="caption"
+                                    sx={{
+                                        color: "text.secondary",
+                                        display: 'block',
+                                        mt: 0.5
+                                    }}>
                                     {weightUnitHint} ({weightUnitLabel})
                                 </Typography>
                             )}
@@ -365,7 +379,9 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                         </Typography>
                         <Stack spacing={WARNING_LIST_SPACING}>
                             {preview.warnings.map((warning, idx) => (
-                                <Typography key={`${warning}-${idx}`} variant="body2" color="text.secondary">
+                                <Typography key={`${warning}-${idx}`} variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {warning}
                                 </Typography>
                             ))}
@@ -388,7 +404,9 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                     })}
                 </Typography>
                 {(result.skippedFoodLogs > 0 || result.skippedWeights > 0) && (
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('import.loseit.completeSkipped', {
                             foods: result.skippedFoodLogs,
                             weights: result.skippedWeights
@@ -396,7 +414,9 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                     </Typography>
                 )}
                 {result.updatedBodyFat > 0 && (
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t('import.loseit.completeBodyFat', { count: result.updatedBodyFat })}
                     </Typography>
                 )}
@@ -407,7 +427,9 @@ const LoseItImportDialog: React.FC<LoseItImportDialogProps> = ({ open, onClose, 
                         </Typography>
                         <Stack spacing={WARNING_LIST_SPACING}>
                             {result.warnings.map((warning, idx) => (
-                                <Typography key={`${warning}-${idx}`} variant="body2" color="text.secondary">
+                                <Typography key={`${warning}-${idx}`} variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {warning}
                                 </Typography>
                             ))}

--- a/frontend/src/components/landing/LandingAppPreview.tsx
+++ b/frontend/src/components/landing/LandingAppPreview.tsx
@@ -86,7 +86,9 @@ function LandingMockLogSummaryCard() {
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, minWidth: 0 }}>
                         <Typography variant="subtitle1">Calories remaining</Typography>
                         <Typography variant="h5">{remaining.toLocaleString()} Calories</Typography>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             Logged: {totalCalories.toLocaleString()} Calories of {dailyTarget.toLocaleString()} Calories target
                         </Typography>
                         <Typography variant="body2" color="primary">
@@ -124,18 +126,26 @@ function LandingMockGoalTrackerCard() {
 
                 <Box>
                     <Stack spacing={0.5} sx={{ mb: 1 }}>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             Started: Aug 12, 2025
                         </Typography>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             Projected target date: Oct 18, 2025
                         </Typography>
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography variant="caption" sx={{
+                            color: "text.secondary"
+                        }}>
                             Projection uses your selected deficit and a steady-rate model.
                         </Typography>
                     </Stack>
 
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         Start: {startWeight.toFixed(1)} lb · Target: {targetWeight.toFixed(1)} lb
                     </Typography>
                     <Typography variant="body1" sx={{ mt: 0.5 }}>
@@ -182,7 +192,13 @@ function LandingMockGoalTrackerCard() {
                             </Box>
                         </Box>
 
-                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                color: "text.secondary",
+                                display: 'block',
+                                mt: 0.75
+                            }}>
                             {progressPercent}% toward goal
                         </Typography>
                     </Box>

--- a/frontend/src/components/onboarding/AboutYouQuestionFooter.tsx
+++ b/frontend/src/components/onboarding/AboutYouQuestionFooter.tsx
@@ -91,7 +91,6 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                 type="date"
                 value={props.dob}
                 onChange={(e) => props.onDobChange(e.target.value)}
-                InputLabelProps={{ shrink: true }}
                 required
                 disabled={props.disabled}
                 size="small"
@@ -100,6 +99,9 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                 error={props.showErrors && !props.dob}
                 helperText={props.showErrors && !props.dob ? 'Required.' : undefined}
                 onKeyDown={handleEnterToSubmit}
+                slotProps={{
+                    inputLabel: { shrink: true }
+                }}
             />
         );
     } else if (props.questionKey === 'sex') {
@@ -145,10 +147,14 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                             }}
                         >
                             <Box>
-                                <Typography variant="body2" fontWeight={800}>
+                                <Typography variant="body2" sx={{
+                                    fontWeight: 800
+                                }}>
                                     {option.title}
                                 </Typography>
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography variant="caption" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {option.description}
                                 </Typography>
                             </Box>
@@ -166,10 +172,6 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                     type="number"
                     value={props.heightCm}
                     onChange={(e) => props.onHeightCmChange(e.target.value)}
-                    inputProps={{ min: 50, max: 272, step: 0.1, inputMode: 'decimal' }}
-                    InputProps={{
-                        endAdornment: <InputAdornment position="end">cm</InputAdornment>
-                    }}
                     required
                     disabled={props.disabled}
                     size="small"
@@ -178,7 +180,13 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                     error={props.showErrors && !heightFieldsValid}
                     helperText={props.showErrors && !heightFieldsValid ? 'Please enter your height.' : ' '}
                     onKeyDown={handleEnterToSubmit}
-                />
+                    slotProps={{
+                        input: {
+                            endAdornment: <InputAdornment position="end">cm</InputAdornment>
+                        },
+
+                        htmlInput: { min: 50, max: 272, step: 0.1, inputMode: 'decimal' }
+                    }} />
             ) : (
                 <Box sx={{ display: 'flex', gap: 2 }}>
                     <TextField
@@ -186,7 +194,6 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                         type="number"
                         value={props.heightFeet}
                         onChange={(e) => props.onHeightFeetChange(e.target.value)}
-                        inputProps={{ min: 1, max: 8, step: 1, inputMode: 'numeric' }}
                         required
                         disabled={props.disabled}
                         size="small"
@@ -196,18 +203,23 @@ const AboutYouQuestionFooter: React.FC<AboutYouQuestionFooterProps> = (props) =>
                         error={props.showErrors && !heightFieldsValid}
                         helperText={props.showErrors && !heightFieldsValid ? 'Enter feet.' : ' '}
                         onKeyDown={handleEnterToSubmit}
+                        slotProps={{
+                            htmlInput: { min: 1, max: 8, step: 1, inputMode: 'numeric' }
+                        }}
                     />
                     <TextField
                         label="Inches"
                         type="number"
                         value={props.heightInches}
                         onChange={(e) => props.onHeightInchesChange(e.target.value)}
-                        inputProps={{ min: 0, max: 11.9, step: 0.1, inputMode: 'decimal' }}
                         disabled={props.disabled}
                         size="small"
                         fullWidth
                         sx={{ flex: 1 }}
                         onKeyDown={handleEnterToSubmit}
+                        slotProps={{
+                            htmlInput: { min: 0, max: 11.9, step: 0.1, inputMode: 'decimal' }
+                        }}
                     />
                 </Box>
             );

--- a/frontend/src/components/onboarding/AboutYouStep.tsx
+++ b/frontend/src/components/onboarding/AboutYouStep.tsx
@@ -106,11 +106,12 @@ const AboutYouStep: React.FC<AboutYouStepProps> = (props) => {
                 <Typography variant="h5" gutterBottom>
                     Estimate your calorie burn
                 </Typography>
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     We can estimate your TDEE (calories burned on a typical day) from a few quick details so your calorie target is realistic.
                 </Typography>
             </Box>
-
             {hasAnySummary ? (
                 <Stack spacing={ONBOARDING_FIELD_SPACING}>
                     {props.completedKeys.includes('dob') && props.dob.trim() && (
@@ -166,7 +167,9 @@ const AboutYouStep: React.FC<AboutYouStepProps> = (props) => {
                     )}
                 </Stack>
             ) : (
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     These details help us estimate your calorie burn. You can update them later in your profile.
                 </Typography>
             )}

--- a/frontend/src/components/onboarding/GoalsQuestionFooter.tsx
+++ b/frontend/src/components/onboarding/GoalsQuestionFooter.tsx
@@ -111,7 +111,6 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                 prompt={prompt}
                 progressLabel={props.progressLabel}
             />
-
             {props.questionKey === 'currentWeight' && (
                 <Box>
                     <TextField
@@ -119,10 +118,6 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                         type="number"
                         value={props.currentWeight}
                         onChange={(e) => props.onCurrentWeightChange(e.target.value)}
-                        inputProps={{ min: 1, step: 0.1, inputMode: 'decimal' }}
-                        InputProps={{
-                            endAdornment: <InputAdornment position="end">{weightUnitLabel}</InputAdornment>
-                        }}
                         required
                         disabled={props.disabled}
                         size="small"
@@ -131,7 +126,13 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                         error={Boolean(currentWeightErrorText)}
                         helperText={currentWeightErrorText ?? ' '}
                         onKeyDown={handleEnterToSubmit}
-                    />
+                        slotProps={{
+                            input: {
+                                endAdornment: <InputAdornment position="end">{weightUnitLabel}</InputAdornment>
+                            },
+
+                            htmlInput: { min: 1, step: 0.1, inputMode: 'decimal' }
+                        }} />
 
                     <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 0.5 }}>
                         <ToggleButtonGroup
@@ -155,7 +156,6 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                     </Box>
                 </Box>
             )}
-
             {props.questionKey === 'targetWeight' && (
                 <Box>
                     <TextField
@@ -163,10 +163,6 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                         type="number"
                         value={props.targetWeight}
                         onChange={(e) => props.onTargetWeightChange(e.target.value)}
-                        inputProps={{ min: 1, step: 0.1, inputMode: 'decimal' }}
-                        InputProps={{
-                            endAdornment: <InputAdornment position="end">{weightUnitLabel}</InputAdornment>
-                        }}
                         required
                         disabled={props.disabled}
                         size="small"
@@ -175,7 +171,13 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                         error={Boolean(targetWeightErrorText)}
                         helperText={targetWeightErrorText ?? ' '}
                         onKeyDown={handleEnterToSubmit}
-                    />
+                        slotProps={{
+                            input: {
+                                endAdornment: <InputAdornment position="end">{weightUnitLabel}</InputAdornment>
+                            },
+
+                            htmlInput: { min: 1, step: 0.1, inputMode: 'decimal' }
+                        }} />
 
                     <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 0.5 }}>
                         <ToggleButtonGroup
@@ -199,7 +201,6 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                     </Box>
                 </Box>
             )}
-
             {props.questionKey === 'pace' && paceGoalMode && (
                 <FormControl fullWidth disabled={props.disabled} size="small">
                     <InputLabel>Pace</InputLabel>
@@ -239,10 +240,14 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                                     }}
                                 >
                                     <Box>
-                                        <Typography variant="body2" fontWeight={800}>
+                                        <Typography variant="body2" sx={{
+                                            fontWeight: 800
+                                        }}>
                                             {hint}
                                         </Typography>
-                                        <Typography variant="caption" color="text.secondary">
+                                        <Typography variant="caption" sx={{
+                                            color: "text.secondary"
+                                        }}>
                                             {sign}
                                             {val} kcal/day
                                         </Typography>
@@ -252,7 +257,12 @@ const GoalsQuestionFooter: React.FC<GoalsQuestionFooterProps> = (props) => {
                         })}
                     </Select>
                     {paceCaloriesLabel && paceHint && (
-                        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                color: "text.secondary",
+                                mt: 0.5
+                            }}>
                             {paceCaloriesLabel} ({paceHint}). You can adjust this later.
                         </Typography>
                     )}

--- a/frontend/src/components/onboarding/GoalsStep.tsx
+++ b/frontend/src/components/onboarding/GoalsStep.tsx
@@ -57,11 +57,12 @@ const GoalsStep: React.FC<GoalsStepProps> = (props) => {
                 <Typography variant="h5" gutterBottom>
                     Set your goal
                 </Typography>
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     Answer a few quick questions and we&apos;ll set a daily calorie target that matches your plan.
                 </Typography>
             </Box>
-
             {hasAnySummary ? (
                 <Stack spacing={ONBOARDING_FIELD_SPACING}>
                     {props.completedKeys.includes('currentWeight') && props.currentWeight.trim() && (
@@ -104,7 +105,9 @@ const GoalsStep: React.FC<GoalsStepProps> = (props) => {
                     )}
                 </Stack>
             ) : (
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     Start with your current weight. You can always tweak this later.
                 </Typography>
             )}

--- a/frontend/src/components/onboarding/ImportStep.tsx
+++ b/frontend/src/components/onboarding/ImportStep.tsx
@@ -27,7 +27,9 @@ const ImportStep: React.FC<ImportStepProps> = ({ onOpenImport, summary }) => {
                 <Typography variant="h5">{t('onboarding.import.title')}</Typography>
                 <Chip size="small" label={t('onboarding.import.optional')} />
             </Box>
-            <Typography color="text.secondary">
+            <Typography sx={{
+                color: "text.secondary"
+            }}>
                 {t('onboarding.import.body')}
             </Typography>
             <Button variant="outlined" onClick={onOpenImport}>

--- a/frontend/src/components/onboarding/OnboardingPlanSummary.tsx
+++ b/frontend/src/components/onboarding/OnboardingPlanSummary.tsx
@@ -180,23 +180,24 @@ const OnboardingPlanSummary: React.FC<OnboardingPlanSummaryProps> = ({
                 <Typography variant="h5" gutterBottom>
                     Your plan is ready
                 </Typography>
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     This is your estimated daily calorie budget. Log food against this target, and we&apos;ll track progress over time.
                 </Typography>
             </Box>
-
             <Box>
                 <Typography variant="h3" sx={{ fontWeight: SUMMARY_NUMBER_FONT_WEIGHT }} color="primary">
                     {primaryTargetText}
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     Estimated burn (TDEE): {typeof tdee === 'number' ? Math.round(tdee) : '—'} kcal/day
                     {goalInfo ? ` | ${goalInfo.label}` : ''}
                 </Typography>
             </Box>
-
             <Divider />
-
             <Stack spacing={1.25}>
                 <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
                     How we calculated it
@@ -206,7 +207,9 @@ const OnboardingPlanSummary: React.FC<OnboardingPlanSummaryProps> = ({
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
                         <Box sx={{ minWidth: 0 }}>
                             <Typography variant="body2">Basal Metabolic Rate (BMR)</Typography>
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography variant="caption" sx={{
+                                color: "text.secondary"
+                            }}>
                                 From sex, age, height, weight (Mifflin-St Jeor)
                             </Typography>
                         </Box>
@@ -221,7 +224,9 @@ const OnboardingPlanSummary: React.FC<OnboardingPlanSummaryProps> = ({
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
                         <Box sx={{ minWidth: 0 }}>
                             <Typography variant="body2">Activity adjustment</Typography>
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography variant="caption" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Level: {activityLevelTitle || '—'} | Multiplier {activityMultiplier ?? '—'}x
                             </Typography>
                         </Box>
@@ -236,7 +241,9 @@ const OnboardingPlanSummary: React.FC<OnboardingPlanSummaryProps> = ({
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
                         <Box sx={{ minWidth: 0 }}>
                             <Typography variant="body2">Goal adjustment</Typography>
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography variant="caption" sx={{
+                                color: "text.secondary"
+                            }}>
                                 {goalInfo?.caption ?? 'Deficit (lose) or surplus (gain) applied to your TDEE'}
                             </Typography>
                         </Box>
@@ -253,20 +260,29 @@ const OnboardingPlanSummary: React.FC<OnboardingPlanSummaryProps> = ({
                     </Box>
 
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
-                        <Typography variant="body2" fontWeight={600}>
+                        <Typography variant="body2" sx={{
+                            fontWeight: 600
+                        }}>
                             Daily target
                         </Typography>
-                        <Typography variant="body2" fontWeight={600} sx={{ textAlign: 'right', minWidth: BREAKDOWN_NUMBER_MIN_WIDTH_PX }}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                fontWeight: 600,
+                                textAlign: 'right',
+                                minWidth: BREAKDOWN_NUMBER_MIN_WIDTH_PX
+                            }}>
                             {typeof dailyTarget === 'number' ? `${Math.round(dailyTarget)} kcal` : '—'}
                         </Typography>
                     </Box>
                 </Stack>
 
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     This is an estimate, not a perfect measurement. You can change your goal pace and profile details any time in the app.
                 </Typography>
             </Stack>
-
             {projectedTargetDate && (
                 <Box
                     sx={(theme) => {
@@ -279,16 +295,23 @@ const OnboardingPlanSummary: React.FC<OnboardingPlanSummaryProps> = ({
                 >
                     <Typography
                         variant="overline"
-                        color="text.secondary"
-                        sx={{ fontWeight: 900, letterSpacing: TARGET_DATE_LABEL_LETTER_SPACING }}
-                    >
+                        sx={{
+                            color: "text.secondary",
+                            fontWeight: 900,
+                            letterSpacing: TARGET_DATE_LABEL_LETTER_SPACING
+                        }}>
                         Target date (estimate)
                     </Typography>
                     <Typography variant="h4" sx={{ fontWeight: 900, lineHeight: 1.1 }} color="secondary">
                         {projectedTargetDate.label}
                     </Typography>
                     {projectionCaption && (
-                        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mt: 0.5
+                            }}>
                             {projectionCaption}
                         </Typography>
                     )}

--- a/frontend/src/components/onboarding/OnboardingQuestionHeader.tsx
+++ b/frontend/src/components/onboarding/OnboardingQuestionHeader.tsx
@@ -23,7 +23,13 @@ const OnboardingQuestionHeader: React.FC<OnboardingQuestionHeaderProps> = ({ pro
             <Typography variant="subtitle2" sx={{ fontWeight: 800, flex: 1 }} aria-live="polite">
                 {prompt}
             </Typography>
-            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 800, flexShrink: 0 }}>
+            <Typography
+                variant="caption"
+                sx={{
+                    color: "text.secondary",
+                    fontWeight: 800,
+                    flexShrink: 0
+                }}>
                 {progressLabel}
             </Typography>
         </Box>

--- a/frontend/src/components/onboarding/OnboardingSummaryRow.tsx
+++ b/frontend/src/components/onboarding/OnboardingSummaryRow.tsx
@@ -43,16 +43,18 @@ const OnboardingSummaryRow: React.FC<OnboardingSummaryRowProps> = ({ label, valu
             <Box sx={{ minWidth: 0 }}>
                 <Typography
                     variant="caption"
-                    color="text.secondary"
-                    sx={{ fontWeight: 700, letterSpacing: SUMMARY_ROW_LABEL_LETTER_SPACING, textTransform: 'uppercase' }}
-                >
+                    sx={{
+                        color: "text.secondary",
+                        fontWeight: 700,
+                        letterSpacing: SUMMARY_ROW_LABEL_LETTER_SPACING,
+                        textTransform: 'uppercase'
+                    }}>
                     {label}
                 </Typography>
                 <Typography variant="body2" sx={{ fontWeight: 700, wordBreak: 'break-word' }}>
                     {value}
                 </Typography>
             </Box>
-
             {onEdit && (
                 <Button variant="text" size="small" onClick={onEdit} sx={{ flexShrink: 0 }}>
                     Edit

--- a/frontend/src/pages/DevDashboard.tsx
+++ b/frontend/src/pages/DevDashboard.tsx
@@ -790,11 +790,12 @@ const DevDashboard: React.FC = () => {
     return (
         <Box>
             <Stack spacing={1} sx={{ mb: 3 }}>
-                <Typography variant="body1" color="text.secondary">
+                <Typography variant="body1" sx={{
+                    color: "text.secondary"
+                }}>
                     Compare search output across providers to tune query quality.
                 </Typography>
             </Stack>
-
             <Card variant="outlined" sx={{ mb: 3 }}>
                 <CardContent>
                     <Stack spacing={2}>
@@ -802,7 +803,9 @@ const DevDashboard: React.FC = () => {
                             <Typography variant="subtitle1" gutterBottom>
                                 Test user tools
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Reset the seeded dev account back to a pre-onboarding state (clears profile fields, goals,
                                 metrics, and food logs) without changing your session.
                             </Typography>
@@ -834,7 +837,6 @@ const DevDashboard: React.FC = () => {
                     </Stack>
                 </CardContent>
             </Card>
-
             <Card variant="outlined" sx={{ mb: 3 }}>
                 <CardContent>
                     <Stack spacing={2}>
@@ -842,19 +844,27 @@ const DevDashboard: React.FC = () => {
                             <Typography variant="subtitle1" gutterBottom>
                                 Vibration API
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Test the exact haptic patterns used in product interactions.
                             </Typography>
                         </Box>
 
                         <Stack spacing={0.5}>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Vibrate API: {supportsVibrationApi ? 'supported' : 'unsupported'}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Account haptics setting: {user?.haptics_enabled ?? true ? 'enabled' : 'disabled'}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Prefers reduced motion: {prefersReducedMotion ? 'yes' : 'no'}
                             </Typography>
                         </Stack>
@@ -899,7 +909,6 @@ const DevDashboard: React.FC = () => {
                     </Stack>
                 </CardContent>
             </Card>
-
             <Card variant="outlined" sx={{ mb: 3 }}>
                 <CardContent>
                     <Stack spacing={2}>
@@ -907,7 +916,9 @@ const DevDashboard: React.FC = () => {
                             <Typography variant="subtitle1" gutterBottom>
                                 App badge
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Set or clear the app badge to validate Badging API support.
                             </Typography>
                         </Box>
@@ -948,7 +959,6 @@ const DevDashboard: React.FC = () => {
                     </Stack>
                 </CardContent>
             </Card>
-
             <Card variant="outlined" sx={{ mb: 3 }}>
                 <CardContent>
                     <Stack spacing={2}>
@@ -956,22 +966,32 @@ const DevDashboard: React.FC = () => {
                             <Typography variant="subtitle1" gutterBottom>
                                 Notifications
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Register a push subscription, then choose push and/or in-app delivery for each dev send.
                             </Typography>
                         </Box>
 
                         <Stack spacing={0.5}>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Notifications permission: {notificationPermission}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Service worker: {supportsServiceWorker ? 'supported' : 'unsupported'}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 PushManager: {supportsPushManager ? 'supported' : 'unsupported'}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Subscription: {hasPushSubscription ? 'active' : 'none'}
                             </Typography>
                         </Stack>
@@ -991,7 +1011,9 @@ const DevDashboard: React.FC = () => {
                         </TextField>
 
                         {isLoadingNotificationStatus && (
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 Loading notification state...
                             </Typography>
                         )}
@@ -1000,28 +1022,40 @@ const DevDashboard: React.FC = () => {
 
                         {notificationStatus && (
                             <Stack spacing={0.5}>
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     Local day: {notificationStatus.local_date}
                                 </Typography>
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     Push subscriptions in scope: {pushStatusRow?.matching_subscription_count ?? 0} (total{' '}
                                     {pushStatusRow?.total_subscription_count ?? 0})
                                 </Typography>
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     Push last sent local date: {pushStatusRow?.last_sent_local_date || 'none'}
                                 </Typography>
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {pushStatusRow?.delivery_dedupe_applies
                                         ? `Push delivered for local day: ${pushStatusRow?.delivered_for_local_day ? 'yes' : 'no'}`
                                         : 'Push delivery dedupe is not used for this notification type.'}
                                 </Typography>
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     In-app rows today: {inAppStatusRow?.today_total_count ?? 0} (active{' '}
                                     {inAppStatusRow?.today_active_count ?? 0}, read {inAppStatusRow?.today_read_count ?? 0},
                                     dismissed {inAppStatusRow?.today_dismissed_count ?? 0}, resolved{' '}
                                     {inAppStatusRow?.today_resolved_count ?? 0})
                                 </Typography>
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {inAppStatusRow?.delivery_dedupe_applies
                                         ? `In-app dedupe key ${inAppStatusRow?.dedupe_key || 'n/a'} is ${
                                               inAppStatusRow?.deduped_for_local_day ? 'already used today' : 'not used today'
@@ -1081,7 +1115,6 @@ const DevDashboard: React.FC = () => {
                     </Stack>
                 </CardContent>
             </Card>
-
             <Card variant="outlined" sx={{ mb: 3 }}>
                 <CardContent>
                     <Stack spacing={2}>
@@ -1100,7 +1133,9 @@ const DevDashboard: React.FC = () => {
                                             />
                                         }
                                         label={
-                                            <Stack direction="row" spacing={1} alignItems="center">
+                                            <Stack direction="row" spacing={1} sx={{
+                                                alignItems: "center"
+                                            }}>
                                                 <Typography variant="body2">{provider.label}</Typography>
                                                 {!provider.ready && (
                                                     <Chip
@@ -1115,12 +1150,16 @@ const DevDashboard: React.FC = () => {
                                     />
                                 ))}
                                 {isLoadingProviders && (
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         Loading providers...
                                     </Typography>
                                 )}
                                 {providers.length === 0 && !isLoadingProviders && (
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         No providers available.
                                     </Typography>
                                 )}
@@ -1129,7 +1168,9 @@ const DevDashboard: React.FC = () => {
 
                         <Divider />
 
-                        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="flex-start">
+                        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{
+                            alignItems: "flex-start"
+                        }}>
                             <TextField
                                 label="Search foods"
                                 placeholder="e.g. greek yogurt, oat milk, chicken breast"
@@ -1142,21 +1183,23 @@ const DevDashboard: React.FC = () => {
                                         void handleSearch();
                                     }
                                 }}
-                                InputProps={{
-                                    endAdornment: (
-                                        <InputAdornment position="end">
-                                            <IconButton
-                                                aria-label="Scan barcode"
-                                                title="Scan barcode"
-                                                onClick={() => setIsScannerOpen(true)}
-                                                size="small"
-                                                edge="end"
-                                                disabled={isSearching || isLoadingProviders}
-                                            >
-                                                <QrCodeScannerIcon />
-                                            </IconButton>
-                                        </InputAdornment>
-                                    )
+                                slotProps={{
+                                    input: {
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label="Scan barcode"
+                                                    title="Scan barcode"
+                                                    onClick={() => setIsScannerOpen(true)}
+                                                    size="small"
+                                                    edge="end"
+                                                    disabled={isSearching || isLoadingProviders}
+                                                >
+                                                    <QrCodeScannerIcon />
+                                                </IconButton>
+                                            </InputAdornment>
+                                        )
+                                    }
                                 }}
                             />
                             <Stack direction="row" spacing={2}>
@@ -1188,7 +1231,9 @@ const DevDashboard: React.FC = () => {
                             }}
                         />
 
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography variant="caption" sx={{
+                            color: "text.secondary"
+                        }}>
                             Tip: Use the barcode scan button to test UPC/EAN lookups (camera or manual entry).
                         </Typography>
 
@@ -1196,9 +1241,10 @@ const DevDashboard: React.FC = () => {
                     </Stack>
                 </CardContent>
             </Card>
-
             {results.length === 0 ? (
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" sx={{
+                    color: "text.secondary"
+                }}>
                     No results yet. Run a query to see provider comparisons.
                 </Typography>
             ) : (
@@ -1210,7 +1256,9 @@ const DevDashboard: React.FC = () => {
                                     <Stack spacing={1.5}>
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, flexWrap: 'wrap' }}>
                                             <Typography variant="h6">{providerResult.label}</Typography>
-                                            <Stack direction="row" spacing={1} alignItems="center">
+                                            <Stack direction="row" spacing={1} sx={{
+                                                alignItems: "center"
+                                            }}>
                                                 {providerResult.elapsedMs !== undefined && (
                                                     <Chip label={`${providerResult.elapsedMs} ms`} size="small" />
                                                 )}
@@ -1225,7 +1273,9 @@ const DevDashboard: React.FC = () => {
                                         {providerResult.error && <Alert severity="error">{providerResult.error}</Alert>}
 
                                         {!providerResult.error && providerResult.items.length === 0 && (
-                                            <Typography variant="body2" color="text.secondary">
+                                            <Typography variant="body2" sx={{
+                                                color: "text.secondary"
+                                            }}>
                                                 No matches returned by this provider.
                                             </Typography>
                                         )}
@@ -1235,7 +1285,9 @@ const DevDashboard: React.FC = () => {
                                                 {providerResult.items.map((item) => (
                                                     <Box key={`${providerResult.name}-${item.id}`}>
                                                         <Typography variant="subtitle2">{item.description}</Typography>
-                                                        <Typography variant="caption" color="text.secondary">
+                                                        <Typography variant="caption" sx={{
+                                                            color: "text.secondary"
+                                                        }}>
                                                             {buildItemDetails(item)}
                                                         </Typography>
                                                         <Divider sx={{ mt: 1 }} />

--- a/frontend/src/pages/Goals.tsx
+++ b/frontend/src/pages/Goals.tsx
@@ -621,6 +621,7 @@ const Goals: React.FC = () => {
                                 label: rawWeightSeriesLabel,
                                 color: rawLineColor,
                                 showMark: true,
+                                shape: 'circle',
                                 connectNulls: false,
                                 valueFormatter: (value) => (value == null ? null : `${value.toFixed(1)} ${unitLabel}`)
                             }

--- a/frontend/src/pages/Goals.tsx
+++ b/frontend/src/pages/Goals.tsx
@@ -17,7 +17,7 @@ import ChevronLeftRoundedIcon from '@mui/icons-material/ChevronLeftRounded';
 import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded';
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
-import { LineChart } from '@mui/x-charts/LineChart';
+import { LineChart, lineClasses } from '@mui/x-charts/LineChart';
 import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
 import GoalTrackerCard from '../components/GoalTrackerCard';
 import { useAuth } from '../context/useAuth';
@@ -395,7 +395,12 @@ const Goals: React.FC = () => {
     }, [t, trendMeta?.volatility]);
 
     const summaryLine = trendMeta ? (
-        <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+        <Typography
+            variant="body2"
+            sx={{
+                color: "text.secondary",
+                textAlign: 'center'
+            }}>
             {t('goals.weightHistorySummary.weeklyRate', {
                 value: trendMeta.weekly_rate.toFixed(2),
                 unit: unitLabel
@@ -488,9 +493,11 @@ const Goals: React.FC = () => {
                         </Tooltip>
                         <Typography
                             variant="caption"
-                            color="text.secondary"
-                            sx={{ minWidth: `${PAN_WINDOW_LABEL_MIN_WIDTH_CH}ch`, textAlign: 'center' }}
-                        >
+                            sx={{
+                                color: "text.secondary",
+                                minWidth: `${PAN_WINDOW_LABEL_MIN_WIDTH_CH}ch`,
+                                textAlign: 'center'
+                            }}>
                             {visibleWindowLabel}
                         </Typography>
                         <Tooltip title={t('goals.weightHistoryPanNext')}>
@@ -529,7 +536,9 @@ const Goals: React.FC = () => {
             </Box>
         );
     } else if (points.length === 0) {
-        weightHistoryContent = <Typography color="text.secondary">{t('goals.noWeightEntries')}</Typography>;
+        weightHistoryContent = <Typography sx={{
+            color: "text.secondary"
+        }}>{t('goals.noWeightEntries')}</Typography>;
     } else {
         weightHistoryContent = (
             <Stack spacing={1.5}>
@@ -619,24 +628,24 @@ const Goals: React.FC = () => {
                         height={CHART_HEIGHT_PX}
                         margin={chartMargin}
                         skipAnimation={false}
-                        slotProps={{ legend: { hidden: true } }}
-                        tooltip={{ trigger: 'axis' }}
+                        hideLegend
+                        slotProps={{ tooltip: { trigger: 'axis' } }}
                         sx={{
-                            '& .MuiAreaElement-series-expectedRangeBand': {
+                            [`& .${lineClasses.area}[data-series="expectedRangeBand"]`]: {
                                 fill: expectedRangeFillColor,
                                 fillOpacity: 1
                             },
-                            '& .MuiLineElement-series-expectedRangeBand': {
+                            [`& .${lineClasses.line}[data-series="expectedRangeBand"]`]: {
                                 stroke: expectedRangeEdgeColor,
                                 strokeWidth: 1
                             },
-                            '& .MuiLineElement-series-trend': {
+                            [`& .${lineClasses.line}[data-series="trend"]`]: {
                                 strokeWidth: TREND_LINE_STROKE_WIDTH_PX
                             },
-                            '& .MuiLineElement-series-raw': {
+                            [`& .${lineClasses.line}[data-series="raw"]`]: {
                                 strokeWidth: RAW_LINE_STROKE_WIDTH_PX
                             },
-                            '& .MuiMarkElement-series-raw': {
+                            [`& .${lineClasses.mark}[data-series="raw"]`]: {
                                 stroke: rawLineColor,
                                 strokeWidth: RAW_MARK_STROKE_WIDTH_PX,
                                 opacity: rawMarksVisible ? 1 : 0,
@@ -675,7 +684,9 @@ const Goals: React.FC = () => {
                                 backgroundColor: rawLineColor
                             }}
                         />
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {rawWeightSeriesLabel}
                         </Typography>
                     </Box>
@@ -689,7 +700,9 @@ const Goals: React.FC = () => {
                                 backgroundColor: trendLineColor
                             }}
                         />
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {trendSeriesLabel}
                         </Typography>
                     </Box>
@@ -705,7 +718,9 @@ const Goals: React.FC = () => {
                                 border: `1px solid ${expectedRangeEdgeColor}`
                             }}
                         />
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {expectedRangeLabel}
                         </Typography>
                     </Box>
@@ -734,7 +749,9 @@ const Goals: React.FC = () => {
                     >
                         <Box sx={{ minWidth: 0, flexGrow: 1 }}>
                             <Typography variant="h6">{t('goals.weightHistoryTitle')}</Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 {t('goals.weightHistoryExplainer.inline')}
                             </Typography>
                         </Box>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -103,7 +103,9 @@ function LandingFeatureCard({ feature }: { feature: LandingFeature }) {
 
                 <Box sx={{ minWidth: 0 }}>
                     <Typography variant="subtitle1">{t(feature.titleKey)}</Typography>
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {t(feature.descriptionKey)}
                     </Typography>
                 </Box>
@@ -179,7 +181,9 @@ const Landing: React.FC = () => {
                         }
                     })}
                 >
-                    <Grid container spacing={{ xs: 3, md: 4 }} alignItems="stretch">
+                    <Grid container spacing={{ xs: 3, md: 4 }} sx={{
+                        alignItems: "stretch"
+                    }}>
                         <Grid size={{ xs: 12, md: 7 }}>
                             <Stack spacing={2.5} sx={{ position: 'relative' }}>
                                 <Stack spacing={1}>
@@ -198,14 +202,21 @@ const Landing: React.FC = () => {
                                         {t('landing.hero.title')}
                                     </Typography>
 
-                                    <Typography variant="h6" color="text.secondary" sx={{ maxWidth: '56ch' }}>
+                                    <Typography
+                                        variant="h6"
+                                        sx={{
+                                            color: "text.secondary",
+                                            maxWidth: '56ch'
+                                        }}>
                                         {t('landing.hero.subtitleLine1')}
                                         <br />
                                         {t('landing.hero.subtitleLine2')}
                                     </Typography>
                                 </Stack>
 
-                                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                                <Stack direction="row" spacing={1} useFlexGap sx={{
+                                    flexWrap: "wrap"
+                                }}>
                                     {LANDING_PILL_KEYS.map((pillKey) => (
                                         <Chip key={pillKey} label={t(pillKey)} size="small" variant="outlined" />
                                     ))}
@@ -232,7 +243,12 @@ const Landing: React.FC = () => {
                                     </Button>
                                 </Stack>
 
-                                <Typography variant="body2" color="text.secondary" sx={{ maxWidth: '68ch' }}>
+                                <Typography
+                                    variant="body2"
+                                    sx={{
+                                        color: "text.secondary",
+                                        maxWidth: '68ch'
+                                    }}>
                                     {t('landing.hero.body')}
                                 </Typography>
                             </Stack>
@@ -251,12 +267,19 @@ const Landing: React.FC = () => {
                         <Typography variant="h4" component="h2">
                             {t('landing.section.goals.title')}
                         </Typography>
-                        <Typography variant="body1" color="text.secondary" sx={{ maxWidth: '80ch' }}>
+                        <Typography
+                            variant="body1"
+                            sx={{
+                                color: "text.secondary",
+                                maxWidth: '80ch'
+                            }}>
                             {t('landing.section.goals.body')}
                         </Typography>
                     </Stack>
 
-                    <Grid container spacing={2} alignItems="stretch">
+                    <Grid container spacing={2} sx={{
+                        alignItems: "stretch"
+                    }}>
                         {LANDING_GOAL_FEATURES.map((feature) => (
                             <Grid key={feature.titleKey} size={{ xs: 12, sm: 6, md: 4 }} sx={{ display: 'flex' }}>
                                 <LandingFeatureCard feature={feature} />
@@ -270,12 +293,19 @@ const Landing: React.FC = () => {
                         <Typography variant="h4" component="h2">
                             {t('landing.section.value.title')}
                         </Typography>
-                        <Typography variant="body1" color="text.secondary" sx={{ maxWidth: '80ch' }}>
+                        <Typography
+                            variant="body1"
+                            sx={{
+                                color: "text.secondary",
+                                maxWidth: '80ch'
+                            }}>
                             {t('landing.section.value.body')}
                         </Typography>
                     </Stack>
 
-                    <Grid container spacing={2} alignItems="stretch">
+                    <Grid container spacing={2} sx={{
+                        alignItems: "stretch"
+                    }}>
                         {LANDING_VALUE_FEATURES.map((feature) => (
                             <Grid key={feature.titleKey} size={{ xs: 12, sm: 6, md: 4 }} sx={{ display: 'flex' }}>
                                 <LandingFeatureCard feature={feature} />
@@ -290,13 +320,17 @@ const Landing: React.FC = () => {
                         borderColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.36 : 0.22)
                     })}
                 >
-                    <Grid container spacing={{ xs: 2, md: 3 }} alignItems="center">
+                    <Grid container spacing={{ xs: 2, md: 3 }} sx={{
+                        alignItems: "center"
+                    }}>
                         <Grid size={{ xs: 12, md: 8 }}>
                             <Stack spacing={0.75}>
                                 <Typography variant="h5" component="h3">
                                     {t('landing.cta.title')}
                                 </Typography>
-                                <Typography variant="body1" color="text.secondary">
+                                <Typography variant="body1" sx={{
+                                    color: "text.secondary"
+                                }}>
                                     {t('landing.cta.body')}
                                 </Typography>
                             </Stack>
@@ -325,10 +359,13 @@ const Landing: React.FC = () => {
                     <Stack
                         direction={{ xs: 'column', sm: 'row' }}
                         spacing={1}
-                        justifyContent="center"
-                        alignItems="center"
-                    >
-                        <Link component={RouterLink} to="/privacy" underline="hover" color="text.secondary">
+                        sx={{
+                            justifyContent: "center",
+                            alignItems: "center"
+                        }}>
+                        <Link component={RouterLink} to="/privacy" underline="hover" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('legal.privacyPolicy')}
                         </Link>
                         <FatSecretAttributionLink />

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -801,10 +801,16 @@ const Onboarding: React.FC = () => {
                 <Typography variant="h4" gutterBottom>
                     Welcome to calibrate
                 </Typography>
-                <Typography color="text.secondary">
+                <Typography sx={{
+                    color: "text.secondary"
+                }}>
                     Let&apos;s set a daily calorie target that helps you reach your weight goal.
                 </Typography>
-                <Typography color="text.secondary" sx={{ mt: 1 }}>
+                <Typography
+                    sx={{
+                        color: "text.secondary",
+                        mt: 1
+                    }}>
                     Three quick steps: set your target weight, estimate calorie burn, and optionally import history.
                 </Typography>
             </Box>
@@ -889,7 +895,14 @@ const Onboarding: React.FC = () => {
         );
     } else if (stage === 'summary') {
         cardFooterContent = (
-            <Stack direction="row" spacing={2} justifyContent="space-between" alignItems="center" sx={{ pt: 2 }}>
+            <Stack
+                direction="row"
+                spacing={2}
+                sx={{
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    pt: 2
+                }}>
                 <Button variant="text" onClick={editSetupFromSummary} disabled={isSaving}>
                     Edit setup
                 </Button>
@@ -906,7 +919,13 @@ const Onboarding: React.FC = () => {
                     <Box>{footerQuestionControl}</Box>
                 </Fade>
 
-                <Stack direction="row" spacing={2} justifyContent="space-between" alignItems="center">
+                <Stack
+                    direction="row"
+                    spacing={2}
+                    sx={{
+                        justifyContent: "space-between",
+                        alignItems: "center"
+                    }}>
                     <Button variant="text" onClick={goBack} disabled={isSaving}>
                         Back
                     </Button>

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -33,7 +33,12 @@ const PrivacyPolicy: React.FC = () => {
                         <Typography variant="h3" component="h1">
                             {t('legal.privacyPolicy')}
                         </Typography>
-                        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mt: 0.75
+                            }}>
                             <Box component="span" sx={{ fontWeight: 700 }}>
                                 Last updated:
                             </Box>{' '}
@@ -48,7 +53,12 @@ const PrivacyPolicy: React.FC = () => {
                             </Link>{' '}
                             (the "Service").
                         </Typography>
-                        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mt: 1
+                            }}>
                             Calibrate Health is a calorie and weight-tracking tool. It is not a medical service and does
                             not provide medical advice.
                         </Typography>
@@ -70,7 +80,9 @@ const PrivacyPolicy: React.FC = () => {
                                     </Typography>
                                     <Box component="ul" sx={LIST_SX}>
                                         <Box component="li">
-                                            <Typography variant="body2" fontWeight={700}>
+                                            <Typography variant="body2" sx={{
+                                                fontWeight: 700
+                                            }}>
                                                 Account information
                                             </Typography>
                                             <Box component="ul" sx={NESTED_LIST_SX}>
@@ -83,7 +95,9 @@ const PrivacyPolicy: React.FC = () => {
                                             </Box>
                                         </Box>
                                         <Box component="li">
-                                            <Typography variant="body2" fontWeight={700}>
+                                            <Typography variant="body2" sx={{
+                                                fontWeight: 700
+                                            }}>
                                                 Profile information
                                             </Typography>
                                             <Box component="ul" sx={NESTED_LIST_SX}>
@@ -108,7 +122,9 @@ const PrivacyPolicy: React.FC = () => {
                                             </Box>
                                         </Box>
                                         <Box component="li">
-                                            <Typography variant="body2" fontWeight={700}>
+                                            <Typography variant="body2" sx={{
+                                                fontWeight: 700
+                                            }}>
                                                 Health-related data you choose to enter
                                             </Typography>
                                             <Box component="ul" sx={NESTED_LIST_SX}>
@@ -124,7 +140,9 @@ const PrivacyPolicy: React.FC = () => {
                                             </Box>
                                         </Box>
                                         <Box component="li">
-                                            <Typography variant="body2" fontWeight={700}>
+                                            <Typography variant="body2" sx={{
+                                                fontWeight: 700
+                                            }}>
                                                 Imported data
                                             </Typography>
                                             <Box component="ul" sx={NESTED_LIST_SX}>
@@ -134,7 +152,9 @@ const PrivacyPolicy: React.FC = () => {
                                             </Box>
                                         </Box>
                                     </Box>
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         All health-related data is entered voluntarily and is stored solely to provide the
                                         core functionality of the Service.
                                     </Typography>
@@ -167,7 +187,9 @@ const PrivacyPolicy: React.FC = () => {
                                             Application usage necessary for authentication and session management
                                         </Typography>
                                     </Box>
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         We do not use this data for advertising or behavioral profiling.
                                     </Typography>
                                 </Stack>
@@ -189,7 +211,9 @@ const PrivacyPolicy: React.FC = () => {
                                             USDA FoodData Central (when enabled)
                                         </Typography>
                                     </Box>
-                                    <Typography variant="body2" color="text.secondary">
+                                    <Typography variant="body2" sx={{
+                                        color: "text.secondary"
+                                    }}>
                                         When you search for foods or scan barcodes, your query may be sent to these
                                         providers. Calibrate does not send personally identifiable information (such as your
                                         email address or account ID) to these services.
@@ -227,7 +251,9 @@ const PrivacyPolicy: React.FC = () => {
                                     Diagnose bugs and maintain system reliability
                                 </Typography>
                             </Box>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 We do not sell your data, rent it, or use it for targeted advertising.
                             </Typography>
                         </Stack>
@@ -252,7 +278,9 @@ const PrivacyPolicy: React.FC = () => {
                                     Security
                                 </Typography>
                             </Box>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 We do not use third-party advertising cookies or tracking pixels.
                             </Typography>
                         </Stack>
@@ -277,7 +305,9 @@ const PrivacyPolicy: React.FC = () => {
                                     Access-controlled databases
                                 </Typography>
                             </Box>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 While no system can guarantee absolute security, we take reasonable measures to protect your
                                 information against unauthorized access, loss, or misuse.
                             </Typography>
@@ -341,7 +371,9 @@ const PrivacyPolicy: React.FC = () => {
                                     Export your data
                                 </Typography>
                             </Box>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 You can exercise most of these rights directly within the Service. If you need assistance,
                                 contact us using the information below.
                             </Typography>
@@ -356,7 +388,9 @@ const PrivacyPolicy: React.FC = () => {
                             <Typography variant="body1">
                                 Calibrate Health is not intended for use by children under the age of 13.
                             </Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 We do not knowingly collect personal data from children. If you believe a child has provided
                                 personal information, please contact us and we will delete it.
                             </Typography>
@@ -369,7 +403,9 @@ const PrivacyPolicy: React.FC = () => {
                         </Typography>
                         <Stack spacing={PARAGRAPH_SPACING} sx={{ mt: 1.5 }} useFlexGap>
                             <Typography variant="body1">We may update this Privacy Policy from time to time.</Typography>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" sx={{
+                                color: "text.secondary"
+                            }}>
                                 If we make material changes, we will notify users by updating the "Last updated" date and,
                                 when appropriate, by providing notice within the Service.
                             </Typography>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -256,7 +256,6 @@ const Profile: React.FC = () => {
                         <TextField
                             label={t('profile.dateOfBirth')}
                             type="date"
-                            InputLabelProps={{ shrink: true }}
                             value={dobValue}
                             onChange={(e) => {
                                 const next = e.target.value;
@@ -264,6 +263,9 @@ const Profile: React.FC = () => {
                                 queueAutosave({ date_of_birth: normalizePatchString(next) });
                             }}
                             fullWidth
+                            slotProps={{
+                                inputLabel: { shrink: true }
+                            }}
                         />
 
                         <FormControl fullWidth>
@@ -292,8 +294,10 @@ const Profile: React.FC = () => {
                                     setHeightCm(next);
                                     queueAutosave({ height_cm: normalizePatchString(next) });
                                 }}
-                                inputProps={{ min: 50, max: 272, step: 0.1 }}
                                 fullWidth
+                                slotProps={{
+                                    htmlInput: { min: 50, max: 272, step: 0.1 }
+                                }}
                             />
                         ) : (
                             <Box sx={{ display: 'flex', gap: 2 }}>
@@ -306,8 +310,10 @@ const Profile: React.FC = () => {
                                         setHeightFeet(next);
                                         queueAutosave(buildFeetInchesHeightPatch(next, heightInchesValue));
                                     }}
-                                    inputProps={{ min: 1, max: 8, step: 1 }}
                                     fullWidth
+                                    slotProps={{
+                                        htmlInput: { min: 1, max: 8, step: 1 }
+                                    }}
                                 />
                                 <TextField
                                     label={t('profile.inches')}
@@ -318,13 +324,17 @@ const Profile: React.FC = () => {
                                         setHeightInches(next);
                                         queueAutosave(buildFeetInchesHeightPatch(heightFeetValue, next));
                                     }}
-                                    inputProps={{ min: 0, max: 11.9, step: 0.1 }}
                                     fullWidth
+                                    slotProps={{
+                                        htmlInput: { min: 0, max: 11.9, step: 0.1 }
+                                    }}
                                 />
                             </Box>
                         )}
 
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography variant="caption" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('profile.unitsTimezoneHint.prefix')}{' '}
                             <Link component={RouterLink} to="/settings">
                                 {t('nav.settings')}
@@ -358,10 +368,14 @@ const Profile: React.FC = () => {
                                         }}
                                     >
                                         <Box>
-                                            <Typography variant="body2" fontWeight={800}>
+                                            <Typography variant="body2" sx={{
+                                                fontWeight: 800
+                                            }}>
                                                 {option.title}
                                             </Typography>
-                                            <Typography variant="caption" color="text.secondary">
+                                            <Typography variant="caption" sx={{
+                                                color: "text.secondary"
+                                            }}>
                                                 {option.description}
                                             </Typography>
                                         </Box>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -425,7 +425,9 @@ const Settings: React.FC = () => {
                     <Stack spacing={1.5} useFlexGap>
                         <SectionHeader title={t('settings.feedbackTitle')} />
 
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('settings.feedbackDescription')}
                         </Typography>
 
@@ -455,7 +457,9 @@ const Settings: React.FC = () => {
                     <Stack spacing={1.5} useFlexGap>
                         <SectionHeader title={t('settings.remindersTitle')} />
 
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('settings.remindersDescription')}
                         </Typography>
 
@@ -475,7 +479,9 @@ const Settings: React.FC = () => {
                             <FormHelperText>{reminderSupport.message}</FormHelperText>
                         </FormControl>
 
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" sx={{
+                            color: "text.secondary"
+                        }}>
                             {t('settings.remindersPreferencesHelper')}
                         </Typography>
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -652,7 +652,7 @@ export function createAppTheme(mode: PaletteMode) {
                     })
                 }
             },
-            MuiLineElement: {
+            MuiLinePlot: {
                 styleOverrides: {
                     root: {
                         strokeWidth: 3,
@@ -661,7 +661,7 @@ export function createAppTheme(mode: PaletteMode) {
                     }
                 }
             },
-            MuiMarkElement: {
+            MuiMarkPlot: {
                 styleOverrides: {
                     root: ({ theme }) => ({
                         fill: theme.palette.background.paper,

--- a/frontend/src/ui/SectionHeader.tsx
+++ b/frontend/src/ui/SectionHeader.tsx
@@ -53,12 +53,13 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
             <Box sx={{ minWidth: 0 }}>
                 <Typography variant={titleVariant}>{title}</Typography>
                 {subtitle ? (
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
                         {subtitle}
                     </Typography>
                 ) : null}
             </Box>
-
             {actions ? <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>{actions}</Box> : null}
         </Box>
     );

--- a/scripts/dev-env.mjs
+++ b/scripts/dev-env.mjs
@@ -22,6 +22,7 @@ const packages = [
     name: "backend",
     directory: path.join(repoRoot, "backend"),
     installArgs: ["ci", "--prefer-offline", "--no-audit", "--fund=false"],
+    requiredPaths: ["node_modules/ts-node/package.json"],
   },
   {
     name: "frontend",
@@ -32,6 +33,11 @@ const packages = [
       "--prefer-offline",
       "--no-audit",
       "--fund=false",
+    ],
+    requiredPaths: [
+      "node_modules/.bin/vite",
+      "node_modules/react/package.json",
+      "node_modules/react-dom/package.json",
     ],
   },
 ];
@@ -300,6 +306,15 @@ function hasCurrentInstall(packageConfig) {
  * @returns {{ current: boolean, reason: string }} Install-cache status.
  */
 function dependencyInstallStatus(packageConfig) {
+  for (const requiredPath of packageConfig.requiredPaths ?? []) {
+    if (!fs.existsSync(path.join(packageConfig.directory, requiredPath))) {
+      return {
+        current: false,
+        reason: `required dependency path is missing (${requiredPath})`,
+      };
+    }
+  }
+
   const sentinel = readInstallSentinel(packageConfig.directory);
   if (!sentinel) {
     return {


### PR DESCRIPTION
## Summary

- Upgrade frontend MUI packages to v9 (`@mui/material`, `@mui/icons-material`, and `@mui/x-charts`).
- Apply the MUI v9 codemods for removed/deprecated props across the frontend.
- Manually update X Charts usage and theme overrides for the v9 API.
- Pin the raw weight chart series marker shape to `circle`, because MUI X v9 cycles marker shapes across line series by default.
- Harden the dev dependency preflight so corrupted/stale node_modules volumes reinstall instead of reaching `vite: not found`.

## Impact

This keeps the React frontend on the current MUI major while preserving the existing UI behavior. The notable manual changes are in the weight history chart: legend hiding now uses `hideLegend`, tooltip config moves under `slotProps.tooltip`, chart element styling uses `lineClasses` plus `data-series` selectors, and raw weight points remain circular instead of inheriting MUI X v9's auto-cycled marker shape.

The devcontainer preflight now validates key package files/binaries before trusting the install sentinel, which should make stale dependency volumes self-heal after lockfile-changing upgrades.

## Validation

- `npm.cmd --prefix frontend run lint`
- `npm.cmd --prefix frontend run build`
- `docker exec 74e6b55c8f97 bash -lc "cd /workspaces/calibrate-health && node scripts/dev-env.mjs deps"`
- Timed Vite smoke start inside the active devcontainer reached `VITE v8.0.8 ready` on port 5790.
- Browser DOM check on `/goals`: raw weight markers render as `circle.MuiLineChart-mark[data-series="raw"]` and no raw marker paths remain.

## Notes

`npm install` reported existing audit findings, and the Vite build still emits the existing chunk-size / `inlineDynamicImports` warnings. I did not run `npm audit fix`.