### PR TITLE
[codex] Improve PWA app experience

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -51,11 +51,15 @@ import { useIncompleteTodayBadge } from '../hooks/useIncompleteTodayBadge';
 import { useInstallState } from '../hooks/useInstallState';
 import CalibrateLogo from './CalibrateLogo';
 import LogDateNavigationCluster from './LogDateNavigationCluster';
+import PwaStatusToasts from './PwaStatusToasts';
 
 const SAFE_AREA_INSET_TOP = 'var(--safe-area-inset-top, 0px)';
 const SAFE_AREA_INSET_BOTTOM = 'var(--safe-area-inset-bottom, 0px)';
 const SAFE_AREA_INSET_LEFT = 'var(--safe-area-inset-left, 0px)';
 const SAFE_AREA_INSET_RIGHT = 'var(--safe-area-inset-right, 0px)';
+const TITLEBAR_AREA_X = 'env(titlebar-area-x, 0px)';
+const TITLEBAR_AREA_WIDTH = 'env(titlebar-area-width, 100vw)';
+const TITLEBAR_AREA_RIGHT_INSET = `calc(100vw - ${TITLEBAR_AREA_X} - ${TITLEBAR_AREA_WIDTH})`; // Keeps toolbar actions clear of desktop PWA window controls.
 const TOOLBAR_HORIZONTAL_PADDING_SPACING = { xs: 1.25, sm: 2.5 }; // Header gutter including safe-area insets.
 const DEFAULT_TOOLBAR_MIN_HEIGHT_SPACING = 7; // MUI default toolbar height in spacing units (56px).
 const NAV_NOTIFICATION_BADGE_MAX = 99; // Prevent oversized badge strings from crowding the header controls.
