### PR TITLE
[codex] Clean up Vite build warnings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,40 +1,64 @@
+import { lazy, Suspense, type ComponentType, type ReactElement } from 'react';
+import { Box, LinearProgress } from '@mui/material';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from './components/Layout';
-import Home from './pages/Home';
-import Login from './pages/Login';
-import Register from './pages/Register';
-import Dashboard from './pages/Dashboard';
-import Log from './pages/Log';
-import Goals from './pages/Goals';
-import Settings from './pages/Settings';
-import Profile from './pages/Profile';
-import Onboarding from './pages/Onboarding';
-import DevDashboard from './pages/DevDashboard';
-import PrivacyPolicy from './pages/PrivacyPolicy';
-
 import ProtectedRoute from './components/ProtectedRoute';
 import PublicRoute from './components/PublicRoute';
+
+const Home = lazy(() => import('./pages/Home'));
+const Login = lazy(() => import('./pages/Login'));
+const Register = lazy(() => import('./pages/Register'));
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const Log = lazy(() => import('./pages/Log'));
+const Goals = lazy(() => import('./pages/Goals'));
+const Settings = lazy(() => import('./pages/Settings'));
+const Profile = lazy(() => import('./pages/Profile'));
+const Onboarding = lazy(() => import('./pages/Onboarding'));
+const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
+const DevDashboard = import.meta.env.DEV ? lazy(() => import('./pages/DevDashboard')) : null;
+
+/**
+ * Lightweight page placeholder that keeps the persistent layout chrome visible during route chunk loads.
+ */
+function RouteLoadingFallback(): ReactElement {
+    return (
+        <Box sx={{ py: 3 }}>
+            <LinearProgress aria-label="Loading page" />
+        </Box>
+    );
+}
+
+/**
+ * Wrap route-level lazy pages so each route can split without duplicating Suspense boilerplate.
+ */
+function renderRouteElement(Page: ComponentType): ReactElement {
+    return (
+        <Suspense fallback={<RouteLoadingFallback />}>
+            <Page />
+        </Suspense>
+    );
+}
 
 function App() {
     return (
         <Routes>
             <Route path="/" element={<Layout />}>
-                <Route index element={<Home />} />
-                <Route path="privacy" element={<PrivacyPolicy />} />
+                <Route index element={renderRouteElement(Home)} />
+                <Route path="privacy" element={renderRouteElement(PrivacyPolicy)} />
                 <Route element={<PublicRoute />}>
-                    <Route path="login" element={<Login />} />
-                    <Route path="register" element={<Register />} />
+                    <Route path="login" element={renderRouteElement(Login)} />
+                    <Route path="register" element={renderRouteElement(Register)} />
                 </Route>
-                {import.meta.env.DEV && <Route path="dev" element={<DevDashboard />} />}
+                {DevDashboard && <Route path="dev" element={renderRouteElement(DevDashboard)} />}
 
                 <Route element={<ProtectedRoute />}>
-                    <Route path="onboarding" element={<Onboarding />} />
-                    <Route path="dashboard" element={<Dashboard />} />
-                    <Route path="log" element={<Log />} />
-                    <Route path="goals" element={<Goals />} />
+                    <Route path="onboarding" element={renderRouteElement(Onboarding)} />
+                    <Route path="dashboard" element={renderRouteElement(Dashboard)} />
+                    <Route path="log" element={renderRouteElement(Log)} />
+                    <Route path="goals" element={renderRouteElement(Goals)} />
                     <Route path="history" element={<Navigate to="/goals" replace />} />
-                    <Route path="settings" element={<Settings />} />
-                    <Route path="profile" element={<Profile />} />
+                    <Route path="settings" element={renderRouteElement(Settings)} />
+                    <Route path="profile" element={renderRouteElement(Profile)} />
                 </Route>
             </Route>
         </Routes>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
     AppBar,
@@ -48,7 +48,6 @@ import { getAvatarLabel } from '../utils/avatarLabel';
 import { getTodayIsoDate } from '../utils/date';
 import { useI18n } from '../i18n/useI18n';
 import { QUICK_ADD_FAB_PAGE_BOTTOM_PADDING } from '../constants/quickAddFab';
-import LogQuickAddFab from './LogQuickAddFab';
 import LogDatePickerControl from './LogDatePickerControl';
 import InAppNotificationsDrawer from './InAppNotificationsDrawer';
 import { useInAppNotificationBadge } from '../hooks/useInAppNotificationBadge';
@@ -78,6 +77,8 @@ const NAV_DATE_PICKER_WIDTH_PX = { xs: 122, sm: 168, md: 200 }; // Narrower widt
 const NAV_DATE_PICKER_MIN_WIDTH_PX = 104; // Allow the picker to shrink on xs while staying readable.
 const NAV_DATE_PICKER_MAX_WIDTH_PX = 220; // Keep the date picker from growing too wide on desktop layouts.
 const NAV_CENTER_PADDING_X_SPACING = { xs: 0.5, sm: 1 }; // Add small horizontal breathing room around the centered date controls.
+// Load the food/weight quick-add dialogs only on the log route; they pull in provider search and form code.
+const LazyLogQuickAddFab = lazy(() => import('./LogQuickAddFab'));
 const NAV_NOTIFICATION_BADGE_MAX = 99; // Prevent oversized badge strings from crowding the header controls.
 const NAV_INSTALL_ICON_SIZE = 'small'; // Keep the install icon compact on xs viewports where toolbar width is tight.
 /**
@@ -664,7 +665,11 @@ const LayoutShell: React.FC = () => {
                 />
             )}
 
-            {showQuickAdd && <LogQuickAddFab date={fabDate} />}
+            {showQuickAdd && (
+                <Suspense fallback={null}>
+                    <LazyLogQuickAddFab date={fabDate} />
+                </Suspense>
+            )}
 
             <Dialog
                 open={isIosInstallDialogOpen && !isInstalled}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -148,6 +148,10 @@ function getPwaOptions(enableServiceWorkerInDev: boolean): Partial<VitePWAOption
     registerType: 'autoUpdate',
     srcDir: 'src',
     filename: 'service-worker.ts',
+    injectManifest: {
+      // Vite 8 deprecates the plugin's ES service worker inline bundle path; iife keeps one SW file without inlineDynamicImports.
+      rollupFormat: 'iife',
+    },
     devOptions: {
       // Keep local service workers opt-in so regular dev mode stays HMR-friendly by default.
       enabled: enableServiceWorkerInDev,


### PR DESCRIPTION
## Summary

- Split frontend route pages and the log quick-add UI into lazy-loaded chunks so the production startup bundle stays below Vite's default warning threshold.
- Build the injected PWA service worker with the plugin's `iife` output path to avoid Vite 8's deprecated `inlineDynamicImports` option while keeping a single generated service worker file.
- Verified the generated PWA manifest still includes the quick-add shortcuts and the service worker still contains precache plus SPA fallback behavior.

Fixes #188.

## Validation

- `npm.cmd --prefix frontend run build`
- `npm.cmd --prefix frontend run lint`
- Preview smoke: `/`, `/log`, `manifest.webmanifest`, and `service-worker.js` served successfully; manifest shortcuts preserved.
- Opt-in dev service worker smoke: `/dev-sw.js?dev-sw` served and dev page registered the PWA dev service worker.