### PR TITLE
Fix responsive dashboard layout regressions

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -265,7 +265,7 @@ const LayoutShell: React.FC = () => {
                                 sm: 'minmax(0, 1fr) auto minmax(0, 1fr)'
                             },
                             gridTemplateAreas: {
-                                xs: '"brand spacer actions"',
+                                xs: '"brand date actions"',
                                 sm: '"brand date actions"'
                             },
                             columnGap: { xs: 0.75, sm: 1.25 },
@@ -300,12 +300,12 @@ const LayoutShell: React.FC = () => {
                     {showAppNav && logDateNavigation && (
                         <LogDateNavigationCluster
                             navigation={logDateNavigation}
-                            placement="navbar"
                             showTodayShortcut
                             sx={{
-                                display: { xs: 'none', sm: 'inline-flex' },
+                                display: 'inline-flex',
                                 justifySelf: 'center',
                                 gridArea: 'date',
+                                minWidth: 0,
                                 WebkitAppRegion: 'no-drag'
                             }}
                         />

--- a/frontend/src/components/LogDateNavigationCluster.tsx
+++ b/frontend/src/components/LogDateNavigationCluster.tsx
@@ -11,28 +11,23 @@ import LogDatePickerControl from './LogDatePickerControl';
 
 type LogDateNavigationClusterProps = {
     navigation: LogDateNavigationState;
-    placement: 'navbar' | 'page';
     showTodayShortcut?: boolean;
     sx?: SxProps<Theme>;
 };
 
 const DATE_CLUSTER_GAP_SPACING = 0.5; // Horizontal gap between date navigation controls.
-const NAVBAR_DATE_CONTROL_WIDTH_PX = { xs: 148, sm: 188, md: 220 }; // Keeps the app-bar date picker centered without crowding actions.
-const PAGE_DATE_CONTROL_WIDTH_PX = { xs: 176, sm: 196, md: 220 }; // Larger page control width for the mobile header fallback.
+const NAVBAR_DATE_CONTROL_WIDTH_PX = { xs: 136, sm: 188, md: 220 }; // Compact xs width keeps the date in the app bar after the wordmark collapses.
+const NAVBAR_AUXILIARY_CONTROL_DISPLAY = { xs: 'none', sm: 'inline-flex' } as const; // xs app bars reserve the center slot for the date field itself.
 
 /**
- * Shared selected-day navigation controls for the app bar and compact page header.
+ * App-bar selected-day navigation controls.
  */
 const LogDateNavigationCluster: React.FC<LogDateNavigationClusterProps> = ({
     navigation,
-    placement,
     showTodayShortcut = false,
     sx
 }) => {
     const { t } = useI18n();
-    const isNavbarPlacement = placement === 'navbar';
-    const iconButtonSize = isNavbarPlacement ? 'small' : 'medium';
-    const pickerWidth = isNavbarPlacement ? NAVBAR_DATE_CONTROL_WIDTH_PX : PAGE_DATE_CONTROL_WIDTH_PX;
 
     return (
         <Box
@@ -42,27 +37,30 @@ const LogDateNavigationCluster: React.FC<LogDateNavigationClusterProps> = ({
                     alignItems: 'center',
                     justifyContent: 'center',
                     gap: DATE_CLUSTER_GAP_SPACING,
-                    minWidth: 0
+                    minWidth: 0,
+                    width: '100%'
                 },
                 sx
             )}
         >
-            <Tooltip title={t('log.nav.prevDay')}>
-                <span>
-                    <IconButton
-                        size={iconButtonSize}
-                        aria-label={t('log.nav.prevDay')}
-                        onClick={navigation.goToPreviousDate}
-                        disabled={!navigation.canGoBack}
-                    >
-                        <ChevronLeftRoundedIcon fontSize="small" />
-                    </IconButton>
-                </span>
-            </Tooltip>
+            <Box component="span" sx={{ display: NAVBAR_AUXILIARY_CONTROL_DISPLAY }}>
+                <Tooltip title={t('log.nav.prevDay')}>
+                    <span>
+                        <IconButton
+                            size="small"
+                            aria-label={t('log.nav.prevDay')}
+                            onClick={navigation.goToPreviousDate}
+                            disabled={!navigation.canGoBack}
+                        >
+                            <ChevronLeftRoundedIcon fontSize="small" />
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            </Box>
 
-            <Box sx={{ width: pickerWidth, maxWidth: '100%' }}>
+            <Box sx={{ width: NAVBAR_DATE_CONTROL_WIDTH_PX, maxWidth: '100%' }}>
                 <LogDatePickerControl
-                    placement={placement}
+                    placement="navbar"
                     value={navigation.date}
                     ariaLabel={t('log.datePicker.aria', { date: navigation.dateLabel })}
                     min={navigation.minDate}
@@ -71,54 +69,46 @@ const LogDateNavigationCluster: React.FC<LogDateNavigationClusterProps> = ({
                 />
             </Box>
 
-            <Tooltip title={t('log.nav.nextDay')}>
-                <span>
-                    <IconButton
-                        size={iconButtonSize}
-                        aria-label={t('log.nav.nextDay')}
-                        onClick={navigation.goToNextDate}
-                        disabled={!navigation.canGoForward}
-                    >
-                        <ChevronRightRoundedIcon fontSize="small" />
-                    </IconButton>
-                </span>
-            </Tooltip>
+            <Box component="span" sx={{ display: NAVBAR_AUXILIARY_CONTROL_DISPLAY }}>
+                <Tooltip title={t('log.nav.nextDay')}>
+                    <span>
+                        <IconButton
+                            size="small"
+                            aria-label={t('log.nav.nextDay')}
+                            onClick={navigation.goToNextDate}
+                            disabled={!navigation.canGoForward}
+                        >
+                            <ChevronRightRoundedIcon fontSize="small" />
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            </Box>
 
             {showTodayShortcut && (
-                <Tooltip title={t('log.nav.jumpToToday')}>
-                    <span>
-                        {isNavbarPlacement ? (
-                            <>
-                                <IconButton
-                                    size={iconButtonSize}
-                                    aria-label={t('log.nav.jumpToToday')}
-                                    onClick={navigation.goToToday}
-                                    disabled={navigation.date === navigation.maxDate}
-                                    sx={{ display: { xs: 'inline-flex', md: 'none' } }}
-                                >
-                                    <TodayRoundedIcon fontSize="small" />
-                                </IconButton>
-                                <Button
-                                    size="small"
-                                    variant="outlined"
-                                    onClick={navigation.goToToday}
-                                    disabled={navigation.date === navigation.maxDate}
-                                    sx={{ display: { xs: 'none', md: 'inline-flex' } }}
-                                >
-                                    {t('today.title')}
-                                </Button>
-                            </>
-                        ) : (
+                <Box component="span" sx={{ display: NAVBAR_AUXILIARY_CONTROL_DISPLAY }}>
+                    <Tooltip title={t('log.nav.jumpToToday')}>
+                        <span>
                             <IconButton
+                                size="small"
                                 aria-label={t('log.nav.jumpToToday')}
                                 onClick={navigation.goToToday}
                                 disabled={navigation.date === navigation.maxDate}
+                                sx={{ display: { xs: 'none', sm: 'inline-flex', md: 'none' } }}
                             >
-                                <TodayRoundedIcon />
+                                <TodayRoundedIcon fontSize="small" />
                             </IconButton>
-                        )}
-                    </span>
-                </Tooltip>
+                            <Button
+                                size="small"
+                                variant="outlined"
+                                onClick={navigation.goToToday}
+                                disabled={navigation.date === navigation.maxDate}
+                                sx={{ display: { xs: 'none', md: 'inline-flex' } }}
+                            >
+                                {t('today.title')}
+                            </Button>
+                        </span>
+                    </Tooltip>
+                </Box>
             )}
         </Box>
     );

--- a/frontend/src/components/TodayHeader.tsx
+++ b/frontend/src/components/TodayHeader.tsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import type { LogDateNavigationState } from '../context/quickAddFabState';
 import { useI18n } from '../i18n/useI18n';
-import LogDateNavigationCluster from './LogDateNavigationCluster';
 
 export type TodayHeaderProps = {
     navigation: LogDateNavigationState;
 };
 
 const TODAY_TITLE_ROW_MIN_HEIGHT_PX = 40; // Keeps the title aligned with the centered date navigation controls.
-const TODAY_TITLE_DISPLAY = { xs: 'none', md: 'flex' } as const; // Below desktop, the date picker is the visible date context.
 
 /**
- * Header for the Today workspace: selected-day title on the left, date controls centered.
+ * Header for the Today workspace. Date controls live in the app bar at all widths.
  */
 const TodayHeader: React.FC<TodayHeaderProps> = ({ navigation }) => {
     const { t } = useI18n();
@@ -22,7 +20,7 @@ const TodayHeader: React.FC<TodayHeaderProps> = ({ navigation }) => {
     return (
         <Box
             sx={{
-                display: { xs: 'grid', sm: 'none', md: 'grid' },
+                display: { xs: 'none', md: 'grid' },
                 gridTemplateColumns: '1fr',
                 gap: { xs: 1, sm: 1.5, md: 2 },
                 alignItems: 'center'
@@ -31,7 +29,7 @@ const TodayHeader: React.FC<TodayHeaderProps> = ({ navigation }) => {
             <Stack spacing={0.75} sx={{ minWidth: 0 }}>
                 <Box
                     sx={{
-                        display: TODAY_TITLE_DISPLAY,
+                        display: 'flex',
                         alignItems: 'center',
                         gap: 1,
                         flexWrap: 'wrap',
@@ -43,13 +41,6 @@ const TodayHeader: React.FC<TodayHeaderProps> = ({ navigation }) => {
                     </Typography>
                 </Box>
             </Stack>
-
-            <LogDateNavigationCluster
-                navigation={navigation}
-                placement="page"
-                showTodayShortcut
-                sx={{ display: { xs: 'inline-flex', sm: 'none' }, justifySelf: 'center', width: '100%' }}
-            />
         </Box>
     );
 };

--- a/frontend/src/components/TodayWorkspace.tsx
+++ b/frontend/src/components/TodayWorkspace.tsx
@@ -23,12 +23,11 @@ const TODAY_WORKSPACE_AREAS = {
     xs: '"calories" "food" "weight" "trend" "goal" "completion"',
     md: '"calories weight" "food context" "completion completion"'
 }; // Named areas keep the mobile task flow and desktop workspace mode explicit.
-const TODAY_WORKSPACE_STATIC_HEIGHT_PX = 560; // Header, summary row, completion row, and grid gaps outside the flexible desktop work row.
 const TODAY_WORKSPACE_AVAILABLE_HEIGHT = `var(${APP_PAGE_AVAILABLE_HEIGHT_CSS_VAR}, 100svh)`;
-const TODAY_WORKSPACE_MAIN_ROW_HEIGHT = {
-    md: `clamp(540px, calc(${TODAY_WORKSPACE_AVAILABLE_HEIGHT} - ${TODAY_WORKSPACE_STATIC_HEIGHT_PX}px), 640px)`,
-    lg: `clamp(580px, calc(${TODAY_WORKSPACE_AVAILABLE_HEIGHT} - ${TODAY_WORKSPACE_STATIC_HEIGHT_PX}px), 680px)`
-}; // Caps the desktop work row against AppPage's content viewport; food log scrolls inside this track.
+const TODAY_WORKSPACE_GRID_ROWS = {
+    xs: 'auto',
+    md: 'auto minmax(0, 1fr) auto'
+}; // Desktop rows consume the measured AppPage viewport instead of relying on a static-height estimate.
 
 /**
  * Main logged-in workspace centered around the selected local day.
@@ -70,21 +69,20 @@ const TodayWorkspace: React.FC = () => {
     );
 
     return (
-        <Container maxWidth="xl" disableGutters>
-            <Stack spacing={sectionSpacing} useFlexGap>
+        <Container maxWidth="xl" disableGutters sx={{ height: { md: TODAY_WORKSPACE_AVAILABLE_HEIGHT }, minHeight: { md: 0 } }}>
+            <Stack spacing={sectionSpacing} useFlexGap sx={{ height: { md: '100%' }, minHeight: { md: 0 } }}>
                 <TodayHeader navigation={navigation} />
 
                 <Box
                     sx={{
+                        flex: { md: 1 },
+                        minHeight: { md: 0 },
                         display: 'grid',
                         gap: sectionSpacing,
                         gridTemplateColumns: TODAY_WORKSPACE_COLUMNS,
                         gridTemplateAreas: TODAY_WORKSPACE_AREAS,
-                        gridTemplateRows: { xs: 'auto', md: `auto ${TODAY_WORKSPACE_MAIN_ROW_HEIGHT.md} auto` },
-                        alignItems: { xs: 'start', md: 'stretch' },
-                        [theme.breakpoints.up('lg')]: {
-                            gridTemplateRows: `auto ${TODAY_WORKSPACE_MAIN_ROW_HEIGHT.lg} auto`
-                        }
+                        gridTemplateRows: TODAY_WORKSPACE_GRID_ROWS,
+                        alignItems: { xs: 'start', md: 'stretch' }
                     }}
                 >
                     <Box sx={{ gridArea: 'calories', minWidth: 0, display: 'flex' }}>

--- a/frontend/src/components/WeightSummaryCard.tsx
+++ b/frontend/src/components/WeightSummaryCard.tsx
@@ -37,6 +37,11 @@ const WEIGHT_CARD_ROW_GAP = { xs: 1.25, sm: 2 }; // Gap between the icon tile an
 const WEIGHT_CARD_BODY_MARGIN_TOP = { xs: 1.25, sm: 1.5 }; // Space between the header and the card body content.
 const WEIGHT_CARD_VALUE_VARIANT = { xs: 'h5', sm: 'h4' } as const; // Larger value treatment makes the latest weigh-in the card anchor.
 const WEIGHT_CARD_PADDING_SPACING = { xs: 1.5, sm: 2 }; // Slightly roomier than dense cards so the context scale has enough breathing room.
+const WEIGHT_CARD_SUMMARY_CONTAINER_NAME = 'weight-summary-card';
+const WEIGHT_CARD_SUMMARY_STACK_MAX_WIDTH_REM = 36; // Card-width cutoff where the CTA moves below the weight value to avoid overlap in desktop sidebars.
+const WEIGHT_CARD_SUMMARY_STACK_QUERY =
+    `@container ${WEIGHT_CARD_SUMMARY_CONTAINER_NAME} (max-width: ${WEIGHT_CARD_SUMMARY_STACK_MAX_WIDTH_REM}rem)`;
+const WEIGHT_CARD_CTA_MIN_WIDTH_PX = 224; // Keeps the action stable when there is enough inline card space.
 const WEIGHT_CONTEXT_METRIC_ICON_SIZE_PX = { xs: 18, sm: 20 }; // Metric tile icons shrink on 320px screens so two tiles stay on one row.
 const WEIGHT_CONTEXT_TRACK_HEIGHT_PX = 4; // Hairline baseline keeps the range band and markers visually dominant.
 const WEIGHT_CONTEXT_RANGE_HEIGHT_PX = 28; // Tall trend band reads as a zone rather than a thin chart series.
@@ -680,6 +685,25 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
     const asOfLabel = formatMetricDateLabel(displayedMetric?.date ?? null);
     const WeightCtaIcon = metricForSelectedDate ? EditRoundedIcon : AddRoundedIcon;
     const ctaVariant = metricForSelectedDate ? 'outlined' : 'contained';
+    const summaryHeaderSx = {
+        display: 'grid',
+        alignItems: 'center',
+        gap: { xs: 1.25, sm: rowGap },
+        gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 1fr) auto' },
+        [WEIGHT_CARD_SUMMARY_STACK_QUERY]: {
+            alignItems: 'stretch',
+            gridTemplateColumns: '1fr'
+        }
+    };
+    const summaryCtaSx = {
+        justifySelf: { xs: 'stretch', sm: 'end' },
+        maxWidth: '100%',
+        minWidth: { sm: WEIGHT_CARD_CTA_MIN_WIDTH_PX },
+        [WEIGHT_CARD_SUMMARY_STACK_QUERY]: {
+            justifySelf: 'stretch',
+            width: '100%'
+        }
+    };
     const trendSnapshotSection = trendMetricsQuery.isLoading || isValidTrendMetric(displayedTrendMetric) ? (
         <>
             <Divider />
@@ -697,12 +721,7 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
         cardBody = (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: stackGap }}>
                 <Box
-                    sx={{
-                        display: 'grid',
-                        alignItems: 'center',
-                        gap: { xs: 1.25, sm: rowGap },
-                        gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 1fr) auto' }
-                    }}
+                    sx={summaryHeaderSx}
                 >
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: rowGap, minWidth: 0 }}>
                         <WeightIconTile sizePx={iconTileSizePx} />
@@ -720,7 +739,12 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
                         </Box>
                     </Box>
 
-                    <Skeleton variant="rounded" height={isXs ? 44 : 40} width={isXs ? '100%' : 184} />
+                    <Skeleton
+                        variant="rounded"
+                        height={isXs ? 44 : 40}
+                        width={isXs ? '100%' : WEIGHT_CARD_CTA_MIN_WIDTH_PX}
+                        sx={summaryCtaSx}
+                    />
                 </Box>
                 {trendSnapshotSection}
             </Box>
@@ -747,18 +771,13 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
         cardBody = (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: stackGap }}>
                 <Box
-                    sx={{
-                        display: 'grid',
-                        alignItems: 'center',
-                        gap: { xs: 1.25, sm: rowGap },
-                        gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 1fr) auto' }
-                    }}
+                    sx={summaryHeaderSx}
                 >
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: rowGap, minWidth: 0 }}>
                         <WeightIconTile sizePx={iconTileSizePx} />
 
                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25, flexGrow: 1, minWidth: 0 }}>
-                            <Typography variant={valueVariant} sx={{ lineHeight: 1.1, whiteSpace: 'nowrap' }}>
+                            <Typography variant={valueVariant} sx={{ lineHeight: 1.1 }}>
                                 {displayedWeightLabel}
                             </Typography>
                             <Typography variant="body2" sx={{
@@ -775,7 +794,7 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
                         startIcon={<WeightCtaIcon />}
                         onClick={onOpenWeightEntry}
                         fullWidth={isXs}
-                        sx={{ justifySelf: { xs: 'stretch', sm: 'end' } }}
+                        sx={summaryCtaSx}
                     >
                         {ctaLabel}
                     </Button>
@@ -795,7 +814,15 @@ const WeightSummaryCard: React.FC<WeightSummaryCardProps> = ({ date, onOpenWeigh
         >
             <SectionHeader title={t('weightSummary.title')} titleVariant="h5" align="center" />
 
-            <Box sx={{ mt: bodyMarginTop }}>{cardBody}</Box>
+            <Box
+                sx={{
+                    mt: bodyMarginTop,
+                    containerType: 'inline-size',
+                    containerName: WEIGHT_CARD_SUMMARY_CONTAINER_NAME
+                }}
+            >
+                {cardBody}
+            </Box>
         </AppCard>
     );
 };


### PR DESCRIPTION
## Summary
- Prevent the weight-card CTA from overlapping the current weight/date text by stacking the action within narrow card containers.
- Size the desktop Today workspace from the measured AppPage viewport instead of a hard-coded static-height estimate.
- Keep the date picker in the compact app bar down to 320px, hiding auxiliary prev/next/Today controls only when space is tight.

## Root Cause
The dashboard was relying on viewport breakpoints and estimated static heights in places where the actual available space is determined by card/container width and app-shell chrome. That made intermediate widths brittle: the weight CTA could collide with the value text, and small header/layout changes could reintroduce document-level vertical scroll.

## Validation
- `npm.cmd --prefix frontend run lint`
- `npm.cmd --prefix frontend run build`
- Browser-verified the dashboard at compact and desktop viewport sizes, including 320px app-bar date picker behavior and screenshot-like desktop dimensions.