### PR TITLE
[codex] Use configured food provider fallbacks

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: sleep infinity
     environment:
       DATABASE_URL: postgresql://user:password@postgres:5432/fitness_app?schema=public
-      FOOD_DATA_PROVIDER: fatsecret
+      FOOD_DATA_PROVIDER: ${FOOD_DATA_PROVIDER}
       PORT: 3000
       SESSION_SECRET: development_secret_key
       FATSECRET_CLIENT_ID: ${FATSECRET_CLIENT_ID}

--- a/.devcontainer/init-devcontainer-env.mjs
+++ b/.devcontainer/init-devcontainer-env.mjs
@@ -228,6 +228,45 @@ function readRepoDotenvValue(key) {
 }
 
 /**
+ * Normalize the food provider value used by backend provider selection.
+ * @param {string} value - Raw provider value from env/dotenv.
+ * @returns {string} Provider key accepted by the backend, or an empty string.
+ */
+function normalizeFoodDataProvider(value) {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "fatsecret" || normalized === "usda") {
+    return normalized;
+  }
+  if (normalized === "openfoodfacts") {
+    return "openfoodfacts";
+  }
+  return "";
+}
+
+/**
+ * Choose a local-dev provider based on explicit config first, then available credentials.
+ * USDA's public DEMO_KEY keeps fresh devcontainers searchable when OFF anonymous access is throttled.
+ * @param {{ fatsecretClientId: string, fatsecretClientSecret: string, usdaApiKey: string }} credentials
+ * @returns {string} Provider key to pass into the devcontainer.
+ */
+function resolveFoodDataProvider(credentials) {
+  const explicitProvider = normalizeFoodDataProvider(
+    process.env.FOOD_DATA_PROVIDER || readRepoDotenvValue("FOOD_DATA_PROVIDER")
+  );
+  if (explicitProvider) {
+    return explicitProvider;
+  }
+
+  if (credentials.fatsecretClientId && credentials.fatsecretClientSecret) {
+    return "fatsecret";
+  }
+  if (credentials.usdaApiKey) {
+    return "usda";
+  }
+  return "usda";
+}
+
+/**
  * Generate VAPID keys in the same URL-safe format used by web-push.
  * @returns {{ publicKey: string, privateKey: string }} Generated keys.
  */
@@ -341,7 +380,13 @@ const fatsecretClientId =
   process.env.FATSECRET_CLIENT_ID || readRepoDotenvValue("FATSECRET_CLIENT_ID");
 const fatsecretClientSecret =
   process.env.FATSECRET_CLIENT_SECRET || readRepoDotenvValue("FATSECRET_CLIENT_SECRET");
-const usdaApiKey = process.env.USDA_API_KEY || readRepoDotenvValue("USDA_API_KEY");
+const configuredUsdaApiKey = process.env.USDA_API_KEY || readRepoDotenvValue("USDA_API_KEY");
+const foodDataProvider = resolveFoodDataProvider({
+  fatsecretClientId,
+  fatsecretClientSecret,
+  usdaApiKey: configuredUsdaApiKey,
+});
+const usdaApiKey = configuredUsdaApiKey || (foodDataProvider === "usda" ? "DEMO_KEY" : "");
 
 let webPushPublicKey =
   process.env.WEB_PUSH_PUBLIC_KEY ||