@@ -92,16 +96,18 @@ function buildSafeAreaToolbarSx(theme: Theme) {
     const baseMinHeight = normalizeToolbarMinHeight(theme.mixins.toolbar.minHeight, fallbackMinHeight);
     const toolbarMixins = theme.mixins.toolbar as Record<string, { minHeight?: number | string } | undefined>;
     const smMinHeight = normalizeToolbarMinHeight(toolbarMixins[theme.breakpoints.up('sm')]?.minHeight, baseMinHeight);
+    const leadingInset = `max(${SAFE_AREA_INSET_LEFT}, ${TITLEBAR_AREA_X})`;
+    const trailingInset = `max(${SAFE_AREA_INSET_RIGHT}, ${TITLEBAR_AREA_RIGHT_INSET})`;
 
     return {
         pt: SAFE_AREA_INSET_TOP,
-        pl: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.xs)} + ${SAFE_AREA_INSET_LEFT})`,
-        pr: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.xs)} + ${SAFE_AREA_INSET_RIGHT})`,
+        pl: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.xs)} + ${leadingInset})`,
+        pr: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.xs)} + ${trailingInset})`,
         minHeight: `calc(${baseMinHeight} + ${SAFE_AREA_INSET_TOP})`,
         [theme.breakpoints.up('sm')]: {
             minHeight: `calc(${smMinHeight} + ${SAFE_AREA_INSET_TOP})`,
-            pl: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.sm)} + ${SAFE_AREA_INSET_LEFT})`,
-            pr: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.sm)} + ${SAFE_AREA_INSET_RIGHT})`
+            pl: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.sm)} + ${leadingInset})`,
+            pr: `calc(${theme.spacing(TOOLBAR_HORIZONTAL_PADDING_SPACING.sm)} + ${trailingInset})`
         }
     };
 }
@@ -307,7 +313,8 @@ const LayoutShell: React.FC = () => {
                                 sm: '"brand date actions"'
                             },
                             columnGap: { xs: 0.75, sm: 1.25 },
-                            alignItems: 'center'
+                            alignItems: 'center',
+                            WebkitAppRegion: 'drag'
                         }
                     ]}
                 >
@@ -324,7 +331,8 @@ const LayoutShell: React.FC = () => {
                             flexShrink: 0,
                             minWidth: 0,
                             justifySelf: 'start',
-                            gridArea: 'brand'
+                            gridArea: 'brand',
+                            WebkitAppRegion: 'no-drag'
                         }}
                     >
                         <CalibrateLogo showWordmark={false} size={34} />
@@ -338,7 +346,12 @@ const LayoutShell: React.FC = () => {
                             navigation={logDateNavigation}
                             placement="navbar"
                             showTodayShortcut
-                            sx={{ display: { xs: 'none', sm: 'inline-flex' }, justifySelf: 'center', gridArea: 'date' }}
+                            sx={{
+                                display: { xs: 'none', sm: 'inline-flex' },
+                                justifySelf: 'center',
+                                gridArea: 'date',
+                                WebkitAppRegion: 'no-drag'
+                            }}
                         />
                     )}
 
@@ -349,7 +362,8 @@ const LayoutShell: React.FC = () => {
                             gap: 1,
                             flexShrink: 0,
                             justifySelf: 'end',
-                            gridArea: 'actions'
+                            gridArea: 'actions',
+                            WebkitAppRegion: 'no-drag'
                         }}
                     >
                         {(showLoginCta || showRegisterCta) && (
@@ -510,6 +524,7 @@ const LayoutShell: React.FC = () => {
             )}
 
             {showAppNav && <LogQuickAddFab date={fabDate} />}
+            <PwaStatusToasts />
 
             <Dialog
                 open={isIosInstallDialogOpen && !isInstalled}

--- a/frontend/src/components/PwaStatusToasts.tsx
+++ b/frontend/src/components/PwaStatusToasts.tsx
@@ -1,0 +1,170 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Button, Snackbar } from '@mui/material';
+import { useI18n } from '../i18n/useI18n';
+import { usePwaRuntimeState } from '../pwa/runtime';
+
+const TRANSIENT_PWA_STATUS_DURATION_MS = 4500; // Keeps success/status notices visible without lingering over app controls.
+const MOBILE_SNACKBAR_BOTTOM_OFFSET = 'calc(80px + var(--safe-area-inset-bottom, 0px))'; // Clear the fixed bottom nav in installed mobile layouts.
+
+type PwaToastKind = 'offline' | 'online' | 'updateReady' | 'updateFailed';
+
+type PwaToastState = {
+    kind: PwaToastKind;
+    message: string;
+    severity: 'info' | 'success' | 'warning' | 'error';
+    persist: boolean;
+};
+
+/**
+ * Resolve navigator.onLine once, defaulting to online during non-browser rendering.
+ */
+function getInitialOnlineState(): boolean {
+    if (typeof navigator === 'undefined') return true;
+    return navigator.onLine;
+}
+
+/**
+ * Surface PWA runtime states that would otherwise be silent browser/service-worker behavior.
+ */
+const PwaStatusToasts: React.FC = () => {
+    const { t } = useI18n();
+    const pwaRuntime = usePwaRuntimeState();
+    const [isOnline, setIsOnline] = useState(getInitialOnlineState);
+    const [networkToast, setNetworkToast] = useState<PwaToastKind | null>(() =>
+        getInitialOnlineState() ? null : 'offline'
+    );
+    const [isApplyingUpdate, setIsApplyingUpdate] = useState(false);
+    const [updateFailed, setUpdateFailed] = useState(false);
+
+    useEffect(() => {
+        const handleOnline = () => {
+            setIsOnline(true);
+            setNetworkToast('online');
+        };
+        const handleOffline = () => {
+            setIsOnline(false);
+            setNetworkToast('offline');
+        };
+
+        window.addEventListener('online', handleOnline);
+        window.addEventListener('offline', handleOffline);
+
+        return () => {
+            window.removeEventListener('online', handleOnline);
+            window.removeEventListener('offline', handleOffline);
+        };
+    }, []);
+
+    const handleApplyUpdate = useCallback(async () => {
+        if (!pwaRuntime.updateServiceWorker || isApplyingUpdate) {
+            return;
+        }
+
+        setIsApplyingUpdate(true);
+        setUpdateFailed(false);
+
+        try {
+            await pwaRuntime.updateServiceWorker();
+        } catch {
+            setUpdateFailed(true);
+            setIsApplyingUpdate(false);
+        }
+    }, [isApplyingUpdate, pwaRuntime]);
+
+    const toast = useMemo<PwaToastState | null>(() => {
+        if (updateFailed) {
+            return {
+                kind: 'updateFailed',
+                message: t('pwa.updateFailed'),
+                severity: 'error',
+                persist: false
+            };
+        }
+
+        if (pwaRuntime.updateAvailable) {
+            return {
+                kind: 'updateReady',
+                message: t('pwa.updateReady'),
+                severity: 'info',
+                persist: true
+            };
+        }
+
+        if (!isOnline || networkToast === 'offline') {
+            return {
+                kind: 'offline',
+                message: t('pwa.offline'),
+                severity: 'warning',
+                persist: true
+            };
+        }
+
+        if (networkToast === 'online') {
+            return {
+                kind: 'online',
+                message: t('pwa.backOnline'),
+                severity: 'success',
+                persist: false
+            };
+        }
+
+        return null;
+    }, [
+        isOnline,
+        networkToast,
+        pwaRuntime.updateAvailable,
+        t,
+        updateFailed
+    ]);
+
+    const handleClose = useCallback(
+        (_event?: React.SyntheticEvent | Event, reason?: string) => {
+            if (reason === 'clickaway') {
+                return;
+            }
+
+            if (toast?.kind === 'offline' || toast?.kind === 'updateReady') {
+                return;
+            }
+
+            if (toast?.kind === 'online') {
+                setNetworkToast(null);
+            }
+
+            if (toast?.kind === 'updateFailed') {
+                setUpdateFailed(false);
+            }
+        },
+        [toast?.kind]
+    );
+
+    const action =
+        toast?.kind === 'updateReady' ? (
+            <Button color="inherit" size="small" onClick={handleApplyUpdate} disabled={isApplyingUpdate}>
+                {t('pwa.updateAction')}
+            </Button>
+        ) : undefined;
+
+    return (
+        <Snackbar
+            open={Boolean(toast)}
+            autoHideDuration={toast?.persist ? null : TRANSIENT_PWA_STATUS_DURATION_MS}
+            onClose={handleClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            sx={{
+                bottom: {
+                    xs: MOBILE_SNACKBAR_BOTTOM_OFFSET,
+                    md: 24
+                }
+            }}
+        >
+            {toast ? (
+                <Alert severity={toast.severity} action={action} onClose={toast.persist ? undefined : handleClose}>
+                    {toast.message}
+                </Alert>
+            ) : undefined}
+        </Snackbar>
+    );
+};
+
+export default PwaStatusToasts;

--- a/frontend/src/context/ThemeModeContext.tsx
+++ b/frontend/src/context/ThemeModeContext.tsx
@@ -6,6 +6,8 @@ import { ThemeModeContext, type ThemeModeContextValue, type ThemePreference } fr
 
 const THEME_PREFERENCE_STORAGE_KEY = 'calibrate.themePreference';
 const LEGACY_THEME_PREFERENCE_STORAGE_KEY = 'calio.themePreference';
+const LIGHT_THEME_COLOR = '#FFFFFF'; // Browser chrome color for the installed app in light mode.
+const DARK_THEME_COLOR = '#111827'; // Browser chrome color for the installed app in dark mode.
 
 /**
  * Type guard for values we allow to be stored/used as theme preferences.
@@ -47,6 +49,15 @@ function persistThemePreference(preference: ThemePreference) {
     }
 }
 
+/**
+ * Keep the browser/PWA title bar color aligned with the active in-app theme.
+ */
+function syncThemeColorMeta(mode: PaletteMode) {
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+    if (!meta) return;
+    meta.content = mode === 'dark' ? DARK_THEME_COLOR : LIGHT_THEME_COLOR;
+}
+
 export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const systemPrefersDark = useMediaQuery('(prefers-color-scheme: dark)', { noSsr: true });
 
@@ -64,6 +75,10 @@ export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }, [preference, systemPrefersDark]);
 
     const theme = useMemo(() => createAppTheme(mode), [mode]);
+
+    useEffect(() => {
+        syncThemeColorMeta(mode);
+    }, [mode]);
 
     const value: ThemeModeContextValue = useMemo(
         () => ({

--- a/frontend/src/i18n/resources.ts
+++ b/frontend/src/i18n/resources.ts
@@ -38,6 +38,11 @@ export const en = {
     'install.ios.step1': 'Tap the Share button in Safari.',
     'install.ios.step2': 'Choose Add to Home Screen.',
     'install.ios.step3': 'Tap Add to finish installing.',
+    'pwa.offline': 'Offline. You can keep viewing cached screens; saving needs a connection.',
+    'pwa.backOnline': 'Back online.',
+    'pwa.updateReady': 'Update ready.',
+    'pwa.updateAction': 'Reload',
+    'pwa.updateFailed': 'Unable to update. Try refreshing.',
 
     'legal.privacyPolicy': 'Privacy policy',
 
@@ -615,6 +620,11 @@ export const es: Record<TranslationKey, string> = {
     'install.ios.step1': 'Toca el boton Compartir en Safari.',
     'install.ios.step2': 'Elige Agregar a pantalla de inicio.',
     'install.ios.step3': 'Toca Agregar para terminar la instalacion.',
+    'pwa.offline': 'Sin conexion. Puedes seguir viendo pantallas en cache; guardar necesita conexion.',
+    'pwa.backOnline': 'En linea de nuevo.',
+    'pwa.updateReady': 'Actualizacion lista.',
+    'pwa.updateAction': 'Recargar',
+    'pwa.updateFailed': 'No se pudo actualizar. Intenta recargar.',
 
     'legal.privacyPolicy': 'Política de privacidad',
 
@@ -1190,6 +1200,11 @@ export const fr: Record<TranslationKey, string> = {
     'install.ios.step1': 'Touchez le bouton Partager dans Safari.',
     'install.ios.step2': "Choisissez Ajouter a l'ecran d'accueil.",
     'install.ios.step3': "Touchez Ajouter pour terminer l'installation.",
+    'pwa.offline': "Hors ligne. Vous pouvez consulter les ecrans en cache; l'enregistrement necessite une connexion.",
+    'pwa.backOnline': 'Connexion retablie.',
+    'pwa.updateReady': 'Mise a jour prete.',
+    'pwa.updateAction': 'Recharger',
+    'pwa.updateFailed': 'Impossible de mettre a jour. Essayez de recharger.',
 
     'legal.privacyPolicy': 'Politique de confidentialité',
 
@@ -1765,6 +1780,11 @@ export const ru: Record<TranslationKey, string> = {
     'install.ios.step1': 'Нажмите кнопку Поделиться в Safari.',
     'install.ios.step2': 'Выберите На экран Домой.',
     'install.ios.step3': 'Нажмите Добавить для завершения установки.',
+    'pwa.offline': 'Нет соединения. Можно просматривать кешированные экраны; для сохранения нужно подключение.',
+    'pwa.backOnline': 'Соединение восстановлено.',
+    'pwa.updateReady': 'Обновление готово.',
+    'pwa.updateAction': 'Перезагрузить',
+    'pwa.updateFailed': 'Не удалось обновить. Попробуйте перезагрузить.',
 
     'legal.privacyPolicy': 'Политика конфиденциальности',
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from './context/AuthContext.tsx'
 import { ThemeModeProvider } from './context/ThemeModeContext.tsx'
 import { registerSW } from 'virtual:pwa-register'
 import { I18nFromAuth } from './i18n/I18nFromAuth.tsx'
+import { publishPwaRuntimeState } from './pwa/runtime.ts'
 
 const queryClient = new QueryClient()
 
@@ -47,7 +48,15 @@ function shouldRegisterServiceWorker(): boolean {
  * Register the PWA service worker so production stays installable and opt-in dev can validate push.
  */
 function registerServiceWorker() {
-  registerSW({ immediate: true })
+  const updateServiceWorker = registerSW({
+    immediate: true,
+    onNeedRefresh() {
+      publishPwaRuntimeState({
+        updateAvailable: true,
+        updateServiceWorker: () => updateServiceWorker(true),
+      })
+    },
+  })
 }
 
 /**

--- a/frontend/src/pwa/runtime.ts
+++ b/frontend/src/pwa/runtime.ts
@@ -1,0 +1,50 @@
+import { useSyncExternalStore } from 'react';
+
+export type PwaRuntimeState = {
+    updateAvailable: boolean;
+    updateServiceWorker: (() => Promise<void>) | null;
+};
+
+const DEFAULT_PWA_RUNTIME_STATE: PwaRuntimeState = {
+    updateAvailable: false,
+    updateServiceWorker: null
+};
+
+let pwaRuntimeState = DEFAULT_PWA_RUNTIME_STATE;
+const listeners = new Set<() => void>();
+
+/**
+ * Publish service-worker lifecycle state from app boot code into React UI.
+ */
+export function publishPwaRuntimeState(nextState: Partial<PwaRuntimeState>) {
+    pwaRuntimeState = {
+        ...pwaRuntimeState,
+        ...nextState
+    };
+
+    for (const listener of listeners) {
+        listener();
+    }
+}
+
+function subscribeToPwaRuntimeState(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+function getPwaRuntimeStateSnapshot(): PwaRuntimeState {
+    return pwaRuntimeState;
+}
+
+/**
+ * Subscribe React components to PWA runtime changes without coupling them to service-worker setup.
+ */
+export function usePwaRuntimeState(): PwaRuntimeState {
+    return useSyncExternalStore(
+        subscribeToPwaRuntimeState,
+        getPwaRuntimeStateSnapshot,
+        getPwaRuntimeStateSnapshot
+    );
+}

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -20,10 +20,15 @@ const SPA_ENTRY_URL = '/index.html';
 const NAVIGATION_DENYLIST = [/^\/api\//, /^\/auth\//, /^\/dev\/test\//];
 
 /**
- * Ensure new service worker versions take control quickly.
+ * Claim pages once a user-approved update activates.
  */
-self.skipWaiting();
 clientsClaim();
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
 
 cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -145,7 +145,7 @@ function getWorktreeNameFromRepoRoot(repoRootName: string) {
 function getPwaOptions(enableServiceWorkerInDev: boolean): Partial<VitePWAOptions> {
   return {
     strategies: 'injectManifest',
-    registerType: 'autoUpdate',
+    registerType: 'prompt',
     srcDir: 'src',
     filename: 'service-worker.ts',
     devOptions: {
@@ -165,9 +165,12 @@ function getPwaOptions(enableServiceWorkerInDev: boolean): Partial<VitePWAOption
       ...PWA_SCREENSHOT_ASSETS,
     ],
     manifest: {
+      id: '/',
       name: 'calibrate',
       short_name: 'calibrate',
       description: 'A responsive calorie tracker.',
+      lang: 'en',
+      dir: 'ltr',
       theme_color: PWA_THEME_COLOR,
       background_color: PWA_BACKGROUND_COLOR,
       categories: ['health', 'fitness', 'lifestyle'],


### PR DESCRIPTION
## Summary
- Add PWA runtime state wiring and focused toasts for offline, back-online, update-ready, and update-failed states.
- Switch service-worker updates to a user-approved reload flow instead of silently activating updates.
- Add stable manifest identity/language metadata, dynamic theme-color syncing, and installed desktop title-bar overlay spacing/drag behavior.

## Why
Calibrate already had a strong PWA foundation, but service-worker lifecycle states were mostly silent and update activation could happen without a clear user affordance. This makes install/runtime behavior more app-like while avoiding non-actionable lifecycle messaging such as the offline-ready toast.

## Validation
- `npm.cmd --prefix frontend run lint`
- `npm.cmd --prefix frontend run build`

Notes: the build still reports the existing large eager SPA chunk warning and the known `vite-plugin-pwa` `inlineDynamicImports` warning.