### PR TITLE
[codex] Revise dashboard summary

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,35 +2,49 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useAuth } from '../context/useAuth';
+import { useQuickAddFab } from '../context/useQuickAddFab';
 import CalorieTargetBanner from '../components/CalorieTargetBanner';
 import LogSummaryCard from '../components/LogSummaryCard';
 import GoalTrackerCard from '../components/GoalTrackerCard';
+import WeightSummaryCard from '../components/WeightSummaryCard';
+import { getTodayIsoDate } from '../utils/date';
 
 /**
  * Dashboard landing page for signed-in users.
+ *
+ * Presents the current day's action state first, then supporting target and goal context so the tab has a distinct
+ * "what needs attention now?" purpose instead of duplicating the detail pages.
  */
 const Dashboard: React.FC = () => {
-    useAuth();
+    const { user } = useAuth();
+    const { openWeightDialogFromFab } = useQuickAddFab();
     const theme = useTheme();
     const { sectionGap, sectionGapCompact } = theme.custom.layout.page;
-    // Shared card spacing across the dashboard stack.
+    const today = React.useMemo(() => getTodayIsoDate(user?.timezone), [user?.timezone]);
+    // Shared card spacing across the dashboard grid; compact on mobile to reduce unnecessary scrolling.
     const cardGap = { xs: sectionGapCompact, sm: sectionGapCompact, md: sectionGap };
 
     return (
         <Box
             sx={{
                 display: 'grid',
-                gridTemplateColumns: { xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' },
+                gridTemplateColumns: { xs: '1fr', lg: 'repeat(3, minmax(0, 1fr))' },
                 gap: cardGap,
-                alignItems: 'stretch'
+                alignItems: 'stretch',
+                gridAutoFlow: 'dense'
             }}
         >
-            <Box sx={{ gridColumn: { lg: '1 / -1' } }}>
-                <CalorieTargetBanner isDashboard />
+            <Box sx={{ gridColumn: { lg: 'span 2' } }}>
+                <LogSummaryCard dashboardMode completionMode="status" />
             </Box>
 
-            <LogSummaryCard dashboardMode completionMode="status" />
-            <GoalTrackerCard isDashboard />
+            <WeightSummaryCard date={today} onOpenWeightEntry={openWeightDialogFromFab} />
+
+            <Box sx={{ gridColumn: { lg: 'span 2' } }}>
+                <GoalTrackerCard isDashboard />
+            </Box>
+
+            <CalorieTargetBanner isDashboard />
         </Box>
     );
 };


### PR DESCRIPTION
## Summary
- Reframe Dashboard as a current-day status summary rather than a broad duplicate of other tabs.
- Put today's log first, add the weight summary card, then keep goal and calorie-target context below.
- Adjust the desktop grid to support the new ordering while staying one-column on mobile.

## Linked Issue
Closes #164

## Validation
- `npm.cmd --prefix frontend run build`