### PR TITLE
Audit frontend React patterns and tighten shared state handling

### DIFF
--- a/frontend/src/components/FoodEntryForm.tsx
+++ b/frontend/src/components/FoodEntryForm.tsx
@@ -286,11 +286,6 @@ const FoodEntryForm: React.FC<Props> = ({ onSuccess, date, initialMealPeriod = n
     const shouldShowMealPeriod =
         mode !== 'search' || (mode === 'search' && ((searchView === 'selected' && !!selectedItem) || !!selectedRecentFood));
 
-    useEffect(() => {
-        if (!initialMealPeriod) return;
-        setMealPeriod(initialMealPeriod);
-    }, [initialMealPeriod]);
-
     // Avoid stale recipe selections if users leave and return to the Recipes tab.
     useEffect(() => {
         setSelectedMyFoodId(null);

--- a/frontend/src/components/TodayWorkspace.tsx
+++ b/frontend/src/components/TodayWorkspace.tsx
@@ -1,12 +1,10 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { Box, Container, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useSearchParams } from 'react-router-dom';
 import type { MealPeriod } from '../types/mealPeriod';
 import { useQuickAddFab } from '../context/useQuickAddFab';
 import { useLogDateNavigationState } from '../hooks/useLogDateNavigationState';
-import { QUICK_ADD_SHORTCUT_ACTIONS, QUICK_ADD_SHORTCUT_QUERY_PARAM } from '../constants/pwaShortcuts';
-import { getQuickAddAction } from '../utils/quickAddShortcut';
+import { useQuickAddLogDateBridge, useQuickAddShortcutAction } from '../hooks/useQuickAddRouteState';
 import CalorieSummary from './CalorieSummary';
 import DayCompletionControl from './DayCompletionControl';
 import FoodLog from './FoodLog';
@@ -36,7 +34,6 @@ const TodayWorkspace: React.FC = () => {
     const theme = useTheme();
     const { sectionGap, sectionGapCompact } = theme.custom.layout.page;
     const sectionSpacing = { xs: sectionGapCompact, sm: sectionGapCompact, md: sectionGap + 0.75 };
-    const [searchParams, setSearchParams] = useSearchParams();
     const { selectedDate, today, navigation } = useLogDateNavigationState();
     const isSelectedToday = selectedDate === today;
     const {
@@ -46,62 +43,27 @@ const TodayWorkspace: React.FC = () => {
         setLogDateNavigation,
         setLogDateOverride
     } = useQuickAddFab();
+    const { openFoodDialog } = dialogs;
 
-    useEffect(() => {
-        setLogDateOverride(selectedDate);
-    }, [selectedDate, setLogDateOverride]);
-
-    useEffect(() => {
-        setLogDateNavigation(navigation);
-        return () => {
-            setLogDateNavigation(null);
-        };
-    }, [navigation, setLogDateNavigation]);
-
-    useEffect(() => {
-        return () => {
-            setLogDateOverride(null);
-        };
-    }, [setLogDateOverride]);
-
-    const quickAddAction = getQuickAddAction(searchParams);
-
-    useEffect(() => {
-        if (!quickAddAction) return;
-
-        navigation.setDate(today);
-
-        switch (quickAddAction) {
-            case QUICK_ADD_SHORTCUT_ACTIONS.food:
-                dialogs.openFoodDialog();
-                break;
-            case QUICK_ADD_SHORTCUT_ACTIONS.weight:
-                openWeightDialogFromFab();
-                break;
-            default:
-                break;
-        }
-
-        if (searchParams.has(QUICK_ADD_SHORTCUT_QUERY_PARAM)) {
-            const nextParams = new URLSearchParams(searchParams);
-            nextParams.delete(QUICK_ADD_SHORTCUT_QUERY_PARAM);
-            setSearchParams(nextParams, { replace: true });
-        }
-    }, [
-        dialogs,
+    useQuickAddLogDateBridge({
+        selectedDate,
         navigation,
-        openWeightDialogFromFab,
-        quickAddAction,
-        searchParams,
-        setSearchParams,
-        today
-    ]);
+        setLogDateNavigation,
+        setLogDateOverride
+    });
+
+    useQuickAddShortcutAction({
+        navigation,
+        today,
+        openFoodDialog,
+        openWeightDialog: openWeightDialogFromFab
+    });
 
     const handleAddFood = useCallback(
         (mealPeriod?: MealPeriod | null) => {
-            dialogs.openFoodDialog(mealPeriod ?? null);
+            openFoodDialog(mealPeriod ?? null);
         },
-        [dialogs]
+        [openFoodDialog]
     );
 
     return (

--- a/frontend/src/components/WeightEntryForm.tsx
+++ b/frontend/src/components/WeightEntryForm.tsx
@@ -337,7 +337,7 @@ const WeightEntryForm: React.FC<Props> = ({ onSuccess, date }) => {
         return findMetricOnOrBeforeDate(metrics, entryDate);
     }, [entryDate, existingMetric, metrics]);
 
-    const contentKey = `${entryDate}:${existingMetric?.id ?? 'new'}:${prefillMetric?.id ?? 'none'}`;
+    const contentKey = `${entryDate}:${weightUnitLabel}:${existingMetric?.id ?? 'new'}:${prefillMetric?.id ?? 'none'}`;
 
     return (
         <WeightEntryFormContent

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -10,6 +10,10 @@ import {
 } from './authContext';
 import type { AppLanguage } from '../i18n/languages';
 import { setHapticsEnabled } from '../utils/haptics';
+
+function isCanceledRequest(error: unknown): boolean {
+    return axios.isCancel(error) || (axios.isAxiosError(error) && error.code === 'ERR_CANCELED');
+}
 
 /**
  * AuthProvider bootstraps session state and exposes auth/profile mutations.
@@ -42,62 +46,69 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     /**
      * Fetch the current session user (best-effort) to hydrate the app shell.
      */
-    const checkAuth = useCallback(async () => {
+    const checkAuth = useCallback(async (signal: AbortSignal) => {
         try {
-            const res = await axios.get('/auth/me');
+            const res = await axios.get('/auth/me', { signal });
             setUser(res.data.user);
         } catch (err) {
+            if (isCanceledRequest(err)) return;
             if (import.meta.env.DEV) {
                 console.error('Auth check failed:', err);
             }
             setUser(null);
         } finally {
-            setIsLoading(false);
+            if (!signal.aborted) {
+                setIsLoading(false);
+            }
         }
     }, []);
 
     useEffect(() => {
-        void checkAuth();
+        const controller = new AbortController();
+        void checkAuth(controller.signal);
+        return () => {
+            controller.abort();
+        };
     }, [checkAuth]);
 
     useEffect(() => {
         setHapticsEnabled(user?.haptics_enabled ?? true);
     }, [user?.haptics_enabled]);
 
-    const login = async (email: string, password: string) => {
+    const login = useCallback(async (email: string, password: string) => {
         const res = await axios.post('/auth/login', { email, password });
         // Ensure no cross-user cache bleed when switching accounts.
         queryClient.clear();
         setUser(res.data.user);
-    };
+    }, [queryClient]);
 
-    const register = async (email: string, password: string) => {
+    const register = useCallback(async (email: string, password: string) => {
         const res = await axios.post('/auth/register', { email, password });
         // Ensure no cross-user cache bleed when switching accounts.
         queryClient.clear();
         setUser(res.data.user);
-    };
+    }, [queryClient]);
 
-    const logout = async () => {
+    const logout = useCallback(async () => {
         await axios.post('/auth/logout');
         setUser(null);
         queryClient.clear();
-    };
+    }, [queryClient]);
 
     /**
      * Change the authenticated user's password (server validates the current password).
      */
-    const changePassword = async (currentPassword: string, newPassword: string) => {
+    const changePassword = useCallback(async (currentPassword: string, newPassword: string) => {
         await axios.patch('/api/user/password', {
             current_password: currentPassword,
             new_password: newPassword
         });
-    };
+    }, []);
 
     /**
      * Patch user preferences (units) and keep the auth context in sync.
      */
-    const updateUnitPreferences = async (preferences: { weight_unit?: WeightUnit; height_unit?: HeightUnit }) => {
+    const updateUnitPreferences = useCallback(async (preferences: { weight_unit?: WeightUnit; height_unit?: HeightUnit }) => {
         const res = await axios.patch('/api/user/preferences', preferences);
         setUser(res.data.user);
         // Values returned by /api/metrics and /api/goals are converted server-side using the user's weight_unit.
@@ -106,47 +117,47 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         void queryClient.invalidateQueries({ queryKey: ['goal'] });
         void queryClient.invalidateQueries({ queryKey: ['user-profile'] });
         void queryClient.invalidateQueries({ queryKey: ['profile'] });
-    };
+    }, [queryClient]);
 
     /**
      * Update account-level reminder preferences that apply across all devices.
      */
-    const updateReminderPreferences = async (preferences: {
+    const updateReminderPreferences = useCallback(async (preferences: {
         reminder_log_weight_enabled?: boolean;
         reminder_log_food_enabled?: boolean;
     }) => {
         const res = await axios.patch('/api/user/preferences', preferences);
         setUser(res.data.user);
-    };
+    }, []);
 
     /**
      * Update feedback preferences that affect interaction affordances like haptics.
      */
-    const updateFeedbackPreferences = async (preferences: {
+    const updateFeedbackPreferences = useCallback(async (preferences: {
         haptics_enabled?: boolean;
     }) => {
         const res = await axios.patch('/api/user/preferences', preferences);
         setUser(res.data.user);
-    };
+    }, []);
 
     /**
      * Update the user's preferred weight unit (kg/lb).
      */
-    const updateWeightUnit = async (weight_unit: WeightUnit) => {
+    const updateWeightUnit = useCallback(async (weight_unit: WeightUnit) => {
         await updateUnitPreferences({ weight_unit });
-    };
+    }, [updateUnitPreferences]);
 
     /**
      * Update the user's preferred height unit (cm or ft/in).
      */
-    const updateHeightUnit = async (height_unit: HeightUnit) => {
+    const updateHeightUnit = useCallback(async (height_unit: HeightUnit) => {
         await updateUnitPreferences({ height_unit });
-    };
+    }, [updateUnitPreferences]);
 
     /**
      * Update the user's preferred UI language (persisted server-side).
      */
-    const updateLanguage = async (language: AppLanguage) => {
+    const updateLanguage = useCallback(async (language: AppLanguage) => {
         if (!user) {
             throw new Error('Not authenticated');
         }
@@ -161,57 +172,76 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             setUser(previousUser);
             throw err;
         }
-    };
+    }, [user]);
 
     /**
      * Patch the authenticated user's profile and keep the auth context in sync with the server response.
      */
-    const updateProfile = async (profile: UserProfilePatchPayload) => {
+    const updateProfile = useCallback(async (profile: UserProfilePatchPayload) => {
         const res = await axios.patch('/api/user/profile', profile);
         setUser(res.data.user);
         void queryClient.invalidateQueries({ queryKey: ['food'] });
         void queryClient.invalidateQueries({ queryKey: ['metrics'] });
         void queryClient.invalidateQueries({ queryKey: ['user-profile'] });
         void queryClient.invalidateQueries({ queryKey: ['profile'] });
-    };
+    }, [queryClient]);
 
     /**
      * Set (or clear) the authenticated user's processed profile photo.
      */
-    const updateProfileImage = async (dataUrl: string | null) => {
+    const updateProfileImage = useCallback(async (dataUrl: string | null) => {
         const res = dataUrl
             ? await axios.put('/api/user/profile-image', { data_url: dataUrl })
             : await axios.delete('/api/user/profile-image');
         setUser(res.data.user);
-    };
+    }, []);
 
     /**
      * Update the user's preferred IANA time zone identifier for date grouping and "today" calculations.
      */
-    const updateTimezone = async (timezone: string) => {
+    const updateTimezone = useCallback(async (timezone: string) => {
         await updateProfile({ timezone });
-    };
+    }, [updateProfile]);
+
+    const value = useMemo(
+        () => ({
+            user,
+            login,
+            register,
+            logout,
+            changePassword,
+            updateUnitPreferences,
+            updateReminderPreferences,
+            updateFeedbackPreferences,
+            updateWeightUnit,
+            updateHeightUnit,
+            updateLanguage,
+            updateProfile,
+            updateProfileImage,
+            updateTimezone,
+            isLoading
+        }),
+        [
+            changePassword,
+            isLoading,
+            login,
+            logout,
+            register,
+            updateFeedbackPreferences,
+            updateHeightUnit,
+            updateLanguage,
+            updateProfile,
+            updateProfileImage,
+            updateReminderPreferences,
+            updateTimezone,
+            updateUnitPreferences,
+            updateWeightUnit,
+            user
+        ]
+    );
 
     return (
-        <AuthContext.Provider
-            value={{
-                user,
-                login,
-                register,
-                logout,
-                changePassword,
-                updateUnitPreferences,
-                updateReminderPreferences,
-                updateFeedbackPreferences,
-                updateWeightUnit,
-                updateHeightUnit,
-                updateLanguage,
-                updateProfile,
-                updateProfileImage,
-                updateTimezone,
-                isLoading
-            }}
-        >
+        <AuthContext.Provider value={value}>
             {children}
         </AuthContext.Provider>
     );

--- a/frontend/src/hooks/useQuickAddRouteState.ts
+++ b/frontend/src/hooks/useQuickAddRouteState.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { LogDateNavigationState } from '../context/quickAddFabState';
+import { QUICK_ADD_SHORTCUT_ACTIONS, QUICK_ADD_SHORTCUT_QUERY_PARAM } from '../constants/pwaShortcuts';
+import { getQuickAddAction } from '../utils/quickAddShortcut';
+
+type QuickAddLogDateBridgeArgs = {
+    selectedDate: string;
+    navigation: LogDateNavigationState;
+    setLogDateOverride: (date: string | null) => void;
+    setLogDateNavigation: (state: LogDateNavigationState | null) => void;
+    isActive?: boolean;
+};
+
+type QuickAddShortcutActionArgs = {
+    navigation: Pick<LogDateNavigationState, 'setDate'>;
+    today: string;
+    openFoodDialog: () => void;
+    openWeightDialog: () => void;
+};
+
+/**
+ * Publish route-owned local-day controls to the shared quick-add shell while the route is active.
+ */
+export function useQuickAddLogDateBridge({
+    selectedDate,
+    navigation,
+    setLogDateOverride,
+    setLogDateNavigation,
+    isActive = true
+}: QuickAddLogDateBridgeArgs): void {
+    useEffect(() => {
+        setLogDateOverride(isActive ? selectedDate : null);
+    }, [isActive, selectedDate, setLogDateOverride]);
+
+    useEffect(() => {
+        return () => {
+            setLogDateOverride(null);
+        };
+    }, [setLogDateOverride]);
+
+    useEffect(() => {
+        setLogDateNavigation(isActive ? navigation : null);
+    }, [isActive, navigation, setLogDateNavigation]);
+
+    useEffect(() => {
+        return () => {
+            setLogDateNavigation(null);
+        };
+    }, [setLogDateNavigation]);
+}
+
+/**
+ * Consume one-shot PWA shortcut query params and open the matching quick-add dialog.
+ */
+export function useQuickAddShortcutAction({
+    navigation,
+    today,
+    openFoodDialog,
+    openWeightDialog
+}: QuickAddShortcutActionArgs): void {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const searchParamSnapshot = searchParams.toString();
+    const consumedShortcutSnapshotRef = useRef<string | null>(null);
+    const { setDate } = navigation;
+
+    useEffect(() => {
+        const nextParams = new URLSearchParams(searchParamSnapshot);
+        const quickAddAction = getQuickAddAction(nextParams);
+        if (!quickAddAction) {
+            consumedShortcutSnapshotRef.current = null;
+            return;
+        }
+        if (consumedShortcutSnapshotRef.current === searchParamSnapshot) return;
+
+        consumedShortcutSnapshotRef.current = searchParamSnapshot;
+
+        setDate(today);
+
+        switch (quickAddAction) {
+            case QUICK_ADD_SHORTCUT_ACTIONS.food:
+                openFoodDialog();
+                break;
+            case QUICK_ADD_SHORTCUT_ACTIONS.weight:
+                openWeightDialog();
+                break;
+            default:
+                break;
+        }
+
+        nextParams.delete(QUICK_ADD_SHORTCUT_QUERY_PARAM);
+        setSearchParams(nextParams, { replace: true });
+    }, [
+        openFoodDialog,
+        openWeightDialog,
+        searchParamSnapshot,
+        setDate,
+        setSearchParams,
+        today
+    ]);
+}

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -1,16 +1,16 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Button, Stack } from '@mui/material';
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 import { useTheme } from '@mui/material/styles';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import CalorieSummary from '../components/CalorieSummary';
 import FoodLog from '../components/FoodLog';
 import TodayHeader from '../components/TodayHeader';
 import { useI18n } from '../i18n/useI18n';
 import { useQuickAddFab } from '../context/useQuickAddFab';
 import { LOG_DATE_QUERY_PARAM, useLogDateNavigationState } from '../hooks/useLogDateNavigationState';
-import { QUICK_ADD_SHORTCUT_ACTIONS, QUICK_ADD_SHORTCUT_QUERY_PARAM } from '../constants/pwaShortcuts';
-import { getQuickAddAction } from '../utils/quickAddShortcut';
+import { useQuickAddLogDateBridge, useQuickAddShortcutAction } from '../hooks/useQuickAddRouteState';
+import type { MealPeriod } from '../types/mealPeriod';
 
 function getDashboardPath(selectedDate: string, today: string): string {
     if (selectedDate === today) return '/dashboard';
@@ -26,7 +26,6 @@ const Log: React.FC = () => {
     const { t } = useI18n();
     const { sectionGap, sectionGapCompact } = theme.custom.layout.page;
     const sectionSpacing = { xs: sectionGapCompact, sm: sectionGapCompact, md: sectionGap + 0.75 };
-    const [searchParams, setSearchParams] = useSearchParams();
     const { selectedDate, today, navigation } = useLogDateNavigationState();
     const isSelectedToday = selectedDate === today;
     const {
@@ -35,57 +34,30 @@ const Log: React.FC = () => {
         setLogDateNavigation,
         setLogDateOverride
     } = useQuickAddFab();
+    const { openFoodDialog } = dialogs;
 
-    useEffect(() => {
-        setLogDateOverride(selectedDate);
-    }, [selectedDate, setLogDateOverride]);
-
-    useEffect(() => {
-        setLogDateNavigation(navigation);
-        return () => {
-            setLogDateNavigation(null);
-        };
-    }, [navigation, setLogDateNavigation]);
-
-    useEffect(() => {
-        return () => {
-            setLogDateOverride(null);
-        };
-    }, [setLogDateOverride]);
-
-    const quickAddAction = getQuickAddAction(searchParams);
     const dashboardPath = useMemo(() => getDashboardPath(selectedDate, today), [selectedDate, today]);
 
-    useEffect(() => {
-        if (!quickAddAction) return;
-
-        navigation.setDate(today);
-
-        switch (quickAddAction) {
-            case QUICK_ADD_SHORTCUT_ACTIONS.food:
-                dialogs.openFoodDialog();
-                break;
-            case QUICK_ADD_SHORTCUT_ACTIONS.weight:
-                openWeightDialogFromFab();
-                break;
-            default:
-                break;
-        }
-
-        if (searchParams.has(QUICK_ADD_SHORTCUT_QUERY_PARAM)) {
-            const nextParams = new URLSearchParams(searchParams);
-            nextParams.delete(QUICK_ADD_SHORTCUT_QUERY_PARAM);
-            setSearchParams(nextParams, { replace: true });
-        }
-    }, [
-        dialogs,
+    useQuickAddLogDateBridge({
+        selectedDate,
         navigation,
-        openWeightDialogFromFab,
-        quickAddAction,
-        searchParams,
-        setSearchParams,
-        today
-    ]);
+        setLogDateNavigation,
+        setLogDateOverride
+    });
+
+    useQuickAddShortcutAction({
+        navigation,
+        today,
+        openFoodDialog,
+        openWeightDialog: openWeightDialogFromFab
+    });
+
+    const handleAddFood = useCallback(
+        (mealPeriod?: MealPeriod | null) => {
+            openFoodDialog(mealPeriod ?? null);
+        },
+        [openFoodDialog]
+    );
 
     return (
         <Stack spacing={sectionSpacing} useFlexGap>
@@ -103,9 +75,7 @@ const Log: React.FC = () => {
             <FoodLog
                 date={selectedDate}
                 isSelectedToday={isSelectedToday}
-                onAddFood={(mealPeriod) => {
-                    dialogs.openFoodDialog(mealPeriod ?? null);
-                }}
+                onAddFood={handleAddFood}
             />
         </Stack>
     );

--- a/frontend/src/pages/MobileToday.tsx
+++ b/frontend/src/pages/MobileToday.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Box, Paper, Stack, Tab, Tabs } from '@mui/material';
-import { useSearchParams } from 'react-router-dom';
 import CalorieSummary from '../components/CalorieSummary';
 import DayCompletionControl from '../components/DayCompletionControl';
 import FoodLog from '../components/FoodLog';
@@ -8,11 +7,11 @@ import GoalProjection from '../components/GoalProjection';
 import TodayHeader from '../components/TodayHeader';
 import WeightSummaryCard from '../components/WeightSummaryCard';
 import WeightTrend from '../components/WeightTrend';
-import { QUICK_ADD_SHORTCUT_ACTIONS, QUICK_ADD_SHORTCUT_QUERY_PARAM } from '../constants/pwaShortcuts';
 import { useQuickAddFab } from '../context/useQuickAddFab';
 import { useI18n } from '../i18n/useI18n';
 import { useLogDateNavigationState } from '../hooks/useLogDateNavigationState';
-import { getQuickAddAction } from '../utils/quickAddShortcut';
+import { useQuickAddLogDateBridge, useQuickAddShortcutAction } from '../hooks/useQuickAddRouteState';
+import type { MealPeriod } from '../types/mealPeriod';
 
 const MOBILE_DASHBOARD_TABS = {
     log: 'log',
@@ -29,7 +28,6 @@ const MOBILE_DASHBOARD_TAB_MIN_HEIGHT_PX = 48; // Compact but thumb-friendly tab
 const MobileToday: React.FC = () => {
     const { t } = useI18n();
     const [activeTab, setActiveTab] = useState<MobileDashboardTab>(MOBILE_DASHBOARD_TABS.log);
-    const [searchParams, setSearchParams] = useSearchParams();
     const { selectedDate, today, navigation } = useLogDateNavigationState();
     const isSelectedToday = selectedDate === today;
     const {
@@ -38,55 +36,31 @@ const MobileToday: React.FC = () => {
         setLogDateNavigation,
         setLogDateOverride
     } = useQuickAddFab();
+    const { openFoodDialog } = dialogs;
     const isLogTabActive = activeTab === MOBILE_DASHBOARD_TABS.log;
     const isGoalsTabActive = activeTab === MOBILE_DASHBOARD_TABS.goals;
 
-    useEffect(() => {
-        setLogDateOverride(isLogTabActive ? selectedDate : null);
-        return () => {
-            setLogDateOverride(null);
-        };
-    }, [isLogTabActive, selectedDate, setLogDateOverride]);
-
-    useEffect(() => {
-        setLogDateNavigation(isLogTabActive ? navigation : null);
-        return () => {
-            setLogDateNavigation(null);
-        };
-    }, [isLogTabActive, navigation, setLogDateNavigation]);
-
-    const quickAddAction = getQuickAddAction(searchParams);
-
-    useEffect(() => {
-        if (!quickAddAction) return;
-
-        navigation.setDate(today);
-
-        switch (quickAddAction) {
-            case QUICK_ADD_SHORTCUT_ACTIONS.food:
-                dialogs.openFoodDialog();
-                break;
-            case QUICK_ADD_SHORTCUT_ACTIONS.weight:
-                openWeightDialogFromFab();
-                break;
-            default:
-                break;
-        }
-
-        if (searchParams.has(QUICK_ADD_SHORTCUT_QUERY_PARAM)) {
-            const nextParams = new URLSearchParams(searchParams);
-            nextParams.delete(QUICK_ADD_SHORTCUT_QUERY_PARAM);
-            setSearchParams(nextParams, { replace: true });
-        }
-    }, [
-        dialogs,
+    useQuickAddLogDateBridge({
+        selectedDate,
         navigation,
-        openWeightDialogFromFab,
-        quickAddAction,
-        searchParams,
-        setSearchParams,
-        today
-    ]);
+        setLogDateNavigation,
+        setLogDateOverride,
+        isActive: isLogTabActive
+    });
+
+    useQuickAddShortcutAction({
+        navigation,
+        today,
+        openFoodDialog,
+        openWeightDialog: openWeightDialogFromFab
+    });
+
+    const handleAddFood = useCallback(
+        (mealPeriod?: MealPeriod | null) => {
+            openFoodDialog(mealPeriod ?? null);
+        },
+        [openFoodDialog]
+    );
 
     const handleTabChange = (_event: React.SyntheticEvent, nextTab: MobileDashboardTab) => {
         setActiveTab(nextTab);
@@ -102,7 +76,7 @@ const MobileToday: React.FC = () => {
                         <FoodLog
                             date={selectedDate}
                             isSelectedToday={isSelectedToday}
-                            onAddFood={(mealPeriod) => dialogs.openFoodDialog(mealPeriod ?? null)}
+                            onAddFood={handleAddFood}
                         />
                         <DayCompletionControl date={selectedDate} />
                     </Stack>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -228,11 +228,18 @@ const Settings: React.FC = () => {
     };
 
     const handleTimezoneChange = async (nextTimezone: string) => {
+        if (!user) {
+            showUnitsStatus(t('status.failedToSaveChanges'), 'error');
+            return;
+        }
+
+        const previous = timezoneValue;
         setTimezoneValue(nextTimezone);
         try {
             await updateTimezone(nextTimezone);
             showUnitsStatus(t('status.changesSaved'), 'success');
         } catch {
+            setTimezoneValue(previous);
             showUnitsStatus(t('status.failedToSaveChanges'), 'error');
         }
     };

--- a/frontend/src/pages/Weight.tsx
+++ b/frontend/src/pages/Weight.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Stack } from '@mui/material';
 import DayCompletionControl from '../components/DayCompletionControl';
 import TodayHeader from '../components/TodayHeader';
@@ -6,6 +6,7 @@ import WeightSummaryCard from '../components/WeightSummaryCard';
 import WeightTrend from '../components/WeightTrend';
 import { useQuickAddFab } from '../context/useQuickAddFab';
 import { useLogDateNavigationState } from '../hooks/useLogDateNavigationState';
+import { useQuickAddLogDateBridge } from '../hooks/useQuickAddRouteState';
 
 /**
  * Mobile Weight route for the daily check-in and trend context.
@@ -18,19 +19,12 @@ const Weight: React.FC = () => {
         setLogDateOverride
     } = useQuickAddFab();
 
-    useEffect(() => {
-        setLogDateOverride(selectedDate);
-        return () => {
-            setLogDateOverride(null);
-        };
-    }, [selectedDate, setLogDateOverride]);
-
-    useEffect(() => {
-        setLogDateNavigation(navigation);
-        return () => {
-            setLogDateNavigation(null);
-        };
-    }, [navigation, setLogDateNavigation]);
+    useQuickAddLogDateBridge({
+        selectedDate,
+        navigation,
+        setLogDateNavigation,
+        setLogDateOverride
+    });
 
     return (
         <Stack spacing={1.5} useFlexGap>


### PR DESCRIPTION
## Summary
- Consolidated repeated route-level quick-add side effects into shared hooks so `Today`, `Log`, `MobileToday`, and `Weight` no longer duplicate the same effect logic.
- Hardened `AuthProvider` with abortable session hydration and a memoized context value to avoid stale updates and unnecessary provider churn.
- Removed a duplicate `FoodEntryForm` sync effect, fixed `WeightEntryForm` remounting when unit labels change, and made settings timezone changes roll back on failure.

## Testing
- `npm.cmd --prefix frontend run lint` passed.
- `npm.cmd --prefix frontend run build` passed.
- `npm.cmd --prefix frontend test` passed.
- Browser smoke tested the built app at `http://127.0.0.1:4173/` with no console errors.