### PR TITLE
[codex] Add Codex devcontainer recreate actions

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -14,6 +14,16 @@ icon = "run"
 command = "node scripts/codex-worktree-env.mjs setup-app"
 
 [[actions]]
+name = "Recreate Devcontainer"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs devcontainer:recreate"
+
+[[actions]]
+name = "Stop Devcontainer"
+icon = "run"
+command = "node scripts/codex-worktree-env.mjs down"
+
+[[actions]]
 name = "Migrate DB"
 icon = "run"
 command = "node scripts/codex-worktree-env.mjs db:migrate"

--- a/.codex/local-environment.md
+++ b/.codex/local-environment.md
@@ -10,6 +10,8 @@ Configured Codex app actions:
 
 | Name | Script |
 | --- | --- |
+| Recreate Devcontainer | `node scripts/codex-worktree-env.mjs devcontainer:recreate` |
+| Stop Devcontainer | `node scripts/codex-worktree-env.mjs down` |
 | Dev | `node scripts/codex-worktree-env.mjs dev` |
 | Dev test | `node scripts/codex-worktree-env.mjs dev:test` |
 | Test | `node scripts/codex-worktree-env.mjs test` |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ same lockfiles can reuse installed dependencies without writing them into the Wi
 Recommended Codex app actions:
 
 - Setup: `npm run codex:setup-app`
+- Recreate Devcontainer: `npm run codex:devcontainer:recreate`
+- Stop Devcontainer: `npm run codex:devcontainer:down`
 - Migrate DB: `npm run codex:db:migrate`
 - Reset DB: `npm run codex:db:reset`
 - Dev server with test-user auto-login: `npm run codex:dev`
@@ -161,6 +163,9 @@ Recommended Codex app actions:
 
 The Dev action runs the same setup checks as Setup first, but cached dependencies, already-applied migrations, and
 existing seed data are skipped. After the preflight passes, it starts `npm run dev:test`.
+Use Recreate Devcontainer after changing devcontainer config or when the worktree's container state needs a clean
+replacement. It tears down the generated Compose stack for the current worktree before starting a fresh container.
+Use Stop Devcontainer to remove the current worktree's generated devcontainer stack during cleanup.
 
 When using VS Code with a Codex-created worktree container, use **Dev Containers: Attach to Running Container** and open
 `/workspaces/calibrate-health` inside the container. **Reopen in Container** follows VS Code's own devcontainer flow and

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "devcontainer:shell": "node scripts/devcontainer-worktree.mjs shell",
     "devcontainer:shell:new": "node scripts/devcontainer-worktree.mjs shell --remove-existing-container",
     "codex:devcontainer:start": "node scripts/codex-worktree-env.mjs devcontainer:start",
+    "codex:devcontainer:recreate": "node scripts/codex-worktree-env.mjs devcontainer:recreate",
+    "codex:devcontainer:down": "node scripts/codex-worktree-env.mjs down",
     "codex:setup-app": "node scripts/codex-worktree-env.mjs setup-app",
     "codex:db:migrate": "node scripts/codex-worktree-env.mjs db:migrate",
     "codex:db:reset": "node scripts/codex-worktree-env.mjs db:reset",

--- a/scripts/codex-worktree-env.mjs
+++ b/scripts/codex-worktree-env.mjs
@@ -13,6 +13,7 @@ const devcontainerScript = path.join(
 
 const commandMap = new Map([
   ["devcontainer:start", { type: "up", skipPostCreate: true }],
+  ["devcontainer:recreate", { type: "recreate", skipPostCreate: true }],
   ["setup-app", { type: "exec", command: ["npm", "run", "setup"] }],
   ["db:migrate", { type: "exec", command: ["npm", "run", "db:migrate:dev"] }],
   ["db:reset", { type: "exec", command: ["npm", "run", "db:reset:dev"] }],
@@ -52,6 +53,8 @@ function printHelp() {
     [
       "Usage:",
       "  npm run codex:devcontainer:start",
+      "  npm run codex:devcontainer:recreate",
+      "  npm run codex:devcontainer:down",
       "  npm run codex:setup-app",
       "  npm run codex:db:migrate",
       "  npm run codex:db:reset",
@@ -61,7 +64,6 @@ function printHelp() {
       "  npm run codex:build",
       "  npm run codex:dev",
       "  npm run codex:shell",
-      "  npm run codex:down",
       "",
       "The target worktree is CODEX_WORKTREE_PATH when Codex provides it; otherwise",
       "the current directory is used. Commands run through the worktree devcontainer.",
@@ -71,6 +73,7 @@ function printHelp() {
 
 /**
  * Run docker compose down for the current worktree's generated devcontainer stack.
+ * @returns {boolean} True when the stack was removed successfully.
  */
 function runComposeDown() {
   const initScript = path.join(workspacePath, ".devcontainer", "init-devcontainer-env.mjs");
@@ -84,10 +87,11 @@ function runComposeDown() {
 
   run(process.execPath, [initScript]);
   if (process.exitCode) {
-    return;
+    return false;
   }
 
   run("docker", ["compose", "--env-file", envFile, "-f", composeFile, "down"]);
+  return !process.exitCode;
 }
 
 const commandName = process.argv[2];
@@ -124,6 +128,19 @@ if (commandName === "down") {
       workspacePath,
       ...(command.skipPostCreate ? ["--skip-post-create"] : []),
       ...(command.removeExistingContainer ? ["--remove-existing-container"] : []),
+    ]);
+  } else if (command.type === "recreate") {
+    if (!runComposeDown()) {
+      process.exit(process.exitCode || 1);
+    }
+
+    run(process.execPath, [
+      devcontainerScript,
+      "up",
+      "--path",
+      workspacePath,
+      "--remove-existing-container",
+      ...(command.skipPostCreate ? ["--skip-post-create"] : []),
     ]);
   } else if (command.type === "shell") {
     run(process.execPath, [devcontainerScript, "shell", "--path", workspacePath]);


### PR DESCRIPTION
## Summary

Adds Codex app actions for managing a worktree devcontainer lifecycle after initial setup:

- `Recreate Devcontainer` tears down the current worktree's generated Compose stack and starts a fresh devcontainer with post-create hooks skipped.
- `Stop Devcontainer` removes the current worktree's generated devcontainer stack for cleanup.
- Documents the new action names and npm scripts alongside the existing Codex app workflow.

## Why

The previous action set assumed a devcontainer created at worktree startup would remain usable for the whole worktree. In practice, devcontainer config changes and stale container state sometimes require replacing or stopping the current worktree's container explicitly.

## Validation

- `node --check scripts/codex-worktree-env.mjs`
- Parsed `package.json` and `package-lock.json` with Node JSON parsing
- `npm run codex:devcontainer:recreate -- --help`
- `npm run codex:devcontainer:down -- --help`

I did not run the actual recreate/down actions to avoid tearing down an active local devcontainer from the source checkout.