@@ -389,6 +434,7 @@ const lines = [
   `VITE_WORKTREE_NAME=${workspaceName}`,
   `VITE_WORKTREE_IS_MAIN=${isMainWorktree ? "true" : "false"}`,
   "# Sourced from the host environment or repo-local .env during devcontainer init so Docker can pass it into the container.",
+  `FOOD_DATA_PROVIDER=${foodDataProvider}`,
   `FATSECRET_CLIENT_ID=${fatsecretClientId}`,
   `FATSECRET_CLIENT_SECRET=${fatsecretClientSecret}`,
   `USDA_API_KEY=${usdaApiKey}`,
@@ -398,10 +444,10 @@ const lines = [
   "",
 ].join("\n");
 
-const tmpPath = `${devcontainerDotenvPath}.tmp`;
+const tmpPath = `${devcontainerDotenvPath}.${process.pid}.tmp`;
 fs.writeFileSync(tmpPath, lines, "utf8");
 if (fs.existsSync(devcontainerDotenvPath) && fs.readFileSync(devcontainerDotenvPath, "utf8") === lines) {
-  fs.rmSync(tmpPath);
+  fs.rmSync(tmpPath, { force: true });
 } else {
   fs.renameSync(tmpPath, devcontainerDotenvPath);
 }

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ GITHUB_TOKEN=
 CODEX_HOME=
 
 # Food data providers (used by devcontainer + docker-compose).
+# Defaults to FatSecret when both FatSecret credentials are set, then USDA.
+# Devcontainers use USDA's public DEMO_KEY when no provider credentials are available.
+# Set explicitly to override, including openfoodfacts when you want to test OFF.
+FOOD_DATA_PROVIDER=
 FATSECRET_CLIENT_ID=
 FATSECRET_CLIENT_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -178,14 +178,18 @@ may create or recreate a separate container.
 4. Dev dashboard (dev-only): `http://localhost:5173/dev` (compare providers + test barcode scanning)
 5. Component workbench: `npm run dev:storybook` (local Storybook defaults to `http://localhost:6006`; devcontainer worktrees use the generated `STORYBOOK_PORT` in `.devcontainer/.env`)
 
-#### FatSecret provider (devcontainer)
+#### Food data provider (devcontainer)
 
-The backend supports multiple food search providers. The devcontainer defaults to the FatSecret provider
-(`FOOD_DATA_PROVIDER=fatsecret`).
+The backend supports multiple food search providers. During devcontainer initialization, the repo writes
+`FOOD_DATA_PROVIDER` into `.devcontainer/.env` from explicit config first, then from available credentials:
+FatSecret when both FatSecret credentials are set, USDA when `USDA_API_KEY` is set, and USDA with api.data.gov's
+public `DEMO_KEY` when no provider credentials are available. This keeps local search usable when Open Food Facts
+anonymous access is throttled.
 
-To make this work, you must have `FATSECRET_CLIENT_ID` and `FATSECRET_CLIENT_SECRET` set (either in the host environment
-or in the repo-local `.env`) before the devcontainer is created/rebuilt. During devcontainer initialization we copy the
-credentials into `.devcontainer/.env` (gitignored), and `docker compose` uses them to pass the values into the container.
+To use FatSecret, set `FOOD_DATA_PROVIDER=fatsecret` with `FATSECRET_CLIENT_ID` and `FATSECRET_CLIENT_SECRET` (either in
+the host environment or in the repo-local `.env`) before the devcontainer is created/rebuilt. During devcontainer
+initialization we copy the provider config into `.devcontainer/.env` (gitignored), and `docker compose` uses it to pass
+the values into the container.
 
 Example (host machine):
 
@@ -196,7 +200,9 @@ export FATSECRET_CLIENT_SECRET="your-client-secret"
 
 If you add/change the credentials, rebuild the devcontainer so the generated `.devcontainer/.env` is refreshed.
 
-To use USDA instead, set `FOOD_DATA_PROVIDER=usda` and supply `USDA_API_KEY` before rebuilding the devcontainer.
+To use USDA with your own quota, set `FOOD_DATA_PROVIDER=usda` and supply `USDA_API_KEY` before rebuilding the
+devcontainer. To test Open Food Facts specifically, set `FOOD_DATA_PROVIDER=openfoodfacts`; that path depends on the
+public Open Food Facts API allowing anonymous requests.
 
 #### Codex app usage
 
@@ -220,7 +226,7 @@ Prereqs: Node.js `20.19+` or `22.12+`, npm, and a Postgres database.
    - `DATABASE_URL=postgresql://user:password@localhost:5432/fitness_app?schema=public`
    - `SESSION_SECRET=some-secret`
    - `PORT=3000` (optional)
-   - `FOOD_DATA_PROVIDER=fatsecret` (optional; defaults to FatSecret)
+   - `FOOD_DATA_PROVIDER=fatsecret` (optional; defaults by available credentials in the devcontainer)
    - `FATSECRET_CLIENT_ID=your-client-id` (required when `FOOD_DATA_PROVIDER=fatsecret`)
    - `FATSECRET_CLIENT_SECRET=your-client-secret` (required when `FOOD_DATA_PROVIDER=fatsecret`)
    - `USDA_API_KEY=your-usda-key` (required when `FOOD_DATA_PROVIDER=usda`)

--- a/backend/src/routes/food.ts
+++ b/backend/src/routes/food.ts
@@ -130,11 +130,11 @@ const buildRecentFoodAccumulator = (log: any, key: string): RecentFoodAccumulato
 });
 
 /**
- * Search ready providers in configured order, stopping at the first provider with results.
+ * Search ready providers in configured order, stopping at the first usable provider response.
  */
 const searchEnabledProviders = async (
     params: FoodSearchRequest,
-    opts: { requireBarcodeLookup: boolean }
+    opts: { fallbackOnEmpty: boolean; requireBarcodeLookup: boolean }
 ): Promise<ProviderSearchOutcome> => {
     const { primary, providers } = getEnabledFoodDataProviders();
     const attempts: ProviderSearchAttempt[] = [];
@@ -191,7 +191,7 @@ const searchEnabledProviders = async (
             }
 
             sawSuccessfulResponse = true;
-            if (result.items.length > 0) {
+            if (result.items.length > 0 || !opts.fallbackOnEmpty) {
                 return {
                     found: true,
                     provider: resolution.provider,
@@ -277,6 +277,7 @@ router.get('/search', async (req, res) => {
     }
 
     const searchOutcome = await searchEnabledProviders(parsed.params, {
+        fallbackOnEmpty: Boolean(parsed.params.barcode),
         requireBarcodeLookup: Boolean(parsed.params.barcode)
     });
 

--- a/backend/src/routes/food.ts
+++ b/backend/src/routes/food.ts
@@ -2,10 +2,10 @@ import express from 'express';
 import prisma from '../config/database';
 import {
     getEnabledFoodDataProviders,
-    getFoodDataProvider,
     getFoodDataProviderByName,
     type FoodDataSource
 } from '../services/foodData';
+import type { FoodDataProvider, FoodSearchRequest, FoodSearchResult } from '../services/foodData';
 import { parseLocalDateOnly } from '../utils/date';
 import { parsePositiveInteger } from '../utils/requestParsing';
 import { parseFoodLogCreateBody, parseFoodLogUpdateBody, parseFoodSearchParams } from './foodUtils';
@@ -17,16 +17,30 @@ import { parseFoodLogCreateBody, parseFoodLogUpdateBody, parseFoodSearchParams }
  */
 const router = express.Router();
 
-type BarcodeProviderAttempt = {
+type ProviderSearchAttempt = {
     name: FoodDataSource;
     status: 'skipped' | 'error' | 'empty';
     detail?: string;
 };
 
+type ProviderSearchOutcome =
+    | {
+          found: true;
+          provider: FoodDataProvider;
+          result: FoodSearchResult;
+          attempts: ProviderSearchAttempt[];
+      }
+    | {
+          found: false;
+          attempts: ProviderSearchAttempt[];
+          sawSuccessfulResponse: boolean;
+          lastError: Error | null;
+      };
+
 /**
- * Summarize barcode lookup attempts for logs without leaking request details.
+ * Summarize provider search attempts for logs without leaking request details.
  */
-const formatBarcodeAttemptSummary = (attempts: BarcodeProviderAttempt[]): string => {
+const formatProviderAttemptSummary = (attempts: ProviderSearchAttempt[]): string => {
     return attempts
         .map((attempt) => {
             const detail = attempt.detail ? ` - ${attempt.detail}` : '';
@@ -116,6 +130,88 @@ const buildRecentFoodAccumulator = (log: any, key: string): RecentFoodAccumulato
 });
 
 /**
+ * Search ready providers in configured order, stopping at the first provider with results.
+ */
+const searchEnabledProviders = async (
+    params: FoodSearchRequest,
+    opts: { requireBarcodeLookup: boolean }
+): Promise<ProviderSearchOutcome> => {
+    const { primary, providers } = getEnabledFoodDataProviders();
+    const attempts: ProviderSearchAttempt[] = [];
+
+    if (!primary.ready) {
+        attempts.push({
+            name: primary.name,
+            status: 'skipped',
+            detail: primary.detail || 'Provider is not ready.'
+        });
+    }
+
+    let sawSuccessfulResponse = false;
+    let lastError: Error | null = null;
+
+    for (const providerInfo of providers) {
+        if (opts.requireBarcodeLookup && !providerInfo.supportsBarcodeLookup) {
+            attempts.push({
+                name: providerInfo.name,
+                status: 'skipped',
+                detail: 'Barcode lookup is disabled for this provider.'
+            });
+            continue;
+        }
+
+        const resolution = getFoodDataProviderByName(providerInfo.name);
+        if (!resolution.provider) {
+            attempts.push({
+                name: providerInfo.name,
+                status: 'skipped',
+                detail: resolution.error || providerInfo.detail || 'Provider is not available.'
+            });
+            continue;
+        }
+
+        if (opts.requireBarcodeLookup && !resolution.provider.supportsBarcodeLookup) {
+            attempts.push({
+                name: providerInfo.name,
+                status: 'skipped',
+                detail: 'Barcode lookup is disabled for this provider.'
+            });
+            continue;
+        }
+
+        try {
+            const result = await resolution.provider.searchFoods(params);
+            if (opts.requireBarcodeLookup && !resolution.provider.supportsBarcodeLookup) {
+                attempts.push({
+                    name: providerInfo.name,
+                    status: 'skipped',
+                    detail: 'Barcode lookup is disabled for this provider.'
+                });
+                continue;
+            }
+
+            sawSuccessfulResponse = true;
+            if (result.items.length > 0) {
+                return {
+                    found: true,
+                    provider: resolution.provider,
+                    result,
+                    attempts
+                };
+            }
+
+            attempts.push({ name: providerInfo.name, status: 'empty' });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Search failed.';
+            attempts.push({ name: providerInfo.name, status: 'error', detail: message });
+            lastError = err instanceof Error ? err : new Error(message);
+        }
+    }
+
+    return { found: false, attempts, sawSuccessfulResponse, lastError };
+};
+
+/**
  * Ensure the session is authenticated before accessing food data.
  */
 const isAuthenticated = (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -180,98 +276,32 @@ router.get('/search', async (req, res) => {
         return res.status(parsed.statusCode).json({ message: parsed.message });
     }
 
-    if (!parsed.params.barcode) {
-        const provider = getFoodDataProvider();
+    const searchOutcome = await searchEnabledProviders(parsed.params, {
+        requireBarcodeLookup: Boolean(parsed.params.barcode)
+    });
 
-        try {
-            // Providers return normalized items so the frontend can show a consistent search UI.
-            const result = await provider.searchFoods(parsed.params);
-
-            res.json({
-                provider: provider.name,
-                supportsBarcodeLookup: provider.supportsBarcodeLookup,
-                ...result
-            });
-        } catch (err) {
-            console.error(err);
-            res.status(500).json({ message: 'Unable to search foods right now.' });
-        }
-        return;
-    }
-
-    const { primary, providers } = getEnabledFoodDataProviders();
-    const barcodeProviders = providers.filter((provider) => provider.supportsBarcodeLookup);
-    const attempts: BarcodeProviderAttempt[] = [];
-
-    if (!primary.ready) {
-        attempts.push({
-            name: primary.name,
-            status: 'skipped',
-            detail: primary.detail || 'Provider is not ready.'
+    if (searchOutcome.found) {
+        return res.json({
+            provider: searchOutcome.provider.name,
+            supportsBarcodeLookup: searchOutcome.provider.supportsBarcodeLookup,
+            ...searchOutcome.result
         });
     }
 
-    let sawSuccessfulResponse = false;
-    let lastError: Error | null = null;
-
-    for (const providerInfo of barcodeProviders) {
-        const resolution = getFoodDataProviderByName(providerInfo.name);
-        if (!resolution.provider) {
-            attempts.push({
-                name: providerInfo.name,
-                status: 'skipped',
-                detail: resolution.error || providerInfo.detail || 'Provider is not available.'
-            });
-            continue;
-        }
-
-        if (!resolution.provider.supportsBarcodeLookup) {
-            attempts.push({
-                name: providerInfo.name,
-                status: 'skipped',
-                detail: 'Barcode lookup is disabled for this provider.'
-            });
-            continue;
-        }
-
-        try {
-            const result = await resolution.provider.searchFoods(parsed.params);
-            if (!resolution.provider.supportsBarcodeLookup) {
-                attempts.push({
-                    name: providerInfo.name,
-                    status: 'skipped',
-                    detail: 'Barcode lookup is disabled for this provider.'
-                });
-                continue;
-            }
-
-            sawSuccessfulResponse = true;
-            if (result.items.length > 0) {
-                return res.json({
-                    provider: resolution.provider.name,
-                    supportsBarcodeLookup: resolution.provider.supportsBarcodeLookup,
-                    ...result
-                });
-            }
-
-            attempts.push({ name: providerInfo.name, status: 'empty' });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : 'Search failed.';
-            attempts.push({ name: providerInfo.name, status: 'error', detail: message });
-            lastError = err instanceof Error ? err : new Error(message);
-        }
-    }
-
-    if (!sawSuccessfulResponse && lastError) {
-        console.error(lastError);
-        if (attempts.length > 0) {
-            console.info(`Barcode lookup failed for all providers. Attempts: ${formatBarcodeAttemptSummary(attempts)}`);
+    if (!searchOutcome.sawSuccessfulResponse && searchOutcome.lastError) {
+        console.error(searchOutcome.lastError);
+        if (searchOutcome.attempts.length > 0) {
+            console.info(
+                `Food search failed for all providers. Attempts: ${formatProviderAttemptSummary(searchOutcome.attempts)}`
+            );
         }
         return res.status(500).json({ message: 'Unable to search foods right now.' });
     }
 
-    if (attempts.length > 0) {
-        console.info(`Barcode lookup returned no results. Attempts: ${formatBarcodeAttemptSummary(attempts)}`);
+    if (searchOutcome.attempts.length > 0) {
+        console.info(
+            `Food search returned no results. Attempts: ${formatProviderAttemptSummary(searchOutcome.attempts)}`
+        );
     }
 
     return res.json({ items: [] });

--- a/backend/src/services/foodData/index.ts
+++ b/backend/src/services/foodData/index.ts
@@ -130,6 +130,13 @@ const buildProviderOrder = (primary: FoodDataSource): FoodDataSource[] => {
     return order;
 };
 
+/**
+ * Pick the first provider in fallback order that has the environment it needs.
+ */
+const getFirstReadyProviderName = (primary: FoodDataSource): FoodDataSource | null => {
+    return buildProviderOrder(primary).find((name) => getMissingProviderEnvVars(name).length === 0) ?? null;
+};
+
 export type EnabledFoodDataProviders = {
     primary: FoodDataProviderInfo;
     providers: FoodDataProviderInfo[];
@@ -259,6 +266,8 @@ export const getFoodDataProvider = (): FoodDataProvider => {
         return providerInstance;
     }
 
+    const fallbackName = getFirstReadyProviderName(normalized) ?? 'openFoodFacts';
+    const fallbackLabel = providerRegistry[fallbackName].label;
     const missing = getMissingProviderEnvVars(normalized);
     if (missing.length > 0) {
         const config = providerRegistry[normalized];
@@ -267,16 +276,16 @@ export const getFoodDataProvider = (): FoodDataProvider => {
             : `Set ${missing.join(', ')} to enable ${config.label}.`;
         console.warn(
             `FOOD_DATA_PROVIDER=${requestedRaw ?? requestedValue}, but ${formatMissingEnvSentence(missing)}. ` +
-                `${action} Falling back to Open Food Facts.`
+                `${action} Falling back to ${fallbackLabel}.`
         );
     } else {
         console.warn(
             `FOOD_DATA_PROVIDER=${requestedRaw ?? requestedValue} failed to initialize. ` +
-                'Check the provider configuration and credentials. Falling back to Open Food Facts.'
+                `Check the provider configuration and credentials. Falling back to ${fallbackLabel}.`
         );
     }
 
-    const fallback = getFoodDataProviderByName('openFoodFacts');
+    const fallback = getFoodDataProviderByName(fallbackName);
     providerInstance = fallback.provider ?? new OpenFoodFactsProvider();
     return providerInstance;
 };

--- a/backend/test/food-data-registry.test.js
+++ b/backend/test/food-data-registry.test.js
@@ -148,7 +148,12 @@ test('foodData registry: getFoodDataProvider falls back when FatSecret credentia
 
   try {
     withFoodDataModule(
-      { FOOD_DATA_PROVIDER: undefined, FATSECRET_CLIENT_ID: undefined, FATSECRET_CLIENT_SECRET: undefined },
+      {
+        FOOD_DATA_PROVIDER: undefined,
+        FATSECRET_CLIENT_ID: undefined,
+        FATSECRET_CLIENT_SECRET: undefined,
+        USDA_API_KEY: undefined
+      },
       ({ getFoodDataProvider }) => {
         const provider = getFoodDataProvider();
         assert.equal(provider.name, 'openFoodFacts');
@@ -161,6 +166,33 @@ test('foodData registry: getFoodDataProvider falls back when FatSecret credentia
   assert.equal(warnCalls.length > 0, true);
 });
 
+test('foodData registry: getFoodDataProvider falls back to USDA when FatSecret is missing but USDA is configured', () => {
+  const warnCalls = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => {
+    warnCalls.push(args.join(' '));
+  };
+
+  try {
+    withFoodDataModule(
+      {
+        FOOD_DATA_PROVIDER: undefined,
+        FATSECRET_CLIENT_ID: undefined,
+        FATSECRET_CLIENT_SECRET: undefined,
+        USDA_API_KEY: 'test-key'
+      },
+      ({ getFoodDataProvider }) => {
+        const provider = getFoodDataProvider();
+        assert.equal(provider.name, 'usda');
+      }
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(warnCalls.some((message) => message.includes('Falling back to USDA FoodData Central')), true);
+});
+
 test('foodData registry: getFoodDataProvider falls back when configured for USDA without an API key', () => {
   const warnCalls = [];
   const originalWarn = console.warn;
@@ -169,10 +201,18 @@ test('foodData registry: getFoodDataProvider falls back when configured for USDA
   };
 
   try {
-    withFoodDataModule({ FOOD_DATA_PROVIDER: 'usda', USDA_API_KEY: undefined }, ({ getFoodDataProvider }) => {
-      const provider = getFoodDataProvider();
-      assert.equal(provider.name, 'openFoodFacts');
-    });
+    withFoodDataModule(
+      {
+        FOOD_DATA_PROVIDER: 'usda',
+        FATSECRET_CLIENT_ID: undefined,
+        FATSECRET_CLIENT_SECRET: undefined,
+        USDA_API_KEY: undefined
+      },
+      ({ getFoodDataProvider }) => {
+        const provider = getFoodDataProvider();
+        assert.equal(provider.name, 'openFoodFacts');
+      }
+    );
   } finally {
     console.warn = originalWarn;
   }

--- a/backend/test/routes-food.test.js
+++ b/backend/test/routes-food.test.js
@@ -152,7 +152,7 @@ test('food route: GET /search calls provider.searchFoods and returns provider me
   assert.equal(Array.isArray(res.body.items), true);
 });
 
-test('food route: GET /search falls back to the next provider when text search returns no matches', async () => {
+test('food route: GET /search keeps text pagination pinned when a provider returns no matches', async () => {
   const callOrder = [];
   const providerA = {
     name: 'fatsecret',
@@ -190,15 +190,15 @@ test('food route: GET /search falls back to the next provider when text search r
   });
 
   const handler = getRouteHandler(router, 'get', '/search');
-  const req = { query: { q: 'apple' }, headers: {} };
+  const req = { query: { q: 'apple', page: '2' }, headers: {} };
   const res = createRes();
 
   await handler(req, res);
 
   assert.equal(res.statusCode, 200);
-  assert.equal(res.body.provider, 'usda');
-  assert.equal(res.body.items.length, 1);
-  assert.deepEqual(callOrder, ['fatsecret', 'usda']);
+  assert.equal(res.body.provider, 'fatsecret');
+  assert.equal(res.body.items.length, 0);
+  assert.deepEqual(callOrder, ['fatsecret']);
 });
 
 test('food route: GET /search falls back to the next provider when text search errors', async () => {

--- a/backend/test/routes-food.test.js
+++ b/backend/test/routes-food.test.js
@@ -116,7 +116,16 @@ test('food route: GET /search calls provider.searchFoods and returns provider me
 
   const router = loadFoodRouter({
     prismaStub: {},
-    foodDataStub: { getFoodDataProvider: () => providerStub }
+    foodDataStub: {
+      getEnabledFoodDataProviders: () => ({
+        primary: { name: 'openFoodFacts', label: 'Open Food Facts', supportsBarcodeLookup: true, ready: true },
+        providers: [{ name: 'openFoodFacts', label: 'Open Food Facts', supportsBarcodeLookup: true, ready: true }]
+      }),
+      getFoodDataProviderByName: (name) => {
+        if (name === 'openFoodFacts') return { provider: providerStub };
+        return { error: 'unknown provider' };
+      }
+    }
   });
 
   const handler = getRouteHandler(router, 'get', '/search');
@@ -141,6 +150,104 @@ test('food route: GET /search calls provider.searchFoods and returns provider me
   assert.equal(res.body.provider, 'openFoodFacts');
   assert.equal(res.body.supportsBarcodeLookup, true);
   assert.equal(Array.isArray(res.body.items), true);
+});
+
+test('food route: GET /search falls back to the next provider when text search returns no matches', async () => {
+  const callOrder = [];
+  const providerA = {
+    name: 'fatsecret',
+    supportsBarcodeLookup: true,
+    searchFoods: async () => {
+      callOrder.push('fatsecret');
+      return { items: [] };
+    }
+  };
+  const providerB = {
+    name: 'usda',
+    supportsBarcodeLookup: true,
+    searchFoods: async () => {
+      callOrder.push('usda');
+      return { items: [{ id: '2', source: 'usda', description: 'Apple', availableMeasures: [] }] };
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub: {},
+    foodDataStub: {
+      getEnabledFoodDataProviders: () => ({
+        primary: { name: 'fatsecret', label: 'FatSecret', supportsBarcodeLookup: true, ready: true },
+        providers: [
+          { name: 'fatsecret', label: 'FatSecret', supportsBarcodeLookup: true, ready: true },
+          { name: 'usda', label: 'USDA FoodData Central', supportsBarcodeLookup: true, ready: true }
+        ]
+      }),
+      getFoodDataProviderByName: (name) => {
+        if (name === 'fatsecret') return { provider: providerA };
+        if (name === 'usda') return { provider: providerB };
+        return { error: 'unknown provider' };
+      }
+    }
+  });
+
+  const handler = getRouteHandler(router, 'get', '/search');
+  const req = { query: { q: 'apple' }, headers: {} };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.provider, 'usda');
+  assert.equal(res.body.items.length, 1);
+  assert.deepEqual(callOrder, ['fatsecret', 'usda']);
+});
+
+test('food route: GET /search falls back to the next provider when text search errors', async () => {
+  const callOrder = [];
+  const providerA = {
+    name: 'fatsecret',
+    supportsBarcodeLookup: true,
+    searchFoods: async () => {
+      callOrder.push('fatsecret');
+      throw new Error('upstream unavailable');
+    }
+  };
+  const providerB = {
+    name: 'usda',
+    supportsBarcodeLookup: true,
+    searchFoods: async () => {
+      callOrder.push('usda');
+      return { items: [{ id: '2', source: 'usda', description: 'Apple', availableMeasures: [] }] };
+    }
+  };
+
+  const router = loadFoodRouter({
+    prismaStub: {},
+    foodDataStub: {
+      getEnabledFoodDataProviders: () => ({
+        primary: { name: 'fatsecret', label: 'FatSecret', supportsBarcodeLookup: true, ready: true },
+        providers: [
+          { name: 'fatsecret', label: 'FatSecret', supportsBarcodeLookup: true, ready: true },
+          { name: 'usda', label: 'USDA FoodData Central', supportsBarcodeLookup: true, ready: true }
+        ]
+      }),
+      getFoodDataProviderByName: (name) => {
+        if (name === 'fatsecret') return { provider: providerA };
+        if (name === 'usda') return { provider: providerB };
+        return { error: 'unknown provider' };
+      }
+    }
+  });
+
+  const handler = getRouteHandler(router, 'get', '/search');
+  const req = { query: { q: 'apple' }, headers: {} };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.provider, 'usda');
+  assert.equal(res.body.items.length, 1);
+  assert.deepEqual(callOrder, ['fatsecret', 'usda']);
 });
 
 test('food route: GET /search falls back to the next provider for barcode lookups', async () => {


### PR DESCRIPTION
## Summary

- detect available food providers from environment-backed credentials during devcontainer startup instead of hard-coding FatSecret
- search ready food providers in configured order for both text and barcode lookups, falling back when a provider errors or returns no results
- document local provider credential behavior and add coverage for provider fallback and environment isolation
- make the generated devcontainer env temp file process-specific to avoid parallel exec races

## Validation

- `npm run devcontainer:exec -- -- npm --prefix backend test -- test/routes-food.test.js test/food-data-registry.test.js`
- live `/api/food/search?q=apple&pageSize=2` returned `200` from FatSecret after credentials were available