### PR TITLE
[codex] Add notification SSE stream

### DIFF
--- a/backend/src/routes/dev.ts
+++ b/backend/src/routes/dev.ts
@@ -18,6 +18,8 @@ import {
 import { buildDevReminderInAppDedupeKey } from '../services/inAppNotifications';
 import { getSafeUtcTodayDateOnlyInTimeZone } from '../utils/date';
 import { deliverUserNotification, type DeliverUserNotificationResult } from '../services/notificationDelivery';
+import { publishNotificationRealtimeUpdate } from '../services/notificationRealtime';
+import { NOTIFICATION_REALTIME_REASONS } from '../../../shared/notificationRealtime';
 
 /**
  * Dev-only endpoints for food provider diagnostics and comparisons.
@@ -463,6 +465,13 @@ router.post('/notifications/clear', requireAuthenticatedUser, async (req, res) =
                   }
               });
         clearedInAppCount = result.count;
+    }
+
+    if (clearedInAppCount > 0) {
+        publishNotificationRealtimeUpdate({
+            userId: user.id,
+            reason: NOTIFICATION_REALTIME_REASONS.CLEARED
+        });
     }
 
     res.json({

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -8,12 +8,17 @@ import {
   resolveInactiveReminderNotificationsForUser
 } from '../services/inAppNotifications';
 import { getWebPushPublicKey } from '../services/webPush';
+import {
+  NOTIFICATION_REALTIME_EVENT_NAME,
+  subscribeToNotificationRealtimeUpdates
+} from '../services/notificationRealtime';
 import { parsePositiveInteger } from '../utils/requestParsing';
 
 /**
  * Push notification subscription endpoints plus in-app reminder feed endpoints.
  */
 const router = express.Router();
+const SSE_HEARTBEAT_INTERVAL_MS = 25_000; // Keep intermediaries from closing otherwise-idle notification streams.
 
 /**
  * Ensure the session is authenticated before accessing notification settings.
@@ -26,6 +31,43 @@ const isAuthenticated = (req: express.Request, res: express.Response, next: expr
 };
 
 router.use(isAuthenticated);
+
+/**
+ * Stream per-user notification state changes to the authenticated browser session.
+ */
+router.get('/stream', (req, res) => {
+  const user = req.user as { id: number };
+
+  res.status(200);
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no'
+  });
+  res.flushHeaders?.();
+  res.write(': connected\n\n');
+
+  const writeEvent = (payload: unknown) => {
+    res.write(`event: ${NOTIFICATION_REALTIME_EVENT_NAME}\n`);
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  };
+
+  const unsubscribe = subscribeToNotificationRealtimeUpdates({
+    userId: user.id,
+    onUpdate: writeEvent
+  });
+
+  const heartbeatId = setInterval(() => {
+    res.write(': heartbeat\n\n');
+  }, SSE_HEARTBEAT_INTERVAL_MS);
+
+  req.on('close', () => {
+    clearInterval(heartbeatId);
+    unsubscribe();
+    res.end();
+  });
+});
 
 router.get('/public-key', (_req, res) => {
   const { publicKey, error } = getWebPushPublicKey();

--- a/backend/src/services/inAppNotifications.ts
+++ b/backend/src/services/inAppNotifications.ts
@@ -2,6 +2,8 @@ import { InAppNotificationType, Prisma } from '@prisma/client';
 import prisma from '../config/database';
 import { getSafeUtcTodayDateOnlyInTimeZone } from '../utils/date';
 import { IN_APP_NOTIFICATION_ACTION_URLS, IN_APP_NOTIFICATION_TYPES, type InAppNotificationType as SharedInAppNotificationType } from '../../../shared/inAppNotifications';
+import { NOTIFICATION_REALTIME_REASONS } from '../../../shared/notificationRealtime';
+import { publishNotificationRealtimeUpdate } from './notificationRealtime';
 
 const REMINDER_TYPES: readonly InAppNotificationType[] = [
     InAppNotificationType.LOG_WEIGHT_REMINDER,
@@ -190,7 +192,7 @@ export const ensureReminderInAppNotificationsForDate = async ({
     missingWeight,
     missingFood,
     db = prisma
-}: EnsureReminderNotificationsArgs): Promise<void> => {
+}: EnsureReminderNotificationsArgs): Promise<number> => {
     const rows: Prisma.InAppNotificationCreateManyInput[] = [];
 
     if (missingWeight) {
@@ -212,13 +214,22 @@ export const ensureReminderInAppNotificationsForDate = async ({
     }
 
     if (rows.length === 0) {
-        return;
+        return 0;
     }
 
-    await db.inAppNotification.createMany({
+    const result = await db.inAppNotification.createMany({
         data: rows,
         skipDuplicates: true
     });
+
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.CREATED
+        });
+    }
+
+    return result.count;
 };
 
 /**
@@ -327,6 +338,14 @@ export const resolveInactiveReminderNotificationsForUser = async ({
         }
     });
 
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.RESOLVED,
+            now
+        });
+    }
+
     return result.count;
 };
 
@@ -371,8 +390,8 @@ export const markInAppNotificationRead = async ({
     notificationId,
     now = new Date(),
     db = prisma
-}: MarkInAppNotificationArgs): Promise<void> => {
-    await db.inAppNotification.updateMany({
+}: MarkInAppNotificationArgs): Promise<number> => {
+    const result = await db.inAppNotification.updateMany({
         where: {
             id: notificationId,
             user_id: userId,
@@ -384,6 +403,16 @@ export const markInAppNotificationRead = async ({
             read_at: now
         }
     });
+
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.READ,
+            now
+        });
+    }
+
+    return result.count;
 };
 
 /**
@@ -394,8 +423,8 @@ export const markInAppNotificationDismissed = async ({
     notificationId,
     now = new Date(),
     db = prisma
-}: MarkInAppNotificationArgs): Promise<void> => {
-    await db.inAppNotification.updateMany({
+}: MarkInAppNotificationArgs): Promise<number> => {
+    const result = await db.inAppNotification.updateMany({
         where: {
             id: notificationId,
             user_id: userId,
@@ -407,4 +436,14 @@ export const markInAppNotificationDismissed = async ({
             read_at: now
         }
     });
+
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.DISMISSED,
+            now
+        });
+    }
+
+    return result.count;
 };

--- a/backend/src/services/inAppNotifications.ts
+++ b/backend/src/services/inAppNotifications.ts
@@ -2,6 +2,8 @@ import { InAppNotificationType, Prisma } from '@prisma/client';
 import prisma from '../config/database';
 import { getSafeUtcTodayDateOnlyInTimeZone } from '../utils/date';
 import { IN_APP_NOTIFICATION_ACTION_URLS, IN_APP_NOTIFICATION_TYPES, type InAppNotificationType as SharedInAppNotificationType } from '../../../shared/inAppNotifications';
+import { NOTIFICATION_REALTIME_REASONS } from '../../../shared/notificationRealtime';
+import { publishNotificationRealtimeUpdate } from './notificationRealtime';
 
 const REMINDER_TYPES: readonly InAppNotificationType[] = [
     InAppNotificationType.LOG_WEIGHT_REMINDER,
@@ -58,6 +60,14 @@ type ReminderMissingStatusArgs = {
     localDate: Date;
     reminderLogWeightEnabled: boolean;
     reminderLogFoodEnabled: boolean;
+    db?: InAppNotificationClient;
+};
+
+type EnsureReminderNotificationsArgs = {
+    userId: number;
+    localDate: Date;
+    missingWeight: boolean;
+    missingFood: boolean;
     db?: InAppNotificationClient;
 };
 
@@ -174,6 +184,55 @@ export const getReminderMissingStatusForDate = async ({
 };
 
 /**
+ * Create in-app reminder entries for missing logs, without re-opening dismissed items.
+ */
+export const ensureReminderInAppNotificationsForDate = async ({
+    userId,
+    localDate,
+    missingWeight,
+    missingFood,
+    db = prisma
+}: EnsureReminderNotificationsArgs): Promise<number> => {
+    const rows: Prisma.InAppNotificationCreateManyInput[] = [];
+
+    if (missingWeight) {
+        rows.push({
+            user_id: userId,
+            type: InAppNotificationType.LOG_WEIGHT_REMINDER,
+            local_date: localDate,
+            dedupe_key: buildReminderInAppDedupeKey(InAppNotificationType.LOG_WEIGHT_REMINDER, localDate)
+        });
+    }
+
+    if (missingFood) {
+        rows.push({
+            user_id: userId,
+            type: InAppNotificationType.LOG_FOOD_REMINDER,
+            local_date: localDate,
+            dedupe_key: buildReminderInAppDedupeKey(InAppNotificationType.LOG_FOOD_REMINDER, localDate)
+        });
+    }
+
+    if (rows.length === 0) {
+        return 0;
+    }
+
+    const result = await db.inAppNotification.createMany({
+        data: rows,
+        skipDuplicates: true
+    });
+
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.CREATED
+        });
+    }
+
+    return result.count;
+};
+
+/**
  * Resolve active reminders when the user completes a log or when the local day has passed.
  */
 export const resolveInactiveReminderNotificationsForUser = async ({
@@ -279,6 +338,14 @@ export const resolveInactiveReminderNotificationsForUser = async ({
         }
     });
 
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.RESOLVED,
+            now
+        });
+    }
+
     return result.count;
 };
 
@@ -323,8 +390,8 @@ export const markInAppNotificationRead = async ({
     notificationId,
     now = new Date(),
     db = prisma
-}: MarkInAppNotificationArgs): Promise<void> => {
-    await db.inAppNotification.updateMany({
+}: MarkInAppNotificationArgs): Promise<number> => {
+    const result = await db.inAppNotification.updateMany({
         where: {
             id: notificationId,
             user_id: userId,
@@ -336,6 +403,16 @@ export const markInAppNotificationRead = async ({
             read_at: now
         }
     });
+
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.READ,
+            now
+        });
+    }
+
+    return result.count;
 };
 
 /**
@@ -346,8 +423,8 @@ export const markInAppNotificationDismissed = async ({
     notificationId,
     now = new Date(),
     db = prisma
-}: MarkInAppNotificationArgs): Promise<void> => {
-    await db.inAppNotification.updateMany({
+}: MarkInAppNotificationArgs): Promise<number> => {
+    const result = await db.inAppNotification.updateMany({
         where: {
             id: notificationId,
             user_id: userId,
@@ -359,4 +436,14 @@ export const markInAppNotificationDismissed = async ({
             read_at: now
         }
     });
+
+    if (result.count > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.DISMISSED,
+            now
+        });
+    }
+
+    return result.count;
 };

--- a/backend/src/services/notificationDelivery.ts
+++ b/backend/src/services/notificationDelivery.ts
@@ -6,6 +6,8 @@ import {
     resolveNotificationDeliveryChannels,
     type NotificationDeliveryChannel
 } from '../../../shared/notificationDelivery';
+import { NOTIFICATION_REALTIME_REASONS } from '../../../shared/notificationRealtime';
+import { publishNotificationRealtimeUpdate } from './notificationRealtime';
 import { type PushNotificationPayload } from './pushNotificationPayloads';
 import { ensureWebPushConfigured, sendWebPushNotification } from './webPush';
 
@@ -142,6 +144,13 @@ const createInAppNotifications = async (
         });
 
         created += 1;
+    }
+
+    if (created > 0) {
+        publishNotificationRealtimeUpdate({
+            userId,
+            reason: NOTIFICATION_REALTIME_REASONS.CREATED
+        });
     }
 
     if (created === 0 && dedupeSkipCount > 0) {

--- a/backend/src/services/notificationRealtime.ts
+++ b/backend/src/services/notificationRealtime.ts
@@ -1,0 +1,72 @@
+import {
+    NOTIFICATION_REALTIME_EVENT_NAME,
+    buildNotificationRealtimePayload,
+    type NotificationRealtimePayload,
+    type NotificationRealtimeReason
+} from '../../../shared/notificationRealtime';
+
+type NotificationRealtimeSubscriber = (payload: NotificationRealtimePayload) => void;
+
+const subscribersByUserId = new Map<number, Set<NotificationRealtimeSubscriber>>();
+
+/**
+ * Owns in-process notification fanout for connected SSE clients.
+ *
+ * This deliberately does not know about Express responses, so notification domain code can publish state changes
+ * without depending on a transport implementation.
+ */
+export const subscribeToNotificationRealtimeUpdates = ({
+    userId,
+    onUpdate
+}: {
+    userId: number;
+    onUpdate: NotificationRealtimeSubscriber;
+}): (() => void) => {
+    const existingSubscribers = subscribersByUserId.get(userId);
+    const subscribers = existingSubscribers ?? new Set<NotificationRealtimeSubscriber>();
+    subscribers.add(onUpdate);
+
+    if (!existingSubscribers) {
+        subscribersByUserId.set(userId, subscribers);
+    }
+
+    return () => {
+        subscribers.delete(onUpdate);
+        if (subscribers.size === 0) {
+            subscribersByUserId.delete(userId);
+        }
+    };
+};
+
+/**
+ * Publish a notification state change to the authenticated user's active SSE connections.
+ */
+export const publishNotificationRealtimeUpdate = ({
+    userId,
+    reason,
+    now = new Date()
+}: {
+    userId: number;
+    reason: NotificationRealtimeReason;
+    now?: Date;
+}): NotificationRealtimePayload => {
+    const payload = buildNotificationRealtimePayload(reason, now);
+    const subscribers = subscribersByUserId.get(userId);
+
+    if (subscribers) {
+        for (const subscriber of subscribers) {
+            subscriber(payload);
+        }
+    }
+
+    return payload;
+};
+
+/**
+ * Expose subscriber counts for tests and lightweight operational assertions.
+ */
+export const getNotificationRealtimeSubscriberCount = (userId: number): number => {
+    return subscribersByUserId.get(userId)?.size ?? 0;
+};
+
+export { NOTIFICATION_REALTIME_EVENT_NAME };

--- a/backend/test/notification-delivery.test.js
+++ b/backend/test/notification-delivery.test.js
@@ -13,17 +13,22 @@ function stubModule(resolvedPath, exports) {
   require.cache[resolvedPath] = moduleInstance;
 }
 
-function loadNotificationDeliveryService({ prismaStub, webPushStub }) {
+function loadNotificationDeliveryService({ prismaStub, webPushStub, notificationRealtimeStub }) {
   const dbPath = require.resolve('../src/config/database');
   const webPushPath = require.resolve('../src/services/webPush');
+  const notificationRealtimePath = require.resolve('../src/services/notificationRealtime');
   const servicePath = require.resolve('../src/services/notificationDelivery');
 
   const previousDbModule = require.cache[dbPath];
   const previousWebPushModule = require.cache[webPushPath];
+  const previousNotificationRealtimeModule = require.cache[notificationRealtimePath];
   delete require.cache[servicePath];
 
   stubModule(dbPath, prismaStub);
   stubModule(webPushPath, webPushStub);
+  if (notificationRealtimeStub) {
+    stubModule(notificationRealtimePath, notificationRealtimeStub);
+  }
 
   const loaded = require('../src/services/notificationDelivery');
 
@@ -32,6 +37,9 @@ function loadNotificationDeliveryService({ prismaStub, webPushStub }) {
 
   if (previousWebPushModule) require.cache[webPushPath] = previousWebPushModule;
   else delete require.cache[webPushPath];
+
+  if (previousNotificationRealtimeModule) require.cache[notificationRealtimePath] = previousNotificationRealtimeModule;
+  else delete require.cache[notificationRealtimePath];
 
   return loaded;
 }
@@ -116,6 +124,57 @@ test('deliverUserNotification creates one in-app notification and dedupes repeat
   assert.equal(createdRows[0].title, 'Test title');
   assert.equal(createdRows[0].body, 'Test body');
   assert.equal(createdRows[0].action_url, '/dashboard');
+});
+
+test('deliverUserNotification publishes realtime update when in-app notification is created', async () => {
+  const publishCalls = [];
+  const prismaStub = {
+    inAppNotification: {
+      findUnique: async () => null,
+      create: async ({ data }) => ({ id: 1, ...data })
+    },
+    pushSubscription: {
+      findUnique: async () => null,
+      findMany: async () => [],
+      update: async () => {
+        throw new Error('should not be called');
+      },
+      delete: async () => {
+        throw new Error('should not be called');
+      }
+    }
+  };
+
+  const webPushStub = {
+    ensureWebPushConfigured: () => ({ ok: true }),
+    sendWebPushNotification: async () => {
+      throw new Error('should not be called');
+    }
+  };
+
+  const { deliverUserNotification } = loadNotificationDeliveryService({
+    prismaStub,
+    webPushStub,
+    notificationRealtimeStub: {
+      publishNotificationRealtimeUpdate: (args) => {
+        publishCalls.push(args);
+      }
+    }
+  });
+
+  const result = await deliverUserNotification({
+    userId: 4,
+    channels: [NOTIFICATION_DELIVERY_CHANNELS.IN_APP],
+    inApp: {
+      type: 'GENERIC',
+      localDate: new Date('2026-02-08T00:00:00.000Z')
+    }
+  });
+
+  assert.equal(result.inApp.created, 1);
+  assert.equal(publishCalls.length, 1);
+  assert.equal(publishCalls[0].userId, 4);
+  assert.equal(publishCalls[0].reason, 'created');
 });
 
 test('deliverUserNotification skips push when endpoint lookup fails', async () => {

--- a/backend/test/notification-realtime.test.js
+++ b/backend/test/notification-realtime.test.js
@@ -1,0 +1,158 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const {
+  NOTIFICATION_REALTIME_REASONS,
+  isNotificationRealtimePayload
+} = require('../../shared/notificationRealtime');
+
+function stubModule(resolvedPath, exports) {
+  const moduleInstance = new Module(resolvedPath);
+  moduleInstance.exports = exports;
+  moduleInstance.loaded = true;
+  require.cache[resolvedPath] = moduleInstance;
+}
+
+function loadInAppNotificationService({ publishNotificationRealtimeUpdateStub }) {
+  const dbPath = require.resolve('../src/config/database');
+  const realtimePath = require.resolve('../src/services/notificationRealtime');
+  const servicePath = require.resolve('../src/services/inAppNotifications');
+
+  const previousDbModule = require.cache[dbPath];
+  const previousRealtimeModule = require.cache[realtimePath];
+  delete require.cache[servicePath];
+
+  stubModule(dbPath, {});
+  stubModule(realtimePath, {
+    publishNotificationRealtimeUpdate: publishNotificationRealtimeUpdateStub
+  });
+
+  const loaded = require('../src/services/inAppNotifications');
+
+  if (previousDbModule) require.cache[dbPath] = previousDbModule;
+  else delete require.cache[dbPath];
+
+  if (previousRealtimeModule) require.cache[realtimePath] = previousRealtimeModule;
+  else delete require.cache[realtimePath];
+
+  return loaded;
+}
+
+test('notification realtime publisher fans out only to the subscribed user and cleans up', () => {
+  delete require.cache[require.resolve('../src/services/notificationRealtime')];
+  const {
+    getNotificationRealtimeSubscriberCount,
+    publishNotificationRealtimeUpdate,
+    subscribeToNotificationRealtimeUpdates
+  } = require('../src/services/notificationRealtime');
+
+  const userOnePayloads = [];
+  const userTwoPayloads = [];
+  const unsubscribeUserOne = subscribeToNotificationRealtimeUpdates({
+    userId: 1,
+    onUpdate: (payload) => userOnePayloads.push(payload)
+  });
+  const unsubscribeUserTwo = subscribeToNotificationRealtimeUpdates({
+    userId: 2,
+    onUpdate: (payload) => userTwoPayloads.push(payload)
+  });
+
+  assert.equal(getNotificationRealtimeSubscriberCount(1), 1);
+  assert.equal(getNotificationRealtimeSubscriberCount(2), 1);
+
+  publishNotificationRealtimeUpdate({
+    userId: 1,
+    reason: NOTIFICATION_REALTIME_REASONS.CREATED,
+    now: new Date('2026-04-24T12:00:00.000Z')
+  });
+
+  assert.equal(userOnePayloads.length, 1);
+  assert.equal(userOnePayloads[0].reason, NOTIFICATION_REALTIME_REASONS.CREATED);
+  assert.equal(userOnePayloads[0].updated_at, '2026-04-24T12:00:00.000Z');
+  assert.equal(userTwoPayloads.length, 0);
+
+  unsubscribeUserOne();
+  assert.equal(getNotificationRealtimeSubscriberCount(1), 0);
+
+  publishNotificationRealtimeUpdate({
+    userId: 1,
+    reason: NOTIFICATION_REALTIME_REASONS.READ
+  });
+
+  assert.equal(userOnePayloads.length, 1);
+  unsubscribeUserTwo();
+});
+
+test('notification realtime payload guard accepts the shared SSE wire shape', () => {
+  assert.equal(
+    isNotificationRealtimePayload({
+      reason: NOTIFICATION_REALTIME_REASONS.DISMISSED,
+      updated_at: '2026-04-24T12:00:00.000Z'
+    }),
+    true
+  );
+  assert.equal(isNotificationRealtimePayload({ reason: 'other', updated_at: '2026-04-24T12:00:00.000Z' }), false);
+  assert.equal(isNotificationRealtimePayload({ reason: NOTIFICATION_REALTIME_REASONS.READ, updated_at: '' }), false);
+});
+
+test('in-app notification mutations publish realtime updates when rows change', async () => {
+  const publishCalls = [];
+  const { markInAppNotificationDismissed, markInAppNotificationRead } = loadInAppNotificationService({
+    publishNotificationRealtimeUpdateStub: (args) => {
+      publishCalls.push(args);
+      return { reason: args.reason, updated_at: args.now.toISOString() };
+    }
+  });
+
+  const now = new Date('2026-04-24T12:00:00.000Z');
+  const db = {
+    inAppNotification: {
+      updateMany: async () => ({ count: 1 })
+    }
+  };
+
+  const readCount = await markInAppNotificationRead({
+    userId: 7,
+    notificationId: 10,
+    now,
+    db
+  });
+  const dismissCount = await markInAppNotificationDismissed({
+    userId: 7,
+    notificationId: 10,
+    now,
+    db
+  });
+
+  assert.equal(readCount, 1);
+  assert.equal(dismissCount, 1);
+  assert.equal(publishCalls.length, 2);
+  assert.deepEqual(
+    publishCalls.map((call) => call.reason),
+    [NOTIFICATION_REALTIME_REASONS.READ, NOTIFICATION_REALTIME_REASONS.DISMISSED]
+  );
+  assert.equal(publishCalls[0].userId, 7);
+});
+
+test('in-app notification mutations skip realtime publishing when nothing changed', async () => {
+  let publishCount = 0;
+  const { markInAppNotificationRead } = loadInAppNotificationService({
+    publishNotificationRealtimeUpdateStub: () => {
+      publishCount += 1;
+    }
+  });
+
+  const result = await markInAppNotificationRead({
+    userId: 7,
+    notificationId: 10,
+    db: {
+      inAppNotification: {
+        updateMany: async () => ({ count: 0 })
+      }
+    }
+  });
+
+  assert.equal(result, 0);
+  assert.equal(publishCount, 0);
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -52,6 +52,7 @@ import LogQuickAddFab from './LogQuickAddFab';
 import LogDatePickerControl from './LogDatePickerControl';
 import InAppNotificationsDrawer from './InAppNotificationsDrawer';
 import { useInAppNotificationBadge } from '../hooks/useInAppNotificationBadge';
+import { useInAppNotificationStream } from '../hooks/useInAppNotificationStream';
 import { type InAppNotification, inAppNotificationsQueryKey, useInAppNotificationsQuery } from '../queries/inAppNotifications';
 import { isInAppNotificationsUpdatedMessage } from '../constants/notificationEvents';
 import { useIncompleteTodayBadge } from '../hooks/useIncompleteTodayBadge';
@@ -262,6 +263,7 @@ const LayoutShell: React.FC = () => {
         unreadCount: unreadNotificationCount,
         hasLoadedCount: hasLoadedNotificationCount
     });
+    useInAppNotificationStream({ enabled: showAppNav, queryClient });
 
     useEffect(() => {
         if (!showAppNav || typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -38,6 +38,7 @@ import { useI18n } from '../i18n/useI18n';
 import LogQuickAddFab from './LogQuickAddFab';
 import InAppNotificationsDrawer from './InAppNotificationsDrawer';
 import { useInAppNotificationBadge } from '../hooks/useInAppNotificationBadge';
+import { useInAppNotificationStream } from '../hooks/useInAppNotificationStream';
 import { type InAppNotification, inAppNotificationsQueryKey, useInAppNotificationsQuery } from '../queries/inAppNotifications';
 import { isInAppNotificationsUpdatedMessage } from '../constants/notificationEvents';
 import { useIncompleteTodayBadge } from '../hooks/useIncompleteTodayBadge';
@@ -160,6 +161,7 @@ const LayoutShell: React.FC = () => {
         unreadCount: unreadNotificationCount,
         hasLoadedCount: hasLoadedNotificationCount
     });
+    useInAppNotificationStream({ enabled: showAppNav, queryClient });
 
     useEffect(() => {
         if (!showAppNav || typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {

--- a/frontend/src/hooks/useInAppNotificationStream.ts
+++ b/frontend/src/hooks/useInAppNotificationStream.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import {
+    NOTIFICATION_REALTIME_EVENT_NAME,
+    isNotificationRealtimePayload
+} from '../../../shared/notificationRealtime';
+import { inAppNotificationsQueryKey } from '../queries/inAppNotifications';
+
+const NOTIFICATION_STREAM_URL = '/api/notifications/stream';
+const NOTIFICATION_STREAM_RECONNECT_MS = 5_000; // Retry after transient stream errors without fighting the server.
+
+/**
+ * Keep the app shell subscribed to server-side notification changes.
+ *
+ * The hook only invalidates the existing notification query; polling and service-worker push messages remain as
+ * fallback refresh paths when SSE is unavailable.
+ */
+export const useInAppNotificationStream = ({
+    enabled,
+    queryClient
+}: {
+    enabled: boolean;
+    queryClient: QueryClient;
+}) => {
+    const reconnectTimeoutRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (!enabled || typeof window === 'undefined' || typeof window.EventSource === 'undefined') {
+            return;
+        }
+
+        let isActive = true;
+        let eventSource: EventSource | null = null;
+
+        const clearReconnectTimeout = () => {
+            if (reconnectTimeoutRef.current !== null) {
+                window.clearTimeout(reconnectTimeoutRef.current);
+                reconnectTimeoutRef.current = null;
+            }
+        };
+
+        const connect = () => {
+            clearReconnectTimeout();
+            if (!isActive) {
+                return;
+            }
+
+            eventSource = new window.EventSource(NOTIFICATION_STREAM_URL, { withCredentials: true });
+            eventSource.addEventListener(NOTIFICATION_REALTIME_EVENT_NAME, (event) => {
+                try {
+                    const payload = JSON.parse(event.data);
+                    if (isNotificationRealtimePayload(payload)) {
+                        void queryClient.invalidateQueries({ queryKey: inAppNotificationsQueryKey() });
+                    }
+                } catch {
+                    // Ignore malformed realtime payloads; polling remains the source of eventual consistency.
+                }
+            });
+            eventSource.onerror = () => {
+                eventSource?.close();
+                eventSource = null;
+                if (!isActive) {
+                    return;
+                }
+                reconnectTimeoutRef.current = window.setTimeout(connect, NOTIFICATION_STREAM_RECONNECT_MS);
+            };
+        };
+
+        connect();
+
+        return () => {
+            isActive = false;
+            clearReconnectTimeout();
+            eventSource?.close();
+        };
+    }, [enabled, queryClient]);
+};

--- a/shared/notificationRealtime.ts
+++ b/shared/notificationRealtime.ts
@@ -1,0 +1,44 @@
+export const NOTIFICATION_REALTIME_EVENT_NAME = 'notification-update';
+
+export const NOTIFICATION_REALTIME_REASONS = {
+    CREATED: 'created',
+    READ: 'read',
+    DISMISSED: 'dismissed',
+    RESOLVED: 'resolved',
+    CLEARED: 'cleared'
+} as const;
+
+export type NotificationRealtimeReason =
+    (typeof NOTIFICATION_REALTIME_REASONS)[keyof typeof NOTIFICATION_REALTIME_REASONS];
+
+export type NotificationRealtimePayload = {
+    reason: NotificationRealtimeReason;
+    updated_at: string;
+};
+
+const NOTIFICATION_REALTIME_REASON_VALUES = new Set<string>(Object.values(NOTIFICATION_REALTIME_REASONS));
+
+/**
+ * Build the wire payload used by the SSE notification stream.
+ */
+export const buildNotificationRealtimePayload = (
+    reason: NotificationRealtimeReason,
+    now = new Date()
+): NotificationRealtimePayload => ({
+    reason,
+    updated_at: now.toISOString()
+});
+
+export const isNotificationRealtimePayload = (value: unknown): value is NotificationRealtimePayload => {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const candidate = value as { reason?: unknown; updated_at?: unknown };
+    return (
+        typeof candidate.reason === 'string' &&
+        NOTIFICATION_REALTIME_REASON_VALUES.has(candidate.reason) &&
+        typeof candidate.updated_at === 'string' &&
+        candidate.updated_at.trim().length > 0
+    );
+};


### PR DESCRIPTION
## Summary
- Add a shared realtime notification event contract.
- Add authenticated per-user SSE streaming at `/api/notifications/stream` with heartbeat cleanup.
- Publish notification changes from in-app create, read, dismiss, resolve, and dev clear flows.
- Subscribe from the app shell and invalidate the existing in-app notifications query while keeping polling and service-worker refresh as fallbacks.

## Linked Issue
Closes #152

## Validation
- `TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=backend/tsconfig.json node -r ./backend/node_modules/ts-node/register --test --test-isolation=none backend/test/notification-delivery.test.js backend/test/notification-realtime.test.js`
- `npm.cmd --prefix backend run build`
- `npm.cmd --prefix frontend run build`