### PR TITLE
Phase 2: ship Android diet-tracking beta

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: calibrate_ci
+          POSTGRES_PASSWORD: calibrate_ci
+          POSTGRES_DB: calibrate_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U calibrate_ci -d calibrate_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     defaults:
       run:
         working-directory: backend
@@ -33,6 +48,11 @@ jobs:
 
       - name: Install deps
         run: npm ci --no-audit --fund=false
+
+      - name: Verify fresh database migrations
+        env:
+          DATABASE_URL: postgresql://calibrate_ci:calibrate_ci@localhost:5432/calibrate_ci?schema=public
+        run: npm run db:migrate
 
       - name: Run tests
         run: npm test

--- a/backend/prisma/migrations/0020_goal_active_lookup_index/migration.sql
+++ b/backend/prisma/migrations/0020_goal_active_lookup_index/migration.sql
@@ -1,2 +1,5 @@
 -- Align latest-goal lookups with append-only goal history.
-CREATE INDEX "Goal_user_id_created_at_id_idx" ON "Goal"("user_id", "created_at" DESC, "id" DESC);
+-- 0019 already creates this index in current fresh installs; keep this migration
+-- idempotent for databases whose earlier migration history predates that addition.
+CREATE INDEX IF NOT EXISTS "Goal_user_id_created_at_id_idx"
+  ON "Goal"("user_id", "created_at" DESC, "id" DESC);

--- a/backend/prisma/migrations/0025_my_food_pinning/migration.sql
+++ b/backend/prisma/migrations/0025_my_food_pinning/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "MyFood"
+ADD COLUMN "is_pinned" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX "MyFood_user_id_is_pinned_name_id_idx"
+ON "MyFood"("user_id", "is_pinned" DESC, "name", "id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -243,6 +243,8 @@ model MyFood {
   serving_unit_label String
   /// Calories per serving. For recipes, this is computed from ingredient snapshots and yield.
   calories_per_serving Float
+  /// Per-user shortcut metadata; changing it never mutates recipe or food-log snapshots.
+  is_pinned   Boolean   @default(false)
   /// For recipes: total calories across all ingredient snapshots.
   recipe_total_calories Float?
   /// For recipes: number of servings yielded by the recipe (can be fractional).
@@ -257,6 +259,7 @@ model MyFood {
   food_logs   FoodLog[]
 
   @@index([user_id, name])
+  @@index([user_id, is_pinned(sort: Desc), name, id])
 }
 
 model RecipeIngredient {

--- a/backend/src/routes/myFoods.ts
+++ b/backend/src/routes/myFoods.ts
@@ -39,12 +39,44 @@ router.get('/', async (req, res) => {
     try {
         const items = await prisma.myFood.findMany({
             where,
-            orderBy: [{ name: 'asc' }, { id: 'asc' }]
+            // A stable final id tie-break keeps repeated mobile fetches deterministic.
+            orderBy: [{ is_pinned: 'desc' }, { name: 'asc' }, { id: 'asc' }]
         });
         res.json(items);
     } catch (err) {
         console.error(err);
         res.status(500).json({ message: 'Server error' });
+    }
+});
+
+router.patch('/:id/pin', async (req, res) => {
+    const user = req.user as any;
+    const id = parsePositiveInteger(req.params.id);
+    if (id === null) {
+        return res.status(400).json({ message: 'Invalid my food id' });
+    }
+    if (typeof req.body?.is_pinned !== 'boolean') {
+        return res.status(400).json({ message: 'is_pinned must be a boolean' });
+    }
+
+    try {
+        // updateMany keeps ownership in the write predicate and does not reveal another user's item.
+        const result = await prisma.myFood.updateMany({
+            where: { id, user_id: user.id },
+            data: { is_pinned: req.body.is_pinned }
+        });
+        if (result.count === 0) {
+            return res.status(404).json({ message: 'My food not found' });
+        }
+
+        const updated = await prisma.myFood.findFirst({ where: { id, user_id: user.id } });
+        if (!updated) {
+            return res.status(404).json({ message: 'My food not found' });
+        }
+        return res.json(updated);
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ message: 'Server error' });
     }
 });
 

--- a/backend/src/routes/myFoods.ts
+++ b/backend/src/routes/myFoods.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import type { Prisma } from '@prisma/client';
 import prisma from '../config/database';
 import { parseNonNegativeNumber, parsePositiveInteger, parsePositiveNumber } from '../utils/requestParsing';
 import { buildExternalIngredientSnapshotRow, parseMyFoodIngredientInput } from './myFoodsRecipeUtils';
@@ -170,6 +171,94 @@ type CreateRecipeIngredientInput =
           grams_total?: unknown;
       };
 
+type RecipeIngredientSnapshotRow = {
+    sort_order: number;
+    source: 'MY_FOOD' | 'EXTERNAL';
+    name_snapshot: string;
+    calories_total_snapshot: number;
+    source_my_food_id?: number | null;
+    quantity_servings?: number | null;
+    serving_size_quantity_snapshot?: number | null;
+    serving_unit_label_snapshot?: string | null;
+    calories_per_serving_snapshot?: number | null;
+    external_source?: string | null;
+    external_id?: string | null;
+    brand_snapshot?: string | null;
+    locale_snapshot?: string | null;
+    barcode_snapshot?: string | null;
+    measure_label_snapshot?: string | null;
+    grams_per_measure_snapshot?: number | null;
+    measure_quantity_snapshot?: number | null;
+    grams_total_snapshot?: number | null;
+};
+
+async function resolveRecipeIngredientRows(
+    tx: Prisma.TransactionClient,
+    userId: number,
+    ingredients: CreateRecipeIngredientInput[]
+): Promise<RecipeIngredientSnapshotRow[]> {
+    const rows: RecipeIngredientSnapshotRow[] = [];
+    for (let idx = 0; idx < ingredients.length; idx += 1) {
+        const ingredient = ingredients[idx];
+        const sortOrderRaw = ingredient && typeof ingredient === 'object' ? (ingredient as any).sort_order : undefined;
+        const sortOrder = parsePositiveInteger(sortOrderRaw) ?? idx + 1;
+        const source = (ingredient as any)?.source;
+        if (source !== 'MY_FOOD' && source !== 'EXTERNAL') {
+            throw createHttpError(400, 'Invalid ingredient source');
+        }
+
+        if (source === 'MY_FOOD') {
+            const parsedIngredient = parseMyFoodIngredientInput(ingredient);
+            if (!parsedIngredient.ok) throw parsedIngredient.error;
+            const sourceFood = await tx.myFood.findFirst({
+                where: { id: parsedIngredient.value.myFoodId, user_id: userId, type: 'FOOD' }
+            });
+            if (!sourceFood) throw createHttpError(404, 'Ingredient my food not found');
+            rows.push({
+                sort_order: sortOrder,
+                source,
+                name_snapshot: sourceFood.name,
+                calories_total_snapshot: parsedIngredient.value.quantityServings * sourceFood.calories_per_serving,
+                source_my_food_id: sourceFood.id,
+                quantity_servings: parsedIngredient.value.quantityServings,
+                serving_size_quantity_snapshot: sourceFood.serving_size_quantity,
+                serving_unit_label_snapshot: sourceFood.serving_unit_label,
+                calories_per_serving_snapshot: sourceFood.calories_per_serving
+            });
+            continue;
+        }
+
+        const externalSnapshot = buildExternalIngredientSnapshotRow(ingredient, sortOrder);
+        if (!externalSnapshot.ok) throw externalSnapshot.error;
+        rows.push({ ...externalSnapshot.value, source });
+    }
+    return rows;
+}
+
+function toRecipeIngredientCreateRow(recipeId: number, row: RecipeIngredientSnapshotRow) {
+    return {
+        recipe_id: recipeId,
+        sort_order: row.sort_order,
+        source: row.source,
+        name_snapshot: row.name_snapshot,
+        calories_total_snapshot: row.calories_total_snapshot,
+        source_my_food_id: row.source_my_food_id ?? null,
+        quantity_servings: row.quantity_servings ?? null,
+        serving_size_quantity_snapshot: row.serving_size_quantity_snapshot ?? null,
+        serving_unit_label_snapshot: row.serving_unit_label_snapshot ?? null,
+        calories_per_serving_snapshot: row.calories_per_serving_snapshot ?? null,
+        external_source: row.external_source ?? null,
+        external_id: row.external_id ?? null,
+        brand_snapshot: row.brand_snapshot ?? null,
+        locale_snapshot: row.locale_snapshot ?? null,
+        barcode_snapshot: row.barcode_snapshot ?? null,
+        measure_label_snapshot: row.measure_label_snapshot ?? null,
+        grams_per_measure_snapshot: row.grams_per_measure_snapshot ?? null,
+        measure_quantity_snapshot: row.measure_quantity_snapshot ?? null,
+        grams_total_snapshot: row.grams_total_snapshot ?? null
+    };
+}
+
 /**
  * Create a recipe from ingredient snapshots. Recipes are stored as immutable snapshots (by design).
  */
@@ -205,76 +294,7 @@ router.post('/recipes', async (req, res) => {
     try {
         // Snapshot ingredient data + recipe totals in a single transaction to keep them consistent.
         const created = await prisma.$transaction(async (tx) => {
-            const ingredientRows: Array<{
-                sort_order: number;
-                source: 'MY_FOOD' | 'EXTERNAL';
-                name_snapshot: string;
-                calories_total_snapshot: number;
-                source_my_food_id?: number | null;
-                quantity_servings?: number | null;
-                serving_size_quantity_snapshot?: number | null;
-                serving_unit_label_snapshot?: string | null;
-                calories_per_serving_snapshot?: number | null;
-                external_source?: string | null;
-                external_id?: string | null;
-                brand_snapshot?: string | null;
-                locale_snapshot?: string | null;
-                barcode_snapshot?: string | null;
-                measure_label_snapshot?: string | null;
-                grams_per_measure_snapshot?: number | null;
-                measure_quantity_snapshot?: number | null;
-                grams_total_snapshot?: number | null;
-            }> = [];
-
-            for (let idx = 0; idx < ingredients.length; idx += 1) {
-                const ingredient = ingredients[idx];
-                const sortOrderRaw = ingredient && typeof ingredient === 'object' ? (ingredient as any).sort_order : undefined;
-                const sortOrder = parsePositiveInteger(sortOrderRaw) ?? idx + 1;
-
-                const source = (ingredient as any)?.source;
-                if (source !== 'MY_FOOD' && source !== 'EXTERNAL') {
-                    throw createHttpError(400, 'Invalid ingredient source');
-                }
-
-                if (source === 'MY_FOOD') {
-                    const parsedIngredient = parseMyFoodIngredientInput(ingredient);
-                    if (!parsedIngredient.ok) {
-                        throw parsedIngredient.error;
-                    }
-
-                    const sourceFood = await tx.myFood.findFirst({
-                        where: { id: parsedIngredient.value.myFoodId, user_id: user.id, type: 'FOOD' }
-                    });
-                    if (!sourceFood) {
-                        throw createHttpError(404, 'Ingredient my food not found');
-                    }
-
-                    const caloriesTotal = parsedIngredient.value.quantityServings * sourceFood.calories_per_serving;
-
-                    ingredientRows.push({
-                        sort_order: sortOrder,
-                        source,
-                        name_snapshot: sourceFood.name,
-                        calories_total_snapshot: caloriesTotal,
-                        source_my_food_id: sourceFood.id,
-                        quantity_servings: parsedIngredient.value.quantityServings,
-                        serving_size_quantity_snapshot: sourceFood.serving_size_quantity,
-                        serving_unit_label_snapshot: sourceFood.serving_unit_label,
-                        calories_per_serving_snapshot: sourceFood.calories_per_serving
-                    });
-                    continue;
-                }
-
-                const externalSnapshot = buildExternalIngredientSnapshotRow(ingredient, sortOrder);
-                if (!externalSnapshot.ok) {
-                    throw externalSnapshot.error;
-                }
-
-                ingredientRows.push({
-                    ...externalSnapshot.value,
-                    source
-                });
-            }
+            const ingredientRows = await resolveRecipeIngredientRows(tx, user.id, ingredients);
 
             const recipeTotalCalories = ingredientRows.reduce((sum, row) => sum + row.calories_total_snapshot, 0);
             const caloriesPerServing = recipeTotalCalories / yieldServings;
@@ -293,27 +313,7 @@ router.post('/recipes', async (req, res) => {
             });
 
             await tx.recipeIngredient.createMany({
-                data: ingredientRows.map((row) => ({
-                    recipe_id: recipe.id,
-                    sort_order: row.sort_order,
-                    source: row.source,
-                    name_snapshot: row.name_snapshot,
-                    calories_total_snapshot: row.calories_total_snapshot,
-                    source_my_food_id: row.source_my_food_id ?? null,
-                    quantity_servings: row.quantity_servings ?? null,
-                    serving_size_quantity_snapshot: row.serving_size_quantity_snapshot ?? null,
-                    serving_unit_label_snapshot: row.serving_unit_label_snapshot ?? null,
-                    calories_per_serving_snapshot: row.calories_per_serving_snapshot ?? null,
-                    external_source: row.external_source ?? null,
-                    external_id: row.external_id ?? null,
-                    brand_snapshot: row.brand_snapshot ?? null,
-                    locale_snapshot: row.locale_snapshot ?? null,
-                    barcode_snapshot: row.barcode_snapshot ?? null,
-                    measure_label_snapshot: row.measure_label_snapshot ?? null,
-                    grams_per_measure_snapshot: row.grams_per_measure_snapshot ?? null,
-                    measure_quantity_snapshot: row.measure_quantity_snapshot ?? null,
-                    grams_total_snapshot: row.grams_total_snapshot ?? null
-                }))
+                data: ingredientRows.map((row) => toRecipeIngredientCreateRow(recipe.id, row))
             });
 
             return recipe;
@@ -325,6 +325,95 @@ router.post('/recipes', async (req, res) => {
         if (isHttpError(err)) {
             return res.status(err.statusCode).json({ message: err.message || 'Request failed' });
         }
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+router.patch('/:id', async (req, res) => {
+    const user = req.user as any;
+    const id = parsePositiveInteger(req.params.id);
+    if (id === null) return res.status(400).json({ message: 'Invalid my food id' });
+
+    const name = normalizeMyFoodName(req.body?.name);
+    const servingSizeQuantity = parsePositiveNumber(req.body?.serving_size_quantity);
+    const servingUnitLabel = normalizeServingUnitLabel(req.body?.serving_unit_label);
+    if (!name) return res.status(400).json({ message: 'Invalid name' });
+    if (servingSizeQuantity === null) return res.status(400).json({ message: 'Invalid serving size quantity' });
+    if (!servingUnitLabel) return res.status(400).json({ message: 'Invalid serving unit label' });
+
+    try {
+        const existing = await prisma.myFood.findFirst({ where: { id, user_id: user.id } });
+        if (!existing) return res.status(404).json({ message: 'My food not found' });
+
+        if (existing.type === 'FOOD') {
+            const caloriesPerServing = parseNonNegativeNumber(req.body?.calories_per_serving);
+            if (caloriesPerServing === null) return res.status(400).json({ message: 'Invalid calories per serving' });
+            const result = await prisma.myFood.updateMany({
+                where: { id, user_id: user.id, type: 'FOOD' },
+                data: {
+                    name,
+                    serving_size_quantity: servingSizeQuantity,
+                    serving_unit_label: servingUnitLabel,
+                    calories_per_serving: caloriesPerServing
+                }
+            });
+            if (result.count === 0) return res.status(404).json({ message: 'My food not found' });
+        } else {
+            const yieldServings = parsePositiveNumber(req.body?.yield_servings);
+            const ingredientsRaw = req.body?.ingredients;
+            if (yieldServings === null) return res.status(400).json({ message: 'Invalid yield servings' });
+            if (!Array.isArray(ingredientsRaw) || ingredientsRaw.length === 0) {
+                return res.status(400).json({ message: 'Recipe must include at least one ingredient' });
+            }
+
+            await prisma.$transaction(async (tx) => {
+                const ingredientRows = await resolveRecipeIngredientRows(
+                    tx,
+                    user.id,
+                    ingredientsRaw as CreateRecipeIngredientInput[]
+                );
+                const recipeTotalCalories = ingredientRows.reduce((sum, row) => sum + row.calories_total_snapshot, 0);
+                const result = await tx.myFood.updateMany({
+                    where: { id, user_id: user.id, type: 'RECIPE' },
+                    data: {
+                        name,
+                        serving_size_quantity: servingSizeQuantity,
+                        serving_unit_label: servingUnitLabel,
+                        calories_per_serving: recipeTotalCalories / yieldServings,
+                        recipe_total_calories: recipeTotalCalories,
+                        yield_servings: yieldServings
+                    }
+                });
+                if (result.count === 0) throw createHttpError(404, 'My food not found');
+                await tx.recipeIngredient.deleteMany({ where: { recipe_id: id } });
+                await tx.recipeIngredient.createMany({
+                    data: ingredientRows.map((row) => toRecipeIngredientCreateRow(id, row))
+                });
+            });
+        }
+
+        const updated = await prisma.myFood.findFirst({ where: { id, user_id: user.id } });
+        if (!updated) return res.status(404).json({ message: 'My food not found' });
+        return res.json(updated);
+    } catch (err) {
+        console.error(err);
+        if (isHttpError(err)) return res.status(err.statusCode).json({ message: err.message || 'Request failed' });
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+router.delete('/:id', async (req, res) => {
+    const user = req.user as any;
+    const id = parsePositiveInteger(req.params.id);
+    if (id === null) return res.status(400).json({ message: 'Invalid my food id' });
+
+    try {
+        // Database SetNull/Cascade relations remove links while preserving historical snapshot columns.
+        const result = await prisma.myFood.deleteMany({ where: { id, user_id: user.id } });
+        if (result.count === 0) return res.status(404).json({ message: 'My food not found' });
+        return res.status(204).end();
+    } catch (err) {
+        console.error(err);
         return res.status(500).json({ message: 'Server error' });
     }
 });

--- a/backend/src/services/accountLifecycle.ts
+++ b/backend/src/services/accountLifecycle.ts
@@ -123,6 +123,7 @@ export type AccountExport = {
     serving_size_quantity: number;
     serving_unit_label: string;
     calories_per_serving: number;
+    is_pinned: boolean;
     recipe_total_calories: number | null;
     yield_servings: number | null;
     created_at: string;
@@ -260,6 +261,7 @@ export function serializeAccountExport(user: AccountExportRow, now = new Date())
       serving_size_quantity: food.serving_size_quantity,
       serving_unit_label: food.serving_unit_label,
       calories_per_serving: food.calories_per_serving,
+      is_pinned: food.is_pinned,
       recipe_total_calories: food.recipe_total_calories,
       yield_servings: food.yield_servings,
       created_at: toIsoDateTime(food.created_at),

--- a/backend/test/account-lifecycle.test.js
+++ b/backend/test/account-lifecycle.test.js
@@ -97,6 +97,7 @@ const exportRow = {
     serving_size_quantity: 1,
     serving_unit_label: 'bowl',
     calories_per_serving: 400,
+    is_pinned: true,
     recipe_total_calories: 800,
     yield_servings: 2,
     created_at: at('2025-01-02T00:00:00.000Z'),
@@ -162,6 +163,7 @@ test('account export returns canonical versioned tracking data without credentia
   assert.deepEqual(result.account.profile_image, { mime_type: 'image/png', data_base64: 'AQID' });
   assert.equal(result.body_metrics[0].date, '2025-01-03');
   assert.equal(result.food_logs[0].serving_unit_label_snapshot, 'bowl');
+  assert.equal(result.my_foods[0].is_pinned, true);
   assert.equal(result.my_foods[0].recipe_ingredients[0].external_id, 'rice-1');
 
   assert.equal(findArgs.where.id, 7);

--- a/backend/test/routes-my-foods.test.js
+++ b/backend/test/routes-my-foods.test.js
@@ -36,6 +36,10 @@ function createRes() {
     json(payload) {
       this.body = payload;
       return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
     }
   };
 }
@@ -337,4 +341,98 @@ test('myFoods route: POST /recipes creates a recipe and ingredient snapshots', a
   assert.equal(receivedIngredientData[0].name_snapshot, 'Tomato sauce');
   assert.equal(receivedIngredientData[0].brand_snapshot, 'Brand');
   assert.equal(receivedIngredientData[0].calories_total_snapshot, 100);
+});
+
+test('myFoods route: PATCH /:id updates an owned food without touching historical logs', async () => {
+  let readCount = 0;
+  let receivedUpdate = null;
+  const prismaStub = {
+    myFood: {
+      findFirst: async () => {
+        readCount += 1;
+        return readCount === 1
+          ? { id: 9, user_id: 7, type: 'FOOD' }
+          : { id: 9, user_id: 7, type: 'FOOD', name: 'New oats', calories_per_serving: 190 };
+      },
+      updateMany: async (args) => {
+        receivedUpdate = args;
+        return { count: 1 };
+      }
+    }
+  };
+  const handler = getRouteHandler(loadMyFoodsRouter(prismaStub), 'patch', '/:id');
+  const res = createRes();
+  await handler({
+    user: { id: 7 },
+    params: { id: '9' },
+    body: { name: ' New oats ', serving_size_quantity: 1, serving_unit_label: ' bowl ', calories_per_serving: 190 }
+  }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(receivedUpdate, {
+    where: { id: 9, user_id: 7, type: 'FOOD' },
+    data: { name: 'New oats', serving_size_quantity: 1, serving_unit_label: 'bowl', calories_per_serving: 190 }
+  });
+  assert.equal('foodLog' in prismaStub, false);
+});
+
+test('myFoods route: PATCH /:id atomically replaces only an owned recipe definition', async () => {
+  let deletedWhere = null;
+  let createdRows = null;
+  const txStub = {
+    myFood: { updateMany: async () => ({ count: 1 }) },
+    recipeIngredient: {
+      deleteMany: async ({ where }) => { deletedWhere = where; },
+      createMany: async ({ data }) => { createdRows = data; }
+    }
+  };
+  const prismaStub = {
+    myFood: {
+      findFirst: async () => ({ id: 10, user_id: 7, type: 'RECIPE', name: 'Soup' })
+    },
+    $transaction: async (fn) => fn(txStub)
+  };
+  const handler = getRouteHandler(loadMyFoodsRouter(prismaStub), 'patch', '/:id');
+  const res = createRes();
+  await handler({
+    user: { id: 7 },
+    params: { id: '10' },
+    body: {
+      name: 'Soup',
+      serving_size_quantity: 1,
+      serving_unit_label: 'bowl',
+      yield_servings: 2,
+      ingredients: [{ source: 'EXTERNAL', name: 'Broth', calories_total: 80 }]
+    }
+  }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(deletedWhere, { recipe_id: 10 });
+  assert.equal(createdRows.length, 1);
+  assert.equal(createdRows[0].recipe_id, 10);
+  assert.equal(createdRows[0].name_snapshot, 'Broth');
+  assert.equal('foodLog' in txStub, false);
+});
+
+test('myFoods route: DELETE /:id scopes deletion to the owner and returns 404 otherwise', async () => {
+  let receivedWhere = null;
+  const prismaStub = {
+    myFood: {
+      deleteMany: async ({ where }) => {
+        receivedWhere = where;
+        return { count: where.id === 11 ? 1 : 0 };
+      }
+    }
+  };
+  const handler = getRouteHandler(loadMyFoodsRouter(prismaStub), 'delete', '/:id');
+  const deleted = createRes();
+  await handler({ user: { id: 7 }, params: { id: '11' } }, deleted);
+  assert.equal(deleted.statusCode, 204);
+  assert.equal(deleted.ended, true);
+  assert.deepEqual(receivedWhere, { id: 11, user_id: 7 });
+
+  const missing = createRes();
+  await handler({ user: { id: 7 }, params: { id: '12' } }, missing);
+  assert.equal(missing.statusCode, 404);
+  assert.deepEqual(missing.body, { message: 'My food not found' });
 });

--- a/backend/test/routes-my-foods.test.js
+++ b/backend/test/routes-my-foods.test.js
@@ -74,10 +74,12 @@ test('myFoods route: rejects unauthenticated requests via router.use middleware'
 
 test('myFoods route: GET / builds filters from q + type', async () => {
   let receivedWhere = null;
+  let receivedOrderBy = null;
   const prismaStub = {
     myFood: {
-      findMany: async ({ where }) => {
+      findMany: async ({ where, orderBy }) => {
         receivedWhere = where;
+        receivedOrderBy = orderBy;
         return [{ id: 1, name: 'Apple' }];
       }
     }
@@ -98,6 +100,73 @@ test('myFoods route: GET / builds filters from q + type', async () => {
     name: { contains: 'app', mode: 'insensitive' },
     type: 'FOOD'
   });
+  assert.deepEqual(receivedOrderBy, [
+    { is_pinned: 'desc' },
+    { name: 'asc' },
+    { id: 'asc' }
+  ]);
+});
+
+test('myFoods route: PATCH /:id/pin validates id and boolean state', async () => {
+  const router = loadMyFoodsRouter({ myFood: {} });
+  const handler = getRouteHandler(router, 'patch', '/:id/pin');
+
+  const invalidIdRes = createRes();
+  await handler({ user: { id: 7 }, params: { id: 'bad' }, body: { is_pinned: true } }, invalidIdRes);
+  assert.equal(invalidIdRes.statusCode, 400);
+  assert.deepEqual(invalidIdRes.body, { message: 'Invalid my food id' });
+
+  const invalidStateRes = createRes();
+  await handler({ user: { id: 7 }, params: { id: '12' }, body: { is_pinned: 'true' } }, invalidStateRes);
+  assert.equal(invalidStateRes.statusCode, 400);
+  assert.deepEqual(invalidStateRes.body, { message: 'is_pinned must be a boolean' });
+});
+
+test('myFoods route: PATCH /:id/pin scopes writes to the authenticated user', async () => {
+  let receivedUpdate = null;
+  let receivedRead = null;
+  const updated = { id: 12, user_id: 7, name: 'Oats', is_pinned: true };
+  const prismaStub = {
+    myFood: {
+      updateMany: async (args) => {
+        receivedUpdate = args;
+        return { count: 1 };
+      },
+      findFirst: async (args) => {
+        receivedRead = args;
+        return updated;
+      }
+    }
+  };
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'patch', '/:id/pin');
+  const res = createRes();
+
+  await handler({ user: { id: 7 }, params: { id: '12' }, body: { is_pinned: true } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, updated);
+  assert.deepEqual(receivedUpdate, {
+    where: { id: 12, user_id: 7 },
+    data: { is_pinned: true }
+  });
+  assert.deepEqual(receivedRead, { where: { id: 12, user_id: 7 } });
+});
+
+test('myFoods route: PATCH /:id/pin returns the same 404 for missing or other-user items', async () => {
+  const prismaStub = {
+    myFood: {
+      updateMany: async () => ({ count: 0 })
+    }
+  };
+  const router = loadMyFoodsRouter(prismaStub);
+  const handler = getRouteHandler(router, 'patch', '/:id/pin');
+  const res = createRes();
+
+  await handler({ user: { id: 7 }, params: { id: '12' }, body: { is_pinned: false } }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(res.body, { message: 'My food not found' });
 });
 
 test('myFoods route: GET /:id validates ids and returns 404 when missing', async () => {
@@ -269,4 +338,3 @@ test('myFoods route: POST /recipes creates a recipe and ingredient snapshots', a
   assert.equal(receivedIngredientData[0].brand_snapshot, 'Brand');
   assert.equal(receivedIngredientData[0].calories_total_snapshot, 100);
 });
-

--- a/docs/android-e2e.md
+++ b/docs/android-e2e.md
@@ -1,0 +1,55 @@
+# Android end-to-end test
+
+The adb-driven E2E test exercises a real debug client, backend, Postgres database, and Android emulator. It proves:
+
+- authenticated startup using the seeded development account;
+- one-tap recent-food logging reaches the API once;
+- an airplane-mode write is persisted in the SQLite outbox;
+- the queued write survives process death;
+- reconnect and relaunch replay it exactly once;
+- a second relaunch does not duplicate it;
+- the app process remains alive with an empty Android crash buffer.
+
+## Prerequisites
+
+Start a disposable Postgres database and apply the real migration chain:
+
+```powershell
+docker run --rm -d --name calibrate-e2e-postgres `
+  -e POSTGRES_USER=calibrate `
+  -e POSTGRES_PASSWORD=calibrate_e2e `
+  -e POSTGRES_DB=calibrate_e2e `
+  -p 127.0.0.1:55432:5432 postgres:16-alpine
+
+$env:DATABASE_URL='postgresql://calibrate:calibrate_e2e@127.0.0.1:55432/calibrate_e2e?schema=public'
+npm.cmd --prefix backend run db:migrate
+npm.cmd --prefix backend run db:seed
+```
+
+Start the backend and Metro in separate terminals:
+
+```powershell
+$env:DATABASE_URL='postgresql://calibrate:calibrate_e2e@127.0.0.1:55432/calibrate_e2e?schema=public'
+$env:SESSION_SECRET='calibrate-e2e-session-secret'
+npm.cmd --prefix backend run dev
+
+$env:NODE_ENV='development'
+npm.cmd --prefix mobile start -- --localhost
+```
+
+Install the current debug APK on a booted emulator, then run from the repository root:
+
+```powershell
+npm.cmd run test:android:e2e
+```
+
+The script defaults to `http://127.0.0.1:3000`, the seeded `test@calibratehealth.app` account, and the standard
+Android SDK path under `%LOCALAPPDATA%`. Override `CALIBRATE_E2E_API_URL`, `CALIBRATE_E2E_EMAIL`,
+`CALIBRATE_E2E_PASSWORD`, or `ADB` when needed. Use only disposable test data: the script deliberately clears the
+emulator app sandbox and adds food logs.
+
+Stop the disposable database when finished:
+
+```powershell
+docker stop calibrate-e2e-postgres
+```

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -1,0 +1,135 @@
+# Android internal release
+
+This runbook produces signed Android artifacts from the Expo project in `mobile/`:
+
+- `internal` produces an APK for direct installation on owned devices.
+- `production` produces an AAB for Google Play internal testing and later store tracks.
+
+The permanent Android identity is the application ID `app.calibratehealth.mobile` plus its signing certificate.
+Changing either creates a different app or prevents an in-place upgrade.
+
+## One-time release setup
+
+The repository uses EAS-managed Android credentials. EAS stores the keystore and passwords outside Git, while
+`mobile/eas.json` keeps artifact shape and version ownership reviewable.
+
+From `mobile/`:
+
+```powershell
+npx eas-cli@16.28.0 login
+npx eas-cli@16.28.0 init
+npx eas-cli@16.28.0 credentials --platform android
+```
+
+`eas init` links the app to an EAS project. Review and commit only its non-secret project ID if it updates
+`mobile/app.json`. Let the credentials command generate or upload the one release keystore. Download an encrypted
+offline backup from EAS credentials and record its alias and passwords in a password manager. Never commit a
+keystore, `credentials.json`, service-account JSON, EAS access token, or signing password.
+
+For unattended builds, store `EXPO_TOKEN` in the CI secret store. It is an account credential and must not use the
+`EXPO_PUBLIC_` prefix. Backend database, food-provider, push, and session secrets remain server-side and never belong
+in an Android build.
+
+## Environment configuration
+
+Internal builds use the EAS `preview` environment and production AABs use `production`. With no override, release
+builds default to `https://calibratehealth.app`, and users can select a self-hosted origin from the sign-in screen.
+
+To give a private build a different initial origin, define `EXPO_PUBLIC_CALIBRATE_SERVER_URL` in the matching EAS
+environment. This value is compiled into the app and is public; it may contain an `https://` origin, never a token,
+password, API key, username, or URL with embedded credentials. Prefer HTTPS for every non-development server.
+
+```powershell
+# Example only: the value is public inside the APK/AAB.
+npx eas-cli@16.28.0 env:create --environment preview --name EXPO_PUBLIC_CALIBRATE_SERVER_URL --value https://health.example.com
+```
+
+## Versioning
+
+`mobile/app.json` is the source of truth:
+
+- `expo.version` is the user-visible semantic version.
+- `expo.android.versionCode` is the monotonically increasing Android build number.
+
+`appVersionSource` is `local`, and EAS profiles do not auto-increment. Before every distributed build, increment
+`versionCode`; increment `version` when the user-visible release changes. Commit both before building so an artifact
+can be traced to one Git commit. Google Play and Android reject an upgrade whose version code is not greater than the
+installed build.
+
+## Validate from a clean checkout
+
+Run from the repository root on the exact commit intended for release:
+
+```powershell
+npm.cmd ci --ignore-scripts --no-audit --fund=false
+npm.cmd --prefix mobile run typecheck
+npm.cmd --prefix mobile test -- --runInBand
+Push-Location mobile
+node ..\node_modules\expo\bin\cli install --check
+node ..\node_modules\expo\bin\cli config --type public
+node ..\node_modules\expo\bin\cli prebuild --platform android --clean --no-install
+Pop-Location
+```
+
+The last command recreates ignored `mobile/android/` output and verifies native config. It must not introduce tracked
+files. Use the repository's local Android/Gradle validation after prebuild when an SDK is installed.
+
+## Build artifacts
+
+Run these commands from `mobile/` with the pinned CLI version used during setup:
+
+```powershell
+# Signed APK for direct installation.
+npx eas-cli@16.28.0 build --platform android --profile internal
+
+# Signed AAB for Google Play internal testing.
+npx eas-cli@16.28.0 build --platform android --profile production
+```
+
+Record the EAS build URL, Git commit, semantic version, version code, and SHA-256 digest of the downloaded artifact in
+the release notes. Do not rename an artifact in a way that loses those identifiers.
+
+Install or upgrade the internal APK with Android Debug Bridge:
+
+```powershell
+adb install -r .\calibrate-internal.apk
+```
+
+`-r` performs an in-place replacement. Do not uninstall the existing app, use `adb install --uninstall`, clear app
+storage, or change the application ID/signing key when testing an upgrade.
+
+## Preserve on-device data during upgrades
+
+Expo SecureStore tokens and the SQLite offline outbox live in the Android application sandbox. Android preserves
+them when all of the following remain true:
+
+1. The application ID remains `app.calibratehealth.mobile`.
+2. The new APK/AAB is signed by the same certificate.
+3. `versionCode` increases.
+4. The app is upgraded in place instead of uninstalled or data-cleared.
+
+Before shipping a SQLite or authentication-storage change, test an upgrade from the last distributed signed APK with
+both an active session and pending/failed offline mutations. Export account data first when testing migrations against
+important real data. Database migrations must be forward-compatible; Android cannot safely roll back to a build that
+does not understand a newer on-device schema.
+
+If a release is bad, publish a fixed build with a higher version code. A lower-version APK is not a safe rollback for
+SecureStore or SQLite changes.
+
+## Internal release checklist
+
+- [ ] Working tree is clean and the release commit is pushed.
+- [ ] `version` is correct and `versionCode` is greater than every distributed Android build.
+- [ ] Application ID is still `app.calibratehealth.mobile`.
+- [ ] Public Expo config includes camera/notification permissions but does not request microphone access.
+- [ ] EAS reports the expected Android signing certificate fingerprint.
+- [ ] No keystore, password, token, service-account JSON, backend secret, or credential URL is tracked or embedded.
+- [ ] Mobile typecheck, tests, Expo dependency check, public config, clean prebuild, and local Gradle build pass.
+- [ ] Upgrade the previous signed APK with `adb install -r`; do not uninstall it first.
+- [ ] Existing login survives the upgrade and logout/login still work.
+- [ ] Existing food, weight, settings, and pending/failed offline changes survive and reconcile correctly.
+- [ ] Test food entry, barcode entry, weigh-in, day completion, account export, and notification permission on a device.
+- [ ] Confirm a self-hosted HTTPS origin can be selected and survives an app restart.
+- [ ] Inspect the APK/AAB for an expected public server origin and absence of credentials.
+- [ ] Record artifact digest, EAS build URL, Git commit, version, version code, device/API level, and test results.
+- [ ] Keep the prior artifact and encrypted keystore backup, but distribute only the new higher-version build.

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -346,7 +346,7 @@ components:
         created_at: { type: string, format: date-time }
     AccountExportMyFood:
       type: object
-      required: [id, type, name, serving_size_quantity, serving_unit_label, calories_per_serving, recipe_total_calories, yield_servings, created_at, updated_at, recipe_ingredients]
+      required: [id, type, name, serving_size_quantity, serving_unit_label, calories_per_serving, is_pinned, recipe_total_calories, yield_servings, created_at, updated_at, recipe_ingredients]
       properties:
         id: { type: integer }
         type: { type: string, enum: [FOOD, RECIPE] }
@@ -354,6 +354,7 @@ components:
         serving_size_quantity: { type: number }
         serving_unit_label: { type: string }
         calories_per_serving: { type: number }
+        is_pinned: { type: boolean }
         recipe_total_calories: { type: [number, 'null'] }
         yield_servings: { type: [number, 'null'] }
         created_at: { type: string, format: date-time }

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -12,6 +12,7 @@
     ],
     "android": {
       "package": "app.calibratehealth.mobile",
+      "versionCode": 1,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#F6F8F4"
@@ -36,6 +37,9 @@
         "CAMERA",
         "VIBRATE",
         "POST_NOTIFICATIONS"
+      ],
+      "blockedPermissions": [
+        "android.permission.RECORD_AUDIO"
       ]
     },
     "plugins": [

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Link } from 'expo-router';
 import { AppButton } from '../../src/components/AppButton';
@@ -12,12 +12,16 @@ import { useAuth } from '../../src/auth/AuthContext';
 import { colors, spacing } from '../../src/theme';
 
 export default function LoginScreen() {
-    const { login, serverUrl, setServerUrl, authError } = useAuth();
+    const { login, serverUrl, setServerUrl, testServerUrl, serverConnection, authError } = useAuth();
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [serverInput, setServerInput] = useState(serverUrl);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        setServerInput(serverUrl);
+    }, [serverUrl]);
 
     async function handleLogin() {
         setIsSubmitting(true);
@@ -55,7 +59,12 @@ export default function LoginScreen() {
                     value={password}
                     onChangeText={setPassword}
                 />
-                <ServerUrlControl value={serverInput} onChangeText={setServerInput} />
+                <ServerUrlControl
+                    value={serverInput}
+                    onChangeText={setServerInput}
+                    connection={serverConnection}
+                    onTestConnection={testServerUrl}
+                />
                 {(error || authError) && <AppText style={styles.error}>{error ?? authError}</AppText>}
                 <AppButton title={isSubmitting ? 'Signing in...' : 'Sign in'} disabled={isSubmitting} onPress={() => void handleLogin()} />
             </AppCard>

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Link } from 'expo-router';
 import { AppButton } from '../../src/components/AppButton';
@@ -12,12 +12,16 @@ import { useAuth } from '../../src/auth/AuthContext';
 import { colors, spacing } from '../../src/theme';
 
 export default function RegisterScreen() {
-    const { register, serverUrl, setServerUrl } = useAuth();
+    const { register, serverUrl, setServerUrl, testServerUrl, serverConnection, authError } = useAuth();
     const [serverInput, setServerInput] = useState(serverUrl);
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        setServerInput(serverUrl);
+    }, [serverUrl]);
 
     async function handleRegister() {
         setIsSubmitting(true);
@@ -50,8 +54,13 @@ export default function RegisterScreen() {
                     onChangeText={setEmail}
                 />
                 <TextField label="Password" secureTextEntry value={password} onChangeText={setPassword} />
-                <ServerUrlControl value={serverInput} onChangeText={setServerInput} />
-                {error && <AppText style={styles.error}>{error}</AppText>}
+                <ServerUrlControl
+                    value={serverInput}
+                    onChangeText={setServerInput}
+                    connection={serverConnection}
+                    onTestConnection={testServerUrl}
+                />
+                {(error || authError) && <AppText style={styles.error}>{error ?? authError}</AppText>}
                 <AppButton title={isSubmitting ? 'Creating...' : 'Create account'} disabled={isSubmitting} onPress={() => void handleRegister()} />
             </AppCard>
 

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -11,6 +11,8 @@ import { LoadingState } from '../../src/components/LoadingState';
 import { useAuth } from '../../src/auth/AuthContext';
 import { LogDateProvider } from '../../src/context/LogDateContext';
 import { useLogDateNavigation } from '../../src/hooks/useLogDateNavigation';
+import { useOfflineOutbox } from '../../src/offline/provider';
+import { OUTBOX_MUTATION_STATES } from '../../src/offline/queuedMutation';
 import { isProfileSetupComplete } from '../../src/utils/profileCompletion';
 import { colors, radius, spacing } from '../../src/theme';
 
@@ -28,6 +30,10 @@ export default function TabsLayout() {
     const { api, user, isLoading } = useAuth();
     const insets = useSafeAreaInsets();
     const logDateNavigation = useLogDateNavigation();
+    const { mutations: queuedMutations } = useOfflineOutbox();
+    const hasFailedOfflineChanges = queuedMutations.some(
+        (mutation) => mutation.state === OUTBOX_MUTATION_STATES.FAILED
+    );
     const profileQuery = useQuery({
         queryKey: ['mobile-profile'],
         queryFn: () => api.getUserProfile(),
@@ -76,6 +82,8 @@ export default function TabsLayout() {
                             title={typeof options.headerTitle === 'string' ? options.headerTitle : ''}
                             user={user}
                             unreadCount={notificationsQuery.data?.unread_count ?? 0}
+                            offlineChangeCount={queuedMutations.length}
+                            hasFailedOfflineChanges={hasFailedOfflineChanges}
                         />
                     )
                 }}
@@ -110,7 +118,9 @@ const TabHeader: React.FC<{
     title: string;
     user: UserClientPayload | null;
     unreadCount: number;
-}> = ({ topInset, title, user, unreadCount }) => (
+    offlineChangeCount: number;
+    hasFailedOfflineChanges: boolean;
+}> = ({ topInset, title, user, unreadCount, offlineChangeCount, hasFailedOfflineChanges }) => (
     <View style={[styles.headerRoot, { paddingTop: topInset }]}>
         <View style={styles.headerRow}>
             <HeaderBrand />
@@ -119,7 +129,12 @@ const TabHeader: React.FC<{
                     <AppText numberOfLines={1} style={styles.headerTitleText}>{title}</AppText>
                 </View>
             )}
-            <HeaderActions user={user} unreadCount={unreadCount} />
+            <HeaderActions
+                user={user}
+                unreadCount={unreadCount}
+                offlineChangeCount={offlineChangeCount}
+                hasFailedOfflineChanges={hasFailedOfflineChanges}
+            />
         </View>
     </View>
 );
@@ -153,7 +168,12 @@ function getAvatarLabel(email?: string | null): string {
     return email?.trim().charAt(0).toUpperCase() || 'C';
 }
 
-const HeaderActions: React.FC<{ user: UserClientPayload | null; unreadCount: number }> = ({ user, unreadCount }) => (
+const HeaderActions: React.FC<{
+    user: UserClientPayload | null;
+    unreadCount: number;
+    offlineChangeCount: number;
+    hasFailedOfflineChanges: boolean;
+}> = ({ user, unreadCount, offlineChangeCount, hasFailedOfflineChanges }) => (
     <View style={styles.headerActions}>
         <Pressable
             accessibilityRole="button"
@@ -170,7 +190,11 @@ const HeaderActions: React.FC<{ user: UserClientPayload | null; unreadCount: num
         </Pressable>
         <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Open settings"
+            accessibilityLabel={
+                offlineChangeCount > 0
+                    ? `Open settings, ${offlineChangeCount} offline changes ${hasFailedOfflineChanges ? 'need attention' : 'pending'}`
+                    : 'Open settings'
+            }
             onPress={() => router.push('/(tabs)/settings')}
             style={({ pressed }) => [styles.accountButton, pressed && styles.pressed]}
         >
@@ -180,6 +204,12 @@ const HeaderActions: React.FC<{ user: UserClientPayload | null; unreadCount: num
                 <View style={styles.avatarFallback}>
                     <AppText style={styles.avatarText}>{getAvatarLabel(user?.email)}</AppText>
                 </View>
+            )}
+            {offlineChangeCount > 0 && (
+                <View
+                    accessibilityElementsHidden
+                    style={[styles.syncBadge, hasFailedOfflineChanges && styles.syncBadgeFailed]}
+                />
             )}
             <Ionicons name="chevron-down" size={13} color={colors.muted} />
         </Pressable>
@@ -279,6 +309,20 @@ const styles = StyleSheet.create({
         fontWeight: '900',
         textAlign: 'center',
         includeFontPadding: false
+    },
+    syncBadge: {
+        position: 'absolute',
+        top: 2,
+        left: 2,
+        width: 9,
+        height: 9,
+        borderRadius: radius.pill,
+        backgroundColor: colors.warning,
+        borderColor: colors.surface,
+        borderWidth: 1
+    },
+    syncBadgeFailed: {
+        backgroundColor: colors.danger
     },
     avatarImage: {
         width: 28,

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -25,6 +25,8 @@ import {
 } from '../../src/account/accountData';
 import { OUTBOX_MUTATION_STATES } from '../../src/offline/queuedMutation';
 import { useOfflineOutbox } from '../../src/offline/provider';
+import { useNativePushRegistration } from '../../src/hooks/useNativePushRegistration';
+import { getPushStatusPresentation } from '../../src/notifications/workflow';
 import { millimetersToCentimeters, millimetersToFeetInches } from '../../src/utils/bodyMeasurements';
 import { getTodayDate } from '../../src/utils/dates';
 import { formatCalories } from '../../src/utils/format';
@@ -60,6 +62,8 @@ export default function SettingsScreen() {
         retryFailed: retryFailedOutbox
     } = useOfflineOutbox();
     const queryClient = useQueryClient();
+    const nativePush = useNativePushRegistration();
+    const pushStatus = getPushStatusPresentation(nativePush.state);
     const [serverInput, setServerInput] = useState(serverUrl);
     const [timezone, setTimezone] = useState(user?.timezone ?? 'UTC');
     const [dateOfBirth, setDateOfBirth] = useState(user?.date_of_birth?.slice(0, 10) ?? '');
@@ -350,6 +354,53 @@ export default function SettingsScreen() {
                     value={logWeightReminders}
                     onValueChange={setLogWeightReminders}
                 />
+                <View style={styles.notificationStatus}>
+                    <AppText variant="label">Push on this device</AppText>
+                    <AppText
+                        accessibilityLiveRegion="polite"
+                        accessibilityRole={pushStatus.isError ? 'alert' : undefined}
+                        style={pushStatus.isError ? styles.error : undefined}
+                        variant={pushStatus.isError ? 'body' : 'muted'}
+                    >
+                        {pushStatus.message}
+                    </AppText>
+                    {pushStatus.action === 'request' && (
+                        <AppButton
+                            title="Enable push notifications"
+                            variant="secondary"
+                            accessibilityHint="Shows the Android notification permission prompt."
+                            leftIcon={<Ionicons name="notifications-outline" size={18} color={colors.text} />}
+                            onPress={() => void nativePush.requestPermission()}
+                        />
+                    )}
+                    {pushStatus.action === 'settings' && (
+                        <View style={styles.row}>
+                            <AppButton
+                                title="Open Android settings"
+                                variant="secondary"
+                                accessibilityHint="Opens notification permissions for Calibrate."
+                                onPress={() => void nativePush.openSettings()}
+                                style={styles.rowButton}
+                            />
+                            <AppButton
+                                title="Check again"
+                                variant="secondary"
+                                accessibilityHint="Checks whether notification permission is now enabled."
+                                onPress={() => void nativePush.refreshPermission()}
+                                style={styles.rowButton}
+                            />
+                        </View>
+                    )}
+                    {pushStatus.action === 'retry' && (
+                        <AppButton
+                            title="Retry push registration"
+                            variant="secondary"
+                            accessibilityHint="Checks permission and registers this device again."
+                            leftIcon={<Ionicons name="refresh-outline" size={18} color={colors.text} />}
+                            onPress={() => void nativePush.retryRegistration()}
+                        />
+                    )}
+                </View>
                 <PreferenceSwitch
                     label="Haptics"
                     value={hapticsEnabled}
@@ -856,6 +907,9 @@ const styles = StyleSheet.create({
     },
     pressedRow: {
         opacity: 0.78
+    },
+    notificationStatus: {
+        gap: spacing.sm
     },
     success: {
         color: colors.success

--- a/mobile/app/(tabs)/today.tsx
+++ b/mobile/app/(tabs)/today.tsx
@@ -97,7 +97,15 @@ export default function TodayScreen() {
     });
 
     const deleteFood = useMutation({
-        mutationFn: (id: number) => api.deleteFoodLog(id),
+        mutationFn: (id: number) => {
+            const payload = { id };
+            return executeOrQueueMutation({
+                operation: OFFLINE_MUTATION_OPERATIONS.DELETE_FOOD_LOG,
+                payload,
+                execute: (operationId) => api.deleteFoodLog(id, operationId),
+                enqueue
+            });
+        },
         onSuccess: async () => {
             await Haptics.selectionAsync();
             await invalidateLogQueries();
@@ -125,7 +133,13 @@ export default function TodayScreen() {
                 payload.servings_consumed = Number(editServings);
             }
 
-            return api.updateFoodLog(editEntry.id, payload);
+            const queuedPayload = { id: editEntry.id, update: payload };
+            return executeOrQueueMutation({
+                operation: OFFLINE_MUTATION_OPERATIONS.UPDATE_FOOD_LOG,
+                payload: queuedPayload,
+                execute: (operationId) => api.updateFoodLog(editEntry.id, payload, operationId),
+                enqueue
+            });
         },
         onSuccess: async () => {
             setEditEntry(null);

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,7 +5,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { AuthProvider, useAuth } from '../src/auth/AuthContext';
-import { useNativePushRegistration } from '../src/hooks/useNativePushRegistration';
+import { NativePushRegistrationProvider } from '../src/hooks/useNativePushRegistration';
+import { useNotificationTapRouting } from '../src/notifications/useNotificationTapRouting';
 import { createQueuedMutationExecutor } from '../src/offline/operations';
 import { OfflineOutboxProvider } from '../src/offline/provider';
 import { colors } from '../src/theme';
@@ -14,7 +15,8 @@ import { AppErrorBoundary } from '../src/components/AppErrorBoundary';
 const queryClient = new QueryClient();
 
 const NativeRuntimeHooks: React.FC = () => {
-    useNativePushRegistration();
+    const { user } = useAuth();
+    useNotificationTapRouting(Boolean(user));
     return null;
 };
 
@@ -30,11 +32,13 @@ export default function RootLayout() {
             <SafeAreaProvider>
                 <QueryClientProvider client={queryClient}>
                     <AuthProvider>
-                        <AuthenticatedRuntime>
-                            <NativeRuntimeHooks />
-                            <StatusBar style="dark" backgroundColor={colors.surface} />
-                            <Slot />
-                        </AuthenticatedRuntime>
+                        <NativePushRegistrationProvider>
+                            <AuthenticatedRuntime>
+                                <NativeRuntimeHooks />
+                                <StatusBar style="dark" backgroundColor={colors.surface} />
+                                <Slot />
+                            </AuthenticatedRuntime>
+                        </NativePushRegistrationProvider>
                     </AuthProvider>
                 </QueryClientProvider>
             </SafeAreaProvider>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -9,6 +9,7 @@ import { useNativePushRegistration } from '../src/hooks/useNativePushRegistratio
 import { createQueuedMutationExecutor } from '../src/offline/operations';
 import { OfflineOutboxProvider } from '../src/offline/provider';
 import { colors } from '../src/theme';
+import { AppErrorBoundary } from '../src/components/AppErrorBoundary';
 
 const queryClient = new QueryClient();
 
@@ -25,16 +26,18 @@ const AuthenticatedRuntime: React.FC<{ children: React.ReactNode }> = ({ childre
 
 export default function RootLayout() {
     return (
-        <SafeAreaProvider>
-            <QueryClientProvider client={queryClient}>
-                <AuthProvider>
-                    <AuthenticatedRuntime>
-                        <NativeRuntimeHooks />
-                        <StatusBar style="dark" backgroundColor={colors.surface} />
-                        <Slot />
-                    </AuthenticatedRuntime>
-                </AuthProvider>
-            </QueryClientProvider>
-        </SafeAreaProvider>
+        <AppErrorBoundary>
+            <SafeAreaProvider>
+                <QueryClientProvider client={queryClient}>
+                    <AuthProvider>
+                        <AuthenticatedRuntime>
+                            <NativeRuntimeHooks />
+                            <StatusBar style="dark" backgroundColor={colors.surface} />
+                            <Slot />
+                        </AuthenticatedRuntime>
+                    </AuthProvider>
+                </QueryClientProvider>
+            </SafeAreaProvider>
+        </AppErrorBoundary>
     );
 }

--- a/mobile/app/barcode.tsx
+++ b/mobile/app/barcode.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useRef, useState } from 'react';
+import { Linking, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { CameraView, useCameraPermissions, type BarcodeScanningResult } from 'expo-camera';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -21,6 +21,13 @@ import { getTodayDate } from '../src/utils/dates';
 import { formatCalories, formatMealPeriod } from '../src/utils/format';
 import { MEAL_OPTIONS } from '../src/utils/meals';
 import { colors, radius, spacing } from '../src/theme';
+import {
+    BarcodeScanGate,
+    getBarcodeLookupErrorMessage,
+    getBarcodeLookupStatus,
+    getCameraPermissionState,
+    getProviderAttribution
+} from '../src/barcode/workflow';
 
 const MEAL_SELECTOR_OPTIONS: Array<OverlaySelectOption<MealPeriod>> = MEAL_OPTIONS.map((option) => ({
     value: option,
@@ -55,10 +62,13 @@ export default function BarcodeScreen() {
     const { api, user } = useAuth();
     const { enqueue } = useOfflineOutbox();
     const queryClient = useQueryClient();
-    const [permission, requestPermission] = useCameraPermissions();
+    const [permission, requestPermission, refreshPermission] = useCameraPermissions();
     const [barcode, setBarcode] = useState<string | null>(null);
+    const [cameraMessage, setCameraMessage] = useState<string | null>(null);
+    const [scanError, setScanError] = useState<string | null>(null);
     const [meal, setMeal] = useState<MealPeriod>(() => parseMeal(mealParam));
     const [isMealSelectorOpen, setIsMealSelectorOpen] = useState(false);
+    const scanGate = useRef(new BarcodeScanGate());
     const selectedDate = typeof date === 'string' ? date : getTodayDate(user?.timezone);
     const lookup = useMutation({
         mutationFn: (code: string) => api.searchFood('', code)
@@ -87,19 +97,92 @@ export default function BarcodeScreen() {
         }
     });
 
-    if (!permission) {
+    const cameraPermissionState = getCameraPermissionState(permission);
+
+    if (cameraPermissionState === 'checking') {
         return <LoadingState label="Checking camera permission..." />;
     }
 
-    if (!permission.granted) {
+    if (cameraPermissionState === 'request' || cameraPermissionState === 'settings') {
+        const mustUseSettings = cameraPermissionState === 'settings';
+
+        async function retryCameraPermission() {
+            setCameraMessage(null);
+            try {
+                const nextPermission = await requestPermission();
+                if (!nextPermission.granted) {
+                    setCameraMessage(
+                        nextPermission.canAskAgain
+                            ? 'Camera permission was not granted. You can try again.'
+                            : 'Camera access is blocked. Open Android settings to enable it.'
+                    );
+                }
+            } catch {
+                setCameraMessage('Unable to request camera permission. Try again.');
+            }
+        }
+
+        async function openCameraSettings() {
+            setCameraMessage(null);
+            try {
+                await Linking.openSettings();
+                setCameraMessage('After enabling Camera in Android settings, return here and check access again.');
+            } catch {
+                setCameraMessage('Unable to open Android settings. Open the Calibrate app permissions manually.');
+            }
+        }
+
+        async function checkCameraPermission() {
+            setCameraMessage(null);
+            try {
+                const nextPermission = await refreshPermission();
+                if (!nextPermission.granted) {
+                    setCameraMessage('Camera access is still disabled in Android settings.');
+                }
+            } catch {
+                setCameraMessage('Unable to check camera permission. Try again.');
+            }
+        }
+
         return (
             <Screen>
                 <AppCard>
-                    <SectionHeader title="Camera permission" description="Barcode scanning uses the Android camera to find matching packaged foods." />
+                    <SectionHeader
+                        title="Camera permission"
+                        description={mustUseSettings
+                            ? 'Camera access is blocked for Calibrate. Enable it from the Android app permissions screen.'
+                            : 'Barcode scanning uses the Android camera to find matching packaged foods.'}
+                    />
+                    {cameraMessage && (
+                        <AppText accessibilityLiveRegion="polite" style={styles.permissionMessage}>
+                            {cameraMessage}
+                        </AppText>
+                    )}
                     <AppButton
-                        title="Allow camera"
+                        accessibilityRole="button"
+                        accessibilityHint={mustUseSettings
+                            ? 'Opens the Calibrate app permissions in Android settings.'
+                            : 'Shows the Android camera permission prompt.'}
+                        title={mustUseSettings ? 'Open Android settings' : 'Try camera permission again'}
                         leftIcon={<Ionicons name="camera-outline" size={18} color="#ffffff" />}
-                        onPress={() => void requestPermission()}
+                        onPress={() => void (mustUseSettings ? openCameraSettings() : retryCameraPermission())}
+                    />
+                    {mustUseSettings && (
+                        <AppButton
+                            accessibilityRole="button"
+                            accessibilityHint="Checks whether camera permission is now enabled."
+                            title="Check camera access"
+                            variant="secondary"
+                            leftIcon={<Ionicons name="refresh-outline" size={18} color={colors.text} />}
+                            onPress={() => void checkCameraPermission()}
+                        />
+                    )}
+                    <AppButton
+                        accessibilityRole="button"
+                        title="Back to log"
+                        variant="ghost"
+                        leftIcon={<Ionicons name="arrow-back" size={18} color={colors.text} />}
+                        onPress={() => router.back()}
                     />
                 </AppCard>
             </Screen>
@@ -107,25 +190,65 @@ export default function BarcodeScreen() {
     }
 
     function handleBarcodeScanned(result: BarcodeScanningResult) {
-        if (barcode) return;
-        setBarcode(result.data);
-        lookup.mutate(result.data);
+        const decision = scanGate.current.accept(result.data);
+        if (decision.kind === 'duplicate') return;
+        if (decision.kind === 'invalid') {
+            setScanError(decision.message);
+            return;
+        }
+
+        setScanError(null);
+        setBarcode(decision.barcode);
+        lookup.mutate(decision.barcode);
     }
 
     const first = lookup.data?.items[0];
+    const lookupStatus = getBarcodeLookupStatus({
+        hasBarcode: barcode !== null,
+        isPending: lookup.isPending,
+        isSuccess: lookup.isSuccess,
+        hasResult: Boolean(first),
+        hasError: Boolean(lookup.error)
+    });
+    const providerAttribution = getProviderAttribution(lookup.data?.provider, lookup.data?.attribution);
+    const lookupErrorMessage = lookup.error ? getBarcodeLookupErrorMessage(lookup.error) : null;
+
+    function resetScanner() {
+        scanGate.current.reset();
+        setBarcode(null);
+        setScanError(null);
+        setIsMealSelectorOpen(false);
+        lookup.reset();
+        logFood.reset();
+    }
+
+    function retryLookup() {
+        if (!barcode) return;
+        lookup.reset();
+        lookup.mutate(barcode);
+    }
+
+    let statusMessage = 'Camera ready. Center an EAN or UPC barcode in the frame.';
+    if (scanError) statusMessage = scanError;
+    else if (lookupStatus === 'searching') statusMessage = 'Searching food providers...';
+    else if (lookupStatus === 'no-result') statusMessage = 'No matching food was found. Try again or scan a different barcode.';
+    else if (lookupStatus === 'error' && lookupErrorMessage) statusMessage = lookupErrorMessage;
+    else if (lookupStatus === 'result' && first) statusMessage = `Found ${first.name}.`;
 
     return (
         <Screen scroll={false} style={styles.root}>
             <CameraView
                 style={styles.camera}
                 facing="back"
+                accessible
+                accessibilityLabel="Barcode camera preview"
                 barcodeScannerSettings={{
                     barcodeTypes: ['ean13', 'ean8', 'upc_a', 'upc_e']
                 }}
-                onBarcodeScanned={handleBarcodeScanned}
+                onBarcodeScanned={barcode ? undefined : handleBarcodeScanned}
             >
                 <View style={styles.scanOverlay}>
-                    <View style={styles.scanFrame} />
+                    <View accessible={false} style={styles.scanFrame} />
                 </View>
             </CameraView>
             <View style={styles.panel}>
@@ -134,15 +257,38 @@ export default function BarcodeScreen() {
                         title={barcode ? `Barcode ${barcode}` : 'Scan barcode'}
                         description="Center the packaged-food barcode in the frame."
                     />
-                    {lookup.isPending && <AppText variant="muted">Searching food providers...</AppText>}
+                    <AppText
+                        accessibilityLiveRegion="polite"
+                        accessibilityRole={lookupStatus === 'error' || Boolean(scanError) ? 'alert' : undefined}
+                        style={lookupStatus === 'error' || scanError ? styles.error : undefined}
+                        variant={lookupStatus === 'error' || scanError ? 'body' : 'muted'}
+                    >
+                        {statusMessage}
+                    </AppText>
                     {first && (
-                        <View style={styles.result}>
+                        <View
+                            accessible
+                            accessibilityLabel={`${first.name}, ${first.brand ?? 'provider result'}, ${formatCalories(first.calories)}`}
+                            style={styles.result}
+                        >
                             <AppText variant="body">{first.name}</AppText>
                             <AppText variant="caption">{first.brand ?? 'Food provider result'}</AppText>
                             <AppText variant="label">{formatCalories(first.calories)}</AppText>
                         </View>
                     )}
-                    {lookup.isSuccess && !first && <AppText variant="muted">No matching food found.</AppText>}
+                    {providerAttribution && (
+                        <AppText
+                            accessibilityRole={providerAttribution.url ? 'link' : undefined}
+                            accessibilityHint={providerAttribution.url ? 'Opens the food provider website.' : undefined}
+                            onPress={providerAttribution.url
+                                ? () => void Linking.openURL(providerAttribution.url!)
+                                : undefined}
+                            style={providerAttribution.url ? styles.attributionLink : undefined}
+                            variant="caption"
+                        >
+                            {providerAttribution.text}
+                        </AppText>
+                    )}
                     <AppText variant="label">Meal</AppText>
                     <OverlaySelect
                         accessibilityLabel="Select meal"
@@ -155,27 +301,43 @@ export default function BarcodeScreen() {
                             setIsMealSelectorOpen(false);
                         }}
                     />
-                    {(lookup.error || logFood.error) && <AppText style={styles.error}>{lookup.error?.message ?? logFood.error?.message}</AppText>}
+                    {logFood.error && (
+                        <AppText accessibilityLiveRegion="assertive" accessibilityRole="alert" style={styles.error}>
+                            {logFood.error.message}
+                        </AppText>
+                    )}
                     <AppButton
+                        accessibilityRole="button"
+                        accessibilityHint="Adds the matched food to the selected day and meal."
                         title={logFood.isPending ? 'Logging...' : `Log to ${selectedDate}`}
-                        disabled={!first || logFood.isPending}
+                        disabled={!first || lookupStatus !== 'result' || logFood.isPending}
                         leftIcon={<Ionicons name="add" size={18} color="#ffffff" />}
                         onPress={() => {
                             if (first) logFood.mutate(first);
                         }}
                     />
+                    {(lookupStatus === 'no-result' || lookupStatus === 'error') && barcode && (
+                        <AppButton
+                            accessibilityRole="button"
+                            accessibilityHint="Repeats the provider lookup for the scanned barcode."
+                            title="Try lookup again"
+                            variant="secondary"
+                            leftIcon={<Ionicons name="cloud-download-outline" size={18} color={colors.text} />}
+                            onPress={retryLookup}
+                        />
+                    )}
                     <View style={styles.actions}>
                         <AppButton
+                            accessibilityRole="button"
+                            accessibilityHint="Clears this result and re-enables the camera scanner."
                             title="Scan again"
                             variant="secondary"
                             leftIcon={<Ionicons name="refresh-outline" size={18} color={colors.text} />}
-                            onPress={() => {
-                                setBarcode(null);
-                                lookup.reset();
-                            }}
+                            onPress={resetScanner}
                             style={styles.actionButton}
                         />
                         <AppButton
+                            accessibilityRole="button"
                             title="Back to log"
                             leftIcon={<Ionicons name="arrow-back" size={18} color="#ffffff" />}
                             onPress={() => router.back()}
@@ -228,5 +390,12 @@ const styles = StyleSheet.create({
     },
     error: {
         color: colors.danger
+    },
+    permissionMessage: {
+        color: colors.muted
+    },
+    attributionLink: {
+        color: colors.primary,
+        textDecorationLine: 'underline'
     }
 });

--- a/mobile/app/my-foods.tsx
+++ b/mobile/app/my-foods.tsx
@@ -14,6 +14,7 @@ import { SectionHeader } from '../src/components/SectionHeader';
 import { TextField } from '../src/components/TextField';
 import { useAuth } from '../src/auth/AuthContext';
 import { formatCalories } from '../src/utils/format';
+import { sortMyFoodsPinnedFirst } from '../src/utils/myFoods';
 import { colors, radius, spacing } from '../src/theme';
 
 type RecipeIngredientDraft = {
@@ -86,6 +87,18 @@ export default function MyFoodsScreen() {
         }
     });
 
+    const setPinned = useMutation({
+        mutationFn: (item: MyFoodSummary) => api.setMyFoodPinned(item.id, !item.is_pinned),
+        onSuccess: (updated) => {
+            queryClient.setQueryData<MyFoodSummary[]>(['mobile-my-foods'], (current = []) =>
+                sortMyFoodsPinnedFirst(current.map((item) => item.id === updated.id ? updated : item))
+            );
+        },
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey: ['mobile-my-foods'] });
+        }
+    });
+
     const canCreateFood = foodName.trim().length > 0 &&
         Number(servingQuantity) > 0 &&
         servingUnit.trim().length > 0 &&
@@ -147,14 +160,30 @@ export default function MyFoodsScreen() {
                                     {formatCalories(item.calories_per_serving)} per {item.serving_size_quantity} {item.serving_unit_label}
                                 </AppText>
                             </View>
-                            <View style={styles.typePill}>
-                                <AppText style={styles.typeText}>{item.type === 'RECIPE' ? 'Recipe' : 'Food'}</AppText>
+                            <View style={styles.libraryActions}>
+                                <Pressable
+                                    accessibilityRole="button"
+                                    accessibilityLabel={`${item.is_pinned ? 'Unpin' : 'Pin'} ${item.name}`}
+                                    disabled={setPinned.isPending && setPinned.variables?.id === item.id}
+                                    onPress={() => setPinned.mutate(item)}
+                                    style={({ pressed }) => [styles.pinButton, pressed && styles.pressed]}
+                                >
+                                    <Ionicons
+                                        name={item.is_pinned ? 'star' : 'star-outline'}
+                                        size={19}
+                                        color={item.is_pinned ? colors.primary : colors.muted}
+                                    />
+                                </Pressable>
+                                <View style={styles.typePill}>
+                                    <AppText style={styles.typeText}>{item.type === 'RECIPE' ? 'Recipe' : 'Food'}</AppText>
+                                </View>
                             </View>
                         </View>
                     ))}
                     {myFoodsQuery.isLoading && <AppText variant="muted">Loading saved foods...</AppText>}
                     {!myFoodsQuery.isLoading && allFoods.length === 0 && <AppText variant="muted">No saved foods yet.</AppText>}
                     {myFoodsQuery.error && <AppText style={styles.error}>{myFoodsQuery.error.message}</AppText>}
+                    {setPinned.error && <AppText style={styles.error}>{setPinned.error.message}</AppText>}
                 </View>
             </AppCard>
 
@@ -310,6 +339,19 @@ const styles = StyleSheet.create({
         flex: 1,
         minWidth: 0,
         gap: spacing.xs
+    },
+    libraryActions: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.sm
+    },
+    pinButton: {
+        width: 38,
+        height: 38,
+        borderRadius: radius.md,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors.surfaceAlt
     },
     typePill: {
         borderRadius: radius.pill,

--- a/mobile/app/my-foods.tsx
+++ b/mobile/app/my-foods.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Alert, Pressable, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { MyFoodSummary } from '@calibrate/api-client';
@@ -15,12 +15,12 @@ import { TextField } from '../src/components/TextField';
 import { useAuth } from '../src/auth/AuthContext';
 import { formatCalories } from '../src/utils/format';
 import { sortMyFoodsPinnedFirst } from '../src/utils/myFoods';
+import {
+    hydrateRecipeIngredientDrafts,
+    serializeRecipeIngredientDrafts,
+    type RecipeIngredientDraft
+} from '../src/utils/myFoodEditing';
 import { colors, radius, spacing } from '../src/theme';
-
-type RecipeIngredientDraft = {
-    myFood: MyFoodSummary;
-    servings: number;
-};
 
 type MyFoodSheet = 'food' | 'recipe' | null;
 
@@ -32,12 +32,15 @@ export default function MyFoodsScreen() {
     const queryClient = useQueryClient();
     const myFoodsQuery = useQuery({ queryKey: ['mobile-my-foods'], queryFn: () => api.getMyFoods() });
     const [activeSheet, setActiveSheet] = useState<MyFoodSheet>(null);
+    const [editingItem, setEditingItem] = useState<MyFoodSummary | null>(null);
     const [foodName, setFoodName] = useState('');
     const [servingQuantity, setServingQuantity] = useState('1');
     const [servingUnit, setServingUnit] = useState('serving');
     const [caloriesPerServing, setCaloriesPerServing] = useState('');
     const [recipeName, setRecipeName] = useState('');
     const [recipeYield, setRecipeYield] = useState('1');
+    const [recipeServingQuantity, setRecipeServingQuantity] = useState('1');
+    const [recipeServingUnit, setRecipeServingUnit] = useState('serving');
     const [recipeIngredients, setRecipeIngredients] = useState<RecipeIngredientDraft[]>([]);
 
     const allFoods = myFoodsQuery.data ?? [];
@@ -46,43 +49,64 @@ export default function MyFoodsScreen() {
         [allFoods]
     );
 
-    const createFood = useMutation({
+    const saveFood = useMutation({
         mutationFn: () =>
-            api.createMyFood({
+            (editingItem ? api.updateMyFood(editingItem.id, {
                 name: foodName.trim(),
                 serving_size_quantity: Number(servingQuantity),
                 serving_unit_label: servingUnit.trim(),
                 calories_per_serving: Number(caloriesPerServing)
-            }),
+            }) : api.createMyFood({
+                name: foodName.trim(),
+                serving_size_quantity: Number(servingQuantity),
+                serving_unit_label: servingUnit.trim(),
+                calories_per_serving: Number(caloriesPerServing)
+            })),
         onSuccess: async () => {
-            setFoodName('');
-            setServingQuantity('1');
-            setServingUnit('serving');
-            setCaloriesPerServing('');
-            setActiveSheet(null);
+            closeEditor();
             await queryClient.invalidateQueries({ queryKey: ['mobile-my-foods'] });
         }
     });
 
-    const createRecipe = useMutation({
+    const saveRecipe = useMutation({
         mutationFn: () =>
-            api.createRecipe({
+            (editingItem ? api.updateMyFood(editingItem.id, {
                 name: recipeName.trim(),
-                serving_size_quantity: 1,
-                serving_unit_label: 'serving',
+                serving_size_quantity: Number(recipeServingQuantity),
+                serving_unit_label: recipeServingUnit.trim(),
                 yield_servings: Number(recipeYield),
-                ingredients: recipeIngredients.map((ingredient, index) => ({
-                    source: 'MY_FOOD',
-                    sort_order: index + 1,
-                    my_food_id: ingredient.myFood.id,
-                    quantity_servings: ingredient.servings
-                }))
-            }),
+                ingredients: serializeRecipeIngredientDrafts(recipeIngredients)
+            }) : api.createRecipe({
+                name: recipeName.trim(),
+                serving_size_quantity: Number(recipeServingQuantity),
+                serving_unit_label: recipeServingUnit.trim(),
+                yield_servings: Number(recipeYield),
+                ingredients: serializeRecipeIngredientDrafts(recipeIngredients)
+            })),
         onSuccess: async () => {
-            setRecipeName('');
-            setRecipeYield('1');
-            setRecipeIngredients([]);
-            setActiveSheet(null);
+            closeEditor();
+            await queryClient.invalidateQueries({ queryKey: ['mobile-my-foods'] });
+        }
+    });
+
+    const loadRecipe = useMutation({
+        mutationFn: (item: MyFoodSummary) => api.getMyFood(item.id),
+        onSuccess: (detail) => {
+            setRecipeName(detail.name);
+            setRecipeServingQuantity(String(detail.serving_size_quantity));
+            setRecipeServingUnit(detail.serving_unit_label);
+            setRecipeYield(String(detail.yield_servings ?? 1));
+            setRecipeIngredients(hydrateRecipeIngredientDrafts(detail, savedFoods));
+        }
+    });
+
+    const deleteItem = useMutation({
+        mutationFn: (item: MyFoodSummary) => api.deleteMyFood(item.id),
+        onSuccess: async (_result, item) => {
+            queryClient.setQueryData<MyFoodSummary[]>(['mobile-my-foods'], (current = []) =>
+                current.filter(({ id }) => id !== item.id)
+            );
+            closeEditor();
             await queryClient.invalidateQueries({ queryKey: ['mobile-my-foods'] });
         }
     });
@@ -99,20 +123,78 @@ export default function MyFoodsScreen() {
         }
     });
 
-    const canCreateFood = foodName.trim().length > 0 &&
+    const canSaveFood = foodName.trim().length > 0 &&
         Number(servingQuantity) > 0 &&
         servingUnit.trim().length > 0 &&
         Number(caloriesPerServing) >= 0;
-    const canCreateRecipe = recipeName.trim().length > 0 && Number(recipeYield) > 0 && recipeIngredients.length > 0;
+    const canSaveRecipe = recipeName.trim().length > 0 &&
+        Number(recipeServingQuantity) > 0 &&
+        recipeServingUnit.trim().length > 0 &&
+        Number(recipeYield) > 0 &&
+        recipeIngredients.length > 0;
+
+    function closeEditor() {
+        setActiveSheet(null);
+        setEditingItem(null);
+        setFoodName('');
+        setServingQuantity('1');
+        setServingUnit('serving');
+        setCaloriesPerServing('');
+        setRecipeName('');
+        setRecipeServingQuantity('1');
+        setRecipeServingUnit('serving');
+        setRecipeYield('1');
+        setRecipeIngredients([]);
+        saveFood.reset();
+        saveRecipe.reset();
+        loadRecipe.reset();
+    }
+
+    function openNew(sheet: Exclude<MyFoodSheet, null>) {
+        closeEditor();
+        setActiveSheet(sheet);
+    }
+
+    function openEditor(item: MyFoodSummary) {
+        closeEditor();
+        setEditingItem(item);
+        setActiveSheet(item.type === 'FOOD' ? 'food' : 'recipe');
+        if (item.type === 'FOOD') {
+            setFoodName(item.name);
+            setServingQuantity(String(item.serving_size_quantity));
+            setServingUnit(item.serving_unit_label);
+            setCaloriesPerServing(String(item.calories_per_serving));
+        } else {
+            loadRecipe.mutate(item);
+        }
+    }
+
+    function confirmDelete() {
+        if (!editingItem) return;
+        Alert.alert(
+            `Delete ${editingItem.name}?`,
+            'Past food logs keep their saved names, calories, and serving snapshots. This library item cannot be restored.',
+            [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'Delete', style: 'destructive', onPress: () => deleteItem.mutate(editingItem) }
+            ]
+        );
+    }
 
     function addRecipeIngredient(myFood: MyFoodSummary) {
-        setRecipeIngredients((current) => [...current, { myFood, servings: 1 }]);
+        setRecipeIngredients((current) => [...current, {
+            key: `new-${myFood.id}-${Date.now()}-${current.length}`,
+            source: 'MY_FOOD',
+            myFood,
+            servings: 1
+        }]);
     }
 
     function adjustRecipeIngredientServings(index: number, delta: number) {
         setRecipeIngredients((current) =>
             current.map((ingredient, currentIndex) => {
                 if (currentIndex !== index) return ingredient;
+                if (ingredient.source !== 'MY_FOOD') return ingredient;
                 return {
                     ...ingredient,
                     servings: Math.max(SERVING_STEP, Math.round((ingredient.servings + delta) * 10) / 10)
@@ -135,7 +217,7 @@ export default function MyFoodsScreen() {
                         <Pressable
                             accessibilityRole="button"
                             accessibilityLabel="Create saved food"
-                            onPress={() => setActiveSheet('food')}
+                            onPress={() => openNew('food')}
                             style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
                         >
                             <Ionicons name="add" size={20} color={colors.primaryDark} />
@@ -143,7 +225,7 @@ export default function MyFoodsScreen() {
                         <Pressable
                             accessibilityRole="button"
                             accessibilityLabel="Create recipe"
-                            onPress={() => setActiveSheet('recipe')}
+                            onPress={() => openNew('recipe')}
                             style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
                         >
                             <Ionicons name="restaurant-outline" size={20} color={colors.primaryDark} />
@@ -161,6 +243,14 @@ export default function MyFoodsScreen() {
                                 </AppText>
                             </View>
                             <View style={styles.libraryActions}>
+                                <Pressable
+                                    accessibilityRole="button"
+                                    accessibilityLabel={`Edit ${item.name}`}
+                                    onPress={() => openEditor(item)}
+                                    style={({ pressed }) => [styles.pinButton, pressed && styles.pressed]}
+                                >
+                                    <Ionicons name="create-outline" size={19} color={colors.text} />
+                                </Pressable>
                                 <Pressable
                                     accessibilityRole="button"
                                     accessibilityLabel={`${item.is_pinned ? 'Unpin' : 'Pin'} ${item.name}`}
@@ -187,8 +277,11 @@ export default function MyFoodsScreen() {
                 </View>
             </AppCard>
 
-            <BottomSheetModal visible={activeSheet === 'food'} onRequestClose={() => setActiveSheet(null)}>
-                <SectionHeader title="New food" description="Create a reusable food with calories per serving." />
+            <BottomSheetModal visible={activeSheet === 'food'} onRequestClose={closeEditor}>
+                <SectionHeader
+                    title={editingItem ? 'Edit food' : 'New food'}
+                    description="Saved food edits do not rewrite existing food logs."
+                />
                 <TextField label="Name" value={foodName} onChangeText={setFoodName} />
                 <View style={styles.row}>
                     <NumberStepperField
@@ -209,29 +302,60 @@ export default function MyFoodsScreen() {
                     min={0}
                     suffix="kcal"
                 />
-                {createFood.error && <AppText style={styles.error}>{createFood.error.message}</AppText>}
+                {saveFood.error && <AppText style={styles.error}>{saveFood.error.message}</AppText>}
+                {deleteItem.error && <AppText style={styles.error}>{deleteItem.error.message}</AppText>}
+                {editingItem && (
+                    <AppButton
+                        title={deleteItem.isPending ? 'Deleting...' : 'Delete food'}
+                        variant="danger"
+                        disabled={deleteItem.isPending || saveFood.isPending}
+                        leftIcon={<Ionicons name="trash-outline" size={18} color="#ffffff" />}
+                        onPress={confirmDelete}
+                    />
+                )}
                 <View style={styles.row}>
                     <AppButton
                         title="Cancel"
                         variant="secondary"
                         leftIcon={<Ionicons name="close" size={18} color={colors.text} />}
-                        onPress={() => setActiveSheet(null)}
+                        onPress={closeEditor}
                         style={styles.field}
                     />
                     <AppButton
-                        title={createFood.isPending ? 'Saving...' : 'Save food'}
-                        disabled={!canCreateFood || createFood.isPending}
+                        title={saveFood.isPending ? 'Saving...' : 'Save food'}
+                        disabled={!canSaveFood || saveFood.isPending || deleteItem.isPending}
                         leftIcon={<Ionicons name="checkmark" size={18} color="#ffffff" />}
-                        onPress={() => createFood.mutate()}
+                        onPress={() => saveFood.mutate()}
                         style={styles.field}
                     />
                 </View>
             </BottomSheetModal>
 
-            <BottomSheetModal visible={activeSheet === 'recipe'} onRequestClose={() => setActiveSheet(null)}>
-                <SectionHeader title="Recipe builder" description="Combine saved foods into a reusable recipe." />
+            <BottomSheetModal visible={activeSheet === 'recipe'} onRequestClose={closeEditor}>
+                <SectionHeader
+                    title={editingItem ? 'Edit recipe' : 'Recipe builder'}
+                    description="Recipe edits create new ingredient snapshots without changing past logs."
+                />
                 <TextField label="Recipe name" value={recipeName} onChangeText={setRecipeName} />
+                <View style={styles.row}>
+                    <NumberStepperField
+                        label="Serving"
+                        value={recipeServingQuantity}
+                        onChangeText={setRecipeServingQuantity}
+                        step={SERVING_STEP}
+                        min={SERVING_STEP}
+                        containerStyle={styles.field}
+                    />
+                    <TextField
+                        label="Unit"
+                        value={recipeServingUnit}
+                        onChangeText={setRecipeServingUnit}
+                        containerStyle={styles.field}
+                    />
+                </View>
                 <NumberStepperField label="Yield servings" value={recipeYield} onChangeText={setRecipeYield} step={1} min={1} />
+                {loadRecipe.isPending && <AppText variant="muted">Loading recipe snapshots...</AppText>}
+                {loadRecipe.error && <AppText style={styles.error}>{loadRecipe.error.message}</AppText>}
                 <AppText variant="label">Ingredients</AppText>
                 <View style={styles.chips}>
                     {savedFoods.slice(0, 12).map((item) => (
@@ -240,12 +364,18 @@ export default function MyFoodsScreen() {
                 </View>
                 {savedFoods.length === 0 && <AppText variant="muted">Create a saved food first, then add it to a recipe.</AppText>}
                 {recipeIngredients.map((ingredient, index) => (
-                    <View key={`${ingredient.myFood.id}-${index}`} style={styles.ingredientRow}>
+                    <View key={ingredient.key} style={styles.ingredientRow}>
                         <View style={styles.libraryText}>
-                            <AppText variant="body" numberOfLines={1}>{ingredient.myFood.name}</AppText>
-                            <AppText variant="caption">{formatCalories(ingredient.myFood.calories_per_serving * ingredient.servings)}</AppText>
+                            <AppText variant="body" numberOfLines={1}>
+                                {ingredient.source === 'MY_FOOD' ? ingredient.myFood.name : ingredient.name}
+                            </AppText>
+                            <AppText variant="caption">
+                                {formatCalories(ingredient.source === 'MY_FOOD'
+                                    ? ingredient.myFood.calories_per_serving * ingredient.servings
+                                    : ingredient.caloriesTotal)}
+                            </AppText>
                         </View>
-                        <View style={styles.stepper}>
+                        {ingredient.source === 'MY_FOOD' && <View style={styles.stepper}>
                             <Pressable
                                 accessibilityRole="button"
                                 accessibilityLabel={`Decrease ${ingredient.myFood.name} servings`}
@@ -263,10 +393,10 @@ export default function MyFoodsScreen() {
                             >
                                 <Ionicons name="add" size={16} color={colors.text} />
                             </Pressable>
-                        </View>
+                        </View>}
                         <Pressable
                             accessibilityRole="button"
-                            accessibilityLabel={`Remove ${ingredient.myFood.name}`}
+                            accessibilityLabel={`Remove ${ingredient.source === 'MY_FOOD' ? ingredient.myFood.name : ingredient.name}`}
                             onPress={() => setRecipeIngredients((current) => current.filter((_, currentIndex) => currentIndex !== index))}
                             style={({ pressed }) => [styles.removeButton, pressed && styles.pressed]}
                         >
@@ -274,20 +404,30 @@ export default function MyFoodsScreen() {
                         </Pressable>
                     </View>
                 ))}
-                {createRecipe.error && <AppText style={styles.error}>{createRecipe.error.message}</AppText>}
+                {saveRecipe.error && <AppText style={styles.error}>{saveRecipe.error.message}</AppText>}
+                {deleteItem.error && <AppText style={styles.error}>{deleteItem.error.message}</AppText>}
+                {editingItem && (
+                    <AppButton
+                        title={deleteItem.isPending ? 'Deleting...' : 'Delete recipe'}
+                        variant="danger"
+                        disabled={deleteItem.isPending || saveRecipe.isPending}
+                        leftIcon={<Ionicons name="trash-outline" size={18} color="#ffffff" />}
+                        onPress={confirmDelete}
+                    />
+                )}
                 <View style={styles.row}>
                     <AppButton
                         title="Cancel"
                         variant="secondary"
                         leftIcon={<Ionicons name="close" size={18} color={colors.text} />}
-                        onPress={() => setActiveSheet(null)}
+                        onPress={closeEditor}
                         style={styles.field}
                     />
                     <AppButton
-                        title={createRecipe.isPending ? 'Saving...' : 'Save recipe'}
-                        disabled={!canCreateRecipe || createRecipe.isPending}
+                        title={saveRecipe.isPending ? 'Saving...' : 'Save recipe'}
+                        disabled={!canSaveRecipe || saveRecipe.isPending || deleteItem.isPending || loadRecipe.isPending}
                         leftIcon={<Ionicons name="checkmark" size={18} color="#ffffff" />}
-                        onPress={() => createRecipe.mutate()}
+                        onPress={() => saveRecipe.mutate()}
                         style={styles.field}
                     />
                 </View>

--- a/mobile/app/notifications.tsx
+++ b/mobile/app/notifications.tsx
@@ -12,25 +12,8 @@ import { Screen } from '../src/components/Screen';
 import { SectionHeader } from '../src/components/SectionHeader';
 import { SkeletonBlock } from '../src/components/SkeletonBlock';
 import { useAuth } from '../src/auth/AuthContext';
+import { getNotificationAction } from '../src/notifications/workflow';
 import { colors, radius, spacing } from '../src/theme';
-
-type NotificationAction = {
-    label: string;
-    href: Href;
-};
-
-function getNotificationAction(notification: InAppNotification): NotificationAction {
-    if (notification.action_url.includes('weight')) {
-        return { label: 'Log weight', href: { pathname: '/(tabs)/weight', params: { date: notification.local_date } } };
-    }
-    if (notification.action_url.includes('goal')) {
-        return { label: 'Open goals', href: '/(tabs)/progress' };
-    }
-    if (notification.action_url.includes('log') || notification.action_url.includes('food')) {
-        return { label: 'Log food', href: { pathname: '/(tabs)/log', params: { date: notification.local_date } } };
-    }
-    return { label: 'Open log', href: '/(tabs)/today' };
-}
 
 function getNotificationText(notification: InAppNotification): { title: string; body: string } {
     const title = notification.title?.trim();
@@ -80,7 +63,7 @@ export default function NotificationsScreen() {
         mutationFn: (notification: InAppNotification) => api.markInAppNotificationRead(notification.id).then(() => notification),
         onSuccess: async (notification) => {
             await queryClient.invalidateQueries({ queryKey: ['mobile-in-app-notifications'] });
-            router.push(getNotificationAction(notification).href);
+            router.push(getNotificationAction(notification.action_url, notification.local_date).href as Href);
         }
     });
 
@@ -119,7 +102,7 @@ export default function NotificationsScreen() {
             )}
 
             {notifications.map((notification) => {
-                const action = getNotificationAction(notification);
+                const action = getNotificationAction(notification.action_url, notification.local_date);
                 const text = getNotificationText(notification);
                 const isUnread = !notification.read_at;
 
@@ -147,6 +130,7 @@ export default function NotificationsScreen() {
                         <View style={styles.actions}>
                             <AppButton
                                 title={action.label}
+                                accessibilityHint="Marks this reminder read and opens its Calibrate destination."
                                 leftIcon={<Ionicons name="open-outline" size={18} color="#ffffff" />}
                                 onPress={() => markRead.mutate(notification)}
                                 style={styles.actionButton}
@@ -170,7 +154,21 @@ export default function NotificationsScreen() {
                 </AppCard>
             )}
 
-            {notificationsQuery.error && <AppText style={styles.error}>{notificationsQuery.error.message}</AppText>}
+            {(notificationsQuery.error || markRead.error || dismissNotification.error) && (
+                <AppCard>
+                    <AppText accessibilityLiveRegion="assertive" accessibilityRole="alert" style={styles.error}>
+                        {notificationsQuery.error?.message ?? markRead.error?.message ?? dismissNotification.error?.message}
+                    </AppText>
+                    {notificationsQuery.error && (
+                        <AppButton
+                            title="Try notifications again"
+                            variant="secondary"
+                            accessibilityHint="Reloads the notification list from your Calibrate server."
+                            onPress={() => void notificationsQuery.refetch()}
+                        />
+                    )}
+                </AppCard>
+            )}
         </Screen>
     );
 }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "internal": {
+      "distribution": "internal",
+      "environment": "preview",
+      "credentialsSource": "remote",
+      "node": "22.14.0",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "environment": "production",
+      "credentialsSource": "remote",
+      "node": "22.14.0",
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/mobile/src/auth/AuthContext.tsx
+++ b/mobile/src/auth/AuthContext.tsx
@@ -3,7 +3,15 @@ import { ApiError, CalibrateApiClient, type UserClientPayload } from '@calibrate
 import { MOBILE_DEVICE_PLATFORMS } from '@calibrate/shared';
 import * as Application from 'expo-application';
 import { useQueryClient } from '@tanstack/react-query';
-import { normalizeServerUrl } from '../config/server';
+import {
+    INITIAL_SERVER_CONNECTION_STATE,
+    normalizeServerUrl,
+    testCalibrateServerConnection,
+    type ServerConnectionResult,
+    type ServerConnectionState
+} from '../config/server';
+import { confirmServerSwitch } from './serverSwitch';
+import { getSessionRestoreErrorMessage } from './authErrors';
 import {
     clearStoredTokens,
     getOrCreateDeviceId,
@@ -22,8 +30,10 @@ type AuthContextValue = {
     serverUrl: string;
     isLoading: boolean;
     authError: string | null;
+    serverConnection: ServerConnectionState;
     updateCurrentUser: (user: UserClientPayload) => void;
     setServerUrl: (value: string) => Promise<boolean>;
+    testServerUrl: (value: string) => Promise<boolean>;
     login: (email: string, password: string) => Promise<void>;
     register: (email: string, password: string) => Promise<void>;
     logout: () => Promise<void>;
@@ -74,8 +84,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const [deviceId, setDeviceId] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [authError, setAuthError] = useState<string | null>(null);
+    const [serverConnection, setServerConnection] = useState<ServerConnectionState>(INITIAL_SERVER_CONNECTION_STATE);
     const accessTokenRef = useRef<string | null>(null);
     const refreshTokenRef = useRef<string | null>(null);
+    const serverTestRequestRef = useRef(0);
 
     const clearSession = useCallback(async () => {
         setUser(null);
@@ -191,7 +203,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
                 }
             } catch (error) {
                 if (isMounted) {
-                    setAuthError(error instanceof Error ? error.message : 'Unable to restore session.');
+                    setAuthError(getSessionRestoreErrorMessage(error));
                     // Only a rejected refresh invalidates stored credentials; offline startup should be retryable.
                     if (error instanceof ApiError && error.status === 401) {
                         await clearSession();
@@ -211,22 +223,54 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         };
     }, [clearSession, loginDevTestUser, persistAuthPayload]);
 
-    const updateServerUrl = useCallback(async (value: string): Promise<boolean> => {
+    const probeServerUrl = useCallback(async (value: string): Promise<ServerConnectionResult> => {
+        const requestId = serverTestRequestRef.current + 1;
+        serverTestRequestRef.current = requestId;
         const normalized = normalizeServerUrl(value);
-        if (!normalized) {
-            setAuthError('Enter a valid http or https server URL.');
+        setServerConnection({
+            status: 'testing',
+            testedInput: value.trim(),
+            testedUrl: normalized,
+            message: 'Testing this Calibrate server...'
+        });
+
+        const result = await testCalibrateServerConnection(value, {
+            mobileVersion: Application.nativeApplicationVersion
+        });
+        if (serverTestRequestRef.current === requestId) {
+            setServerConnection({
+                status: result.ok ? 'connected' : 'error',
+                testedInput: value.trim(),
+                testedUrl: result.url,
+                message: result.message
+            });
+        }
+        return result;
+    }, []);
+
+    const testServerUrl = useCallback(async (value: string): Promise<boolean> => {
+        const result = await probeServerUrl(value);
+        if (result.ok) setAuthError(null);
+        return result.ok;
+    }, [probeServerUrl]);
+
+    const updateServerUrl = useCallback(async (value: string): Promise<boolean> => {
+        const result = await confirmServerSwitch({
+            candidate: value,
+            currentServerUrl: serverUrl,
+            testConnection: probeServerUrl,
+            clearCurrentSession: clearSession,
+            persistServerUrl: writeServerUrl
+        });
+        if (!result.ok) {
+            setAuthError(result.message);
             return false;
         }
 
-        if (normalized !== serverUrl) {
-            // Credentials are scoped to one self-hosted server and must never follow a server switch.
-            await clearSession();
-        }
-        setServerUrlState(normalized);
-        await writeServerUrl(normalized);
+        setServerUrlState(result.url);
         setAuthError(null);
         return true;
-    }, [clearSession, serverUrl]);
+    }, [clearSession, probeServerUrl, serverUrl]);
 
     const updateCurrentUser = useCallback((nextUser: UserClientPayload) => {
         setUser(nextUser);
@@ -282,14 +326,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             serverUrl,
             isLoading,
             authError,
+            serverConnection,
             updateCurrentUser,
             setServerUrl: updateServerUrl,
+            testServerUrl,
             login,
             register,
             logout,
             clearLocalSession: clearSession
         }),
-        [accessToken, api, authError, clearSession, deviceId, isLoading, login, logout, refreshToken, register, serverUrl, updateCurrentUser, updateServerUrl, user]
+        [accessToken, api, authError, clearSession, deviceId, isLoading, login, logout, refreshToken, register, serverConnection, serverUrl, testServerUrl, updateCurrentUser, updateServerUrl, user]
     );
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/mobile/src/auth/authErrors.test.ts
+++ b/mobile/src/auth/authErrors.test.ts
@@ -1,0 +1,16 @@
+import { ApiError } from '@calibrate/api-client';
+import { getSessionRestoreErrorMessage } from './authErrors';
+
+describe('session restore error copy', () => {
+    it('distinguishes an expired session from a temporarily unavailable server', () => {
+        expect(getSessionRestoreErrorMessage(new ApiError('unauthorized', 401, null)))
+            .toBe('Your saved session expired. Sign in again.');
+        expect(getSessionRestoreErrorMessage(new TypeError('Network request failed')))
+            .toContain('your session is still stored');
+    });
+
+    it('does not expose arbitrary implementation errors', () => {
+        expect(getSessionRestoreErrorMessage(new Error('postgres password was bad')))
+            .toBe('Unable to restore your saved session. Test the server connection or sign in again.');
+    });
+});

--- a/mobile/src/auth/authErrors.ts
+++ b/mobile/src/auth/authErrors.ts
@@ -1,0 +1,15 @@
+import { ApiError } from '@calibrate/api-client';
+
+/** Turn startup refresh failures into next-step guidance without exposing raw transport errors. */
+export function getSessionRestoreErrorMessage(error: unknown): string {
+    if (error instanceof ApiError && error.status === 401) {
+        return 'Your saved session expired. Sign in again.';
+    }
+    if (
+        error instanceof TypeError
+        || (error instanceof Error && /network|fetch|timed out|connect|offline/i.test(error.message))
+    ) {
+        return 'Could not reach your saved Calibrate server. Check the server connection; your session is still stored.';
+    }
+    return 'Unable to restore your saved session. Test the server connection or sign in again.';
+}

--- a/mobile/src/auth/serverSwitch.test.ts
+++ b/mobile/src/auth/serverSwitch.test.ts
@@ -1,0 +1,84 @@
+import { confirmServerSwitch } from './serverSwitch';
+import type { ServerConnectionResult } from '../config/server';
+
+const failedConnection: ServerConnectionResult = {
+    ok: false,
+    url: 'https://new.example',
+    code: 'unreachable',
+    message: 'Could not connect.'
+};
+
+const successfulConnection: ServerConnectionResult = {
+    ok: true,
+    url: 'https://new.example',
+    message: 'Connected.',
+    config: {
+        api_version: 1,
+        api_versions: {
+            current: 'v1',
+            supported: ['v1'],
+            legacy_alias: '/api',
+            legacy_deprecation: 'none'
+        },
+        server_version: '1.0.0',
+        hosted_origin: 'https://new.example',
+        min_supported_mobile_version: '0.1.0',
+        capabilities: {
+            self_hosted_server_url: true,
+            native_push: true,
+            wear_os_ready: false
+        }
+    }
+};
+
+describe('confirmServerSwitch', () => {
+    it('preserves a working session and persisted URL when confirmation fails', async () => {
+        const clearCurrentSession = jest.fn(async () => undefined);
+        const persistServerUrl = jest.fn(async () => undefined);
+
+        const result = await confirmServerSwitch({
+            candidate: 'https://new.example',
+            currentServerUrl: 'https://working.example',
+            testConnection: async () => failedConnection,
+            clearCurrentSession,
+            persistServerUrl
+        });
+
+        expect(result).toBe(failedConnection);
+        expect(clearCurrentSession).not.toHaveBeenCalled();
+        expect(persistServerUrl).not.toHaveBeenCalled();
+    });
+
+    it('clears server-scoped credentials only after successful confirmation', async () => {
+        const events: string[] = [];
+
+        await confirmServerSwitch({
+            candidate: 'https://new.example',
+            currentServerUrl: 'https://working.example',
+            testConnection: async () => {
+                events.push('confirmed');
+                return successfulConnection;
+            },
+            clearCurrentSession: async () => { events.push('cleared'); },
+            persistServerUrl: async () => { events.push('persisted'); }
+        });
+
+        expect(events).toEqual(['confirmed', 'cleared', 'persisted']);
+    });
+
+    it('keeps the current session when re-confirming the same normalized server', async () => {
+        const clearCurrentSession = jest.fn(async () => undefined);
+        const persistServerUrl = jest.fn(async () => undefined);
+
+        await confirmServerSwitch({
+            candidate: 'https://new.example',
+            currentServerUrl: 'https://new.example',
+            testConnection: async () => successfulConnection,
+            clearCurrentSession,
+            persistServerUrl
+        });
+
+        expect(clearCurrentSession).not.toHaveBeenCalled();
+        expect(persistServerUrl).toHaveBeenCalledWith('https://new.example');
+    });
+});

--- a/mobile/src/auth/serverSwitch.ts
+++ b/mobile/src/auth/serverSwitch.ts
@@ -1,0 +1,25 @@
+import type { ServerConnectionResult } from '../config/server';
+
+type ConfirmServerSwitchOptions = {
+    candidate: string;
+    currentServerUrl: string;
+    testConnection: (candidate: string) => Promise<ServerConnectionResult>;
+    clearCurrentSession: () => Promise<void>;
+    persistServerUrl: (serverUrl: string) => Promise<void>;
+};
+
+/**
+ * Confirm the candidate before mutating server-scoped credentials or persisted settings.
+ *
+ * This ordering is the safety invariant for switching away from a working self-hosted instance.
+ */
+export async function confirmServerSwitch(options: ConfirmServerSwitchOptions): Promise<ServerConnectionResult> {
+    const connection = await options.testConnection(options.candidate);
+    if (!connection.ok) return connection;
+
+    if (connection.url !== options.currentServerUrl) {
+        await options.clearCurrentSession();
+    }
+    await options.persistServerUrl(connection.url);
+    return connection;
+}

--- a/mobile/src/barcode/workflow.test.ts
+++ b/mobile/src/barcode/workflow.test.ts
@@ -1,0 +1,71 @@
+import {
+    BarcodeScanGate,
+    getBarcodeLookupErrorMessage,
+    getBarcodeLookupStatus,
+    getCameraPermissionState,
+    getProviderAttribution,
+    normalizeBarcode
+} from './workflow';
+
+describe('barcode workflow', () => {
+    it('routes denied permissions to retry or Android settings based on canAskAgain', () => {
+        expect(getCameraPermissionState(null)).toBe('checking');
+        expect(getCameraPermissionState({ granted: true, canAskAgain: true })).toBe('granted');
+        expect(getCameraPermissionState({ granted: false, canAskAgain: true })).toBe('request');
+        expect(getCameraPermissionState({ granted: false, canAskAgain: false })).toBe('settings');
+    });
+
+    it('normalizes supported EAN/UPC values without dropping leading zeroes', () => {
+        expect(normalizeBarcode(' 012345678905 ')).toBe('012345678905');
+        expect(normalizeBarcode('12345670')).toBe('12345670');
+        expect(normalizeBarcode('12345')).toBeNull();
+        expect(normalizeBarcode('1234ABC89012')).toBeNull();
+        expect(normalizeBarcode(undefined)).toBeNull();
+    });
+
+    it('debounces duplicate callbacks synchronously and accepts the code again after rescan', () => {
+        let now = 100;
+        const gate = new BarcodeScanGate(() => now);
+
+        expect(gate.accept('012345678905')).toEqual({ kind: 'accepted', barcode: '012345678905' });
+        expect(gate.accept('012345678905')).toEqual({ kind: 'duplicate' });
+        now += 2_000;
+        expect(gate.accept('123456789012')).toEqual({ kind: 'duplicate' });
+
+        gate.reset();
+        expect(gate.accept('012345678905')).toEqual({ kind: 'accepted', barcode: '012345678905' });
+    });
+
+    it('rejects malformed events without permanently locking the scanner', () => {
+        let now = 100;
+        const gate = new BarcodeScanGate(() => now);
+
+        expect(gate.accept('not-a-barcode')).toMatchObject({ kind: 'invalid' });
+        expect(gate.accept('not-a-barcode')).toEqual({ kind: 'duplicate' });
+        now += 2_000;
+        expect(gate.accept('012345678905')).toEqual({ kind: 'accepted', barcode: '012345678905' });
+    });
+
+    it('distinguishes searching, no-result, provider failure, and result states', () => {
+        expect(getBarcodeLookupStatus({ hasBarcode: false, isPending: false, isSuccess: true, hasResult: false, hasError: false })).toBe('idle');
+        expect(getBarcodeLookupStatus({ hasBarcode: true, isPending: true, isSuccess: false, hasResult: false, hasError: false })).toBe('searching');
+        expect(getBarcodeLookupStatus({ hasBarcode: true, isPending: false, isSuccess: true, hasResult: false, hasError: false })).toBe('no-result');
+        expect(getBarcodeLookupStatus({ hasBarcode: true, isPending: false, isSuccess: false, hasResult: false, hasError: true })).toBe('error');
+        expect(getBarcodeLookupStatus({ hasBarcode: true, isPending: false, isSuccess: true, hasResult: true, hasError: false })).toBe('result');
+    });
+
+    it('turns provider and network failures into actionable messages', () => {
+        expect(getBarcodeLookupErrorMessage({ status: 503 })).toMatch(/providers are unavailable/i);
+        expect(getBarcodeLookupErrorMessage(new Error('Network request failed'))).toMatch(/Calibrate server/i);
+        expect(getBarcodeLookupErrorMessage(new Error('unexpected'))).toMatch(/scan a different barcode/i);
+    });
+
+    it('preserves exact FatSecret attribution and labels other providers', () => {
+        expect(getProviderAttribution('fatsecret')).toEqual({
+            text: 'Powered by fatsecret',
+            url: 'https://www.fatsecret.com'
+        });
+        expect(getProviderAttribution('openFoodFacts')).toEqual({ text: 'Data from Open Food Facts' });
+        expect(getProviderAttribution(undefined, 'Provider attribution')).toEqual({ text: 'Provider attribution' });
+    });
+});

--- a/mobile/src/barcode/workflow.ts
+++ b/mobile/src/barcode/workflow.ts
@@ -1,0 +1,132 @@
+const BARCODE_DUPLICATE_WINDOW_MS = 1_200;
+const SUPPORTED_BARCODE_LENGTHS = new Set([6, 7, 8, 12, 13]);
+const FATSECRET_URL = 'https://www.fatsecret.com';
+
+export type CameraPermissionState = 'checking' | 'granted' | 'request' | 'settings';
+
+export type BarcodeScanDecision =
+    | { kind: 'accepted'; barcode: string }
+    | { kind: 'duplicate' }
+    | { kind: 'invalid'; message: string };
+
+export type BarcodeLookupStatus = 'idle' | 'searching' | 'result' | 'no-result' | 'error';
+
+export type ProviderAttribution = {
+    text: string;
+    url?: string;
+};
+
+/** Decide whether Android can prompt again or must hand permission control to system settings. */
+export function getCameraPermissionState(
+    permission: { granted: boolean; canAskAgain: boolean } | null
+): CameraPermissionState {
+    if (!permission) return 'checking';
+    if (permission.granted) return 'granted';
+    return permission.canAskAgain ? 'request' : 'settings';
+}
+
+/** Normalize only the numeric lengths emitted by the configured EAN/UPC camera scanner. */
+export function normalizeBarcode(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    if (!/^\d+$/.test(normalized)) return null;
+    return SUPPORTED_BARCODE_LENGTHS.has(normalized.length) ? normalized : null;
+}
+
+/**
+ * Synchronously locks after an accepted scan so repeated native camera callbacks cannot launch
+ * duplicate provider requests before React has committed the next render.
+ */
+export class BarcodeScanGate {
+    private locked = false;
+    private lastRawValue: string | null = null;
+    private lastEventAt = Number.NEGATIVE_INFINITY;
+
+    constructor(
+        private readonly now: () => number = Date.now,
+        private readonly duplicateWindowMs = BARCODE_DUPLICATE_WINDOW_MS
+    ) {}
+
+    accept(rawValue: unknown): BarcodeScanDecision {
+        const comparableValue = typeof rawValue === 'string' ? rawValue.trim() : '';
+        const eventAt = this.now();
+        if (
+            comparableValue.length > 0 &&
+            comparableValue === this.lastRawValue &&
+            eventAt - this.lastEventAt < this.duplicateWindowMs
+        ) {
+            return { kind: 'duplicate' };
+        }
+
+        this.lastRawValue = comparableValue;
+        this.lastEventAt = eventAt;
+        if (this.locked) return { kind: 'duplicate' };
+
+        const barcode = normalizeBarcode(rawValue);
+        if (!barcode) {
+            return {
+                kind: 'invalid',
+                message: 'That barcode could not be read. Use a clear EAN or UPC barcode and try again.'
+            };
+        }
+
+        this.locked = true;
+        return { kind: 'accepted', barcode };
+    }
+
+    reset(): void {
+        this.locked = false;
+        this.lastRawValue = null;
+        this.lastEventAt = Number.NEGATIVE_INFINITY;
+    }
+}
+
+export function getBarcodeLookupStatus(options: {
+    hasBarcode: boolean;
+    isPending: boolean;
+    isSuccess: boolean;
+    hasResult: boolean;
+    hasError: boolean;
+}): BarcodeLookupStatus {
+    if (!options.hasBarcode) return 'idle';
+    if (options.isPending) return 'searching';
+    if (options.hasError) return 'error';
+    if (options.hasResult) return 'result';
+    if (options.isSuccess) return 'no-result';
+    return 'idle';
+}
+
+/** Convert transport/provider failures into actionable copy without exposing raw gateway responses. */
+export function getBarcodeLookupErrorMessage(error: unknown): string {
+    const status = error && typeof error === 'object' && 'status' in error
+        ? (error as { status?: unknown }).status
+        : undefined;
+    if (typeof status === 'number' && status >= 500) {
+        return 'Food providers are unavailable right now. Try the lookup again in a moment.';
+    }
+
+    const message = error instanceof Error ? error.message : '';
+    if (/network|fetch|timed out|connect|offline/i.test(message)) {
+        return 'Could not reach your Calibrate server. Check your connection and try again.';
+    }
+    return 'Barcode lookup failed. Try again or scan a different barcode.';
+}
+
+/** Preserve provider credit, including the required FatSecret attribution text and destination. */
+export function getProviderAttribution(provider?: string, attribution?: string): ProviderAttribution | null {
+    const normalizedProvider = provider?.trim().toLowerCase();
+    if (normalizedProvider === 'fatsecret') {
+        return { text: 'Powered by fatsecret', url: FATSECRET_URL };
+    }
+
+    const explicitAttribution = attribution?.trim();
+    if (explicitAttribution) return { text: explicitAttribution };
+    if (!normalizedProvider) return null;
+
+    const providerLabel = normalizedProvider === 'openfoodfacts'
+        ? 'Open Food Facts'
+        : normalizedProvider === 'usda'
+            ? 'USDA FoodData Central'
+            : provider!.trim();
+    return { text: `Data from ${providerLabel}` };
+}

--- a/mobile/src/components/AddFoodSheet.tsx
+++ b/mobile/src/components/AddFoodSheet.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { MEAL_PERIODS, type MealPeriod } from '@calibrate/shared';
-import type { FoodLogCreatePayload, FoodSearchResult, MyFoodSummary, RecentFoodSummary } from '@calibrate/api-client';
+import type { FoodLogCreatePayload, MyFoodSummary, RecentFoodSummary } from '@calibrate/api-client';
 import { AppButton } from './AppButton';
 import { AppText } from './AppText';
 import { BottomSheetModal } from './BottomSheetModal';
@@ -21,6 +21,13 @@ import { formatDateOnlyForDisplay } from '../utils/dates';
 import { formatCalories, formatMealPeriod } from '../utils/format';
 import { MEAL_OPTIONS } from '../utils/meals';
 import { selectQuickRecentFoods } from '../utils/myFoods';
+import {
+    buildSearchedFoodLogPayload,
+    calculateFoodServing,
+    getPreferredFoodMeasureIndex,
+    normalizeSearchedFoodItem,
+    type SearchedFoodItem
+} from '../food/serving';
 import { colors, radius, spacing } from '../theme';
 
 type AddFoodSheetProps = {
@@ -46,13 +53,20 @@ const DEFAULT_RECIPE_LIMIT = 6;
 const DEFAULT_PINNED_LIMIT = 6;
 const ADD_FOOD_MODE_MIN_HEIGHT = 360; // Stabilizes the sheet while switching between Quick, Search, and Recipes.
 
-function foodResultCalories(result: FoodSearchResult): string {
-    return typeof result.calories === 'number' ? formatCalories(result.calories) : 'Calories not listed';
-}
-
 function parsePositiveServings(value: string): number {
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function describeSearchedFood(item: SearchedFoodItem): string {
+    const preferredIndex = getPreferredFoodMeasureIndex(item);
+    const measure = preferredIndex === null ? null : item.measures[preferredIndex];
+    const calculation = measure ? calculateFoodServing(item, measure, 1) : null;
+    return [
+        item.brand,
+        measure ? `${measure.label} (${measure.gramWeight} g)` : 'No usable serving measure',
+        calculation ? formatCalories(calculation.calories) : 'Calories unavailable'
+    ].filter(Boolean).join(' | ');
 }
 
 /**
@@ -67,24 +81,6 @@ function getDefaultMealPeriodForTime(now: Date): MealPeriod {
     if (minutesSinceMidnight >= 11 * 60 + 30) return MEAL_PERIODS.LUNCH;
     if (minutesSinceMidnight >= 9 * 60) return MEAL_PERIODS.MORNING_SNACK;
     return MEAL_PERIODS.BREAKFAST;
-}
-
-function buildSearchFoodPayload(result: FoodSearchResult, date: string, meal: MealPeriod, servings: number): FoodLogCreatePayload {
-    const caloriesPerServing = typeof result.calories === 'number' ? result.calories : 0;
-    const calories = Math.round(caloriesPerServing * servings);
-
-    return {
-        date,
-        meal_period: meal,
-        name: result.name,
-        calories,
-        servings_consumed: servings,
-        calories_per_serving_snapshot: caloriesPerServing,
-        external_source: result.source ?? null,
-        external_id: result.id,
-        brand: result.brand ?? null,
-        barcode: result.barcode ?? null
-    };
 }
 
 function buildRecentFoodPayload(
@@ -143,9 +139,13 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     const [calories, setCalories] = useState('');
     const [meal, setMeal] = useState<MealPeriod>(initialMeal ?? getDefaultMealPeriodForTime(new Date()));
     const [servings, setServings] = useState('1');
+    const [searchQuantity, setSearchQuantity] = useState('1');
     const [query, setQuery] = useState('');
     const [recipeQuery, setRecipeQuery] = useState('');
     const [searchError, setSearchError] = useState<string | null>(null);
+    const [selectedSearchItem, setSelectedSearchItem] = useState<SearchedFoodItem | null>(null);
+    const [selectedMeasureIndex, setSelectedMeasureIndex] = useState('0');
+    const [isMeasureSelectorOpen, setIsMeasureSelectorOpen] = useState(false);
     const [isMealSelectorOpen, setIsMealSelectorOpen] = useState(false);
     const foodDayQuery = useQuery({
         queryKey: ['mobile-food-day', date],
@@ -182,6 +182,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
         }
         if (visible) {
             setIsMealSelectorOpen(false);
+            setIsMeasureSelectorOpen(false);
         }
     }, [initialMeal, visible]);
 
@@ -237,15 +238,20 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     });
 
     const logSearchResult = useMutation({
-        mutationFn: (result: FoodSearchResult) =>
-            createFoodLog(buildSearchFoodPayload(result, date, meal, parsePositiveServings(servings))),
-        onSuccess: () => confirmLogged(true)
+        mutationFn: (payload: FoodLogCreatePayload) => createFoodLog(payload),
+        onSuccess: () => {
+            setSelectedSearchItem(null);
+            setSearchQuantity('1');
+            return confirmLogged(true);
+        }
     });
 
     const searchFood = useMutation({
         mutationFn: () => api.searchFood(query),
         onSuccess: () => {
             setSearchError(null);
+            setSelectedSearchItem(null);
+            setIsMeasureSelectorOpen(false);
         },
         onError: (error) => {
             setSearchError(error instanceof Error ? error.message : 'Food search failed.');
@@ -262,6 +268,26 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     const hasValidServings = Number.isFinite(Number(servings)) && Number(servings) > 0;
     const servingsError = servings.trim().length > 0 && !hasValidServings ? 'Servings must be a positive number.' : null;
     const recentFoodMatches = recentFoodsQuery.data?.items ?? [];
+    const searchResults = useMemo(
+        () => (searchFood.data?.items ?? [])
+            .map(normalizeSearchedFoodItem)
+            .filter((item): item is SearchedFoodItem => item !== null),
+        [searchFood.data?.items]
+    );
+    const selectedMeasure = selectedSearchItem?.measures[Number(selectedMeasureIndex)] ?? null;
+    const parsedSearchQuantity = Number(searchQuantity);
+    const selectedServingCalculation = selectedSearchItem && selectedMeasure
+        ? calculateFoodServing(selectedSearchItem, selectedMeasure, parsedSearchQuantity)
+        : null;
+    const selectedServingPayload = selectedSearchItem
+        ? buildSearchedFoodLogPayload({
+              item: selectedSearchItem,
+              measure: selectedMeasure,
+              quantity: parsedSearchQuantity,
+              date,
+              meal
+          })
+        : null;
     const savedFoods = myFoodsQuery.data ?? [];
     const pinnedFoods = savedFoods.filter((item) => item.is_pinned).slice(0, DEFAULT_PINNED_LIMIT);
     const quickRecentFoods = selectQuickRecentFoods(
@@ -278,6 +304,15 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     function openBarcodeScanner() {
         onClose();
         router.push({ pathname: '/barcode', params: { date, meal } });
+    }
+
+    function selectSearchItem(item: SearchedFoodItem) {
+        const preferredMeasureIndex = getPreferredFoodMeasureIndex(item);
+        setSelectedSearchItem(item);
+        setSelectedMeasureIndex(String(preferredMeasureIndex ?? 0));
+        setSearchQuantity('1');
+        setSearchError(null);
+        setIsMeasureSelectorOpen(false);
     }
 
     function renderModeContent() {
@@ -347,30 +382,37 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
         }
 
         if (mode === 'search') {
-            const results = searchFood.data?.items ?? [];
+            const measureOptions: Array<OverlaySelectOption<string>> = selectedSearchItem
+                ? selectedSearchItem.measures.map((measure, index) => ({
+                      value: String(index),
+                      label: measure.label,
+                      description: `${measure.gramWeight} g per measure`
+                  }))
+                : [];
+            let searchedFoodLogTitle = 'Log food';
+            if (logSearchResult.isPending) {
+                searchedFoodLogTitle = 'Logging...';
+            } else if (selectedServingCalculation) {
+                searchedFoodLogTitle = `Log ${formatCalories(selectedServingCalculation.calories)}`;
+            }
             const hasQuery = query.trim().length > 0;
-            const hasResults = recentFoodMatches.length > 0 || results.length > 0;
+            const hasResults = recentFoodMatches.length > 0 || searchResults.length > 0;
             return (
                 <View style={styles.section}>
                     <TextField
                         label="Search foods"
                         value={query}
-                        onChangeText={setQuery}
+                        onChangeText={(value) => {
+                            setQuery(value);
+                            setSelectedSearchItem(null);
+                            setIsMeasureSelectorOpen(false);
+                        }}
                         returnKeyType="search"
                         editable={!isDayComplete && !isSubmitting}
                         onSubmitEditing={() => {
                             if (query.trim()) searchFood.mutate();
                         }}
                     />
-                    <NumberStepperField
-                        label="Servings"
-                        value={servings}
-                        onChangeText={setServings}
-                        step={SERVINGS_STEP}
-                        min={SERVINGS_STEP}
-                        editable={!isDayComplete && !isSubmitting}
-                    />
-                    {servingsError && <AppText style={styles.error}>{servingsError}</AppText>}
                     {searchError && <AppText style={styles.error}>{searchError}</AppText>}
                     <View style={styles.row}>
                         <AppButton
@@ -392,6 +434,80 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                     {searchFood.data?.provider && (
                         <AppText variant="caption">Results from {searchFood.data.provider}</AppText>
                     )}
+                    {selectedSearchItem && (
+                        <View style={styles.servingCard}>
+                            <View style={styles.servingHeader}>
+                                <View style={styles.foodText}>
+                                    <AppText variant="subtitle" numberOfLines={2}>{selectedSearchItem.name}</AppText>
+                                    {selectedSearchItem.brand && <AppText variant="caption">{selectedSearchItem.brand}</AppText>}
+                                </View>
+                                <Pressable
+                                    accessibilityRole="button"
+                                    accessibilityLabel={`Clear ${selectedSearchItem.name} selection`}
+                                    onPress={() => setSelectedSearchItem(null)}
+                                    style={({ pressed }) => [styles.clearSelection, pressed && styles.pressed]}
+                                >
+                                    <Ionicons name="close" size={19} color={colors.muted} />
+                                </Pressable>
+                            </View>
+
+                            {measureOptions.length > 0 && (
+                                <View style={styles.section}>
+                                    <AppText variant="label">Measure</AppText>
+                                    <OverlaySelect
+                                        accessibilityLabel="Select food measure"
+                                        value={selectedMeasureIndex}
+                                        options={measureOptions}
+                                        isOpen={isMeasureSelectorOpen}
+                                        onToggle={() => setIsMeasureSelectorOpen((current) => !current)}
+                                        onChange={(nextIndex) => {
+                                            setSelectedMeasureIndex(nextIndex);
+                                            setIsMeasureSelectorOpen(false);
+                                        }}
+                                    />
+                                </View>
+                            )}
+                            <NumberStepperField
+                                label="Quantity"
+                                value={searchQuantity}
+                                onChangeText={setSearchQuantity}
+                                step={SERVINGS_STEP}
+                                min={SERVINGS_STEP}
+                                editable={!isDayComplete && !isSubmitting && measureOptions.length > 0}
+                            />
+
+                            {selectedServingCalculation && selectedMeasure && (
+                                <View
+                                    accessible
+                                    accessibilityLiveRegion="polite"
+                                    accessibilityLabel={`${formatCalories(selectedServingCalculation.calories)}, ${selectedServingCalculation.gramsTotal} grams total`}
+                                    style={styles.servingSummary}
+                                >
+                                    <AppText variant="subtitle">{formatCalories(selectedServingCalculation.calories)}</AppText>
+                                    <AppText variant="caption">
+                                        {searchQuantity} x {selectedMeasure.label} | {selectedServingCalculation.gramsTotal} g total
+                                    </AppText>
+                                </View>
+                            )}
+                            {selectedServingPayload && !selectedServingPayload.ok && (
+                                <AppText accessibilityRole="alert" style={styles.error}>{selectedServingPayload.message}</AppText>
+                            )}
+                            {logSearchResult.error && (
+                                <AppText accessibilityRole="alert" style={styles.error}>{logSearchResult.error.message}</AppText>
+                            )}
+                            <AppButton
+                                title={searchedFoodLogTitle}
+                                disabled={isDayComplete || isSubmitting || !selectedServingPayload?.ok}
+                                leftIcon={<Ionicons name="add" size={18} color={selectedServingPayload?.ok ? colors.surface : colors.muted} />}
+                                onPress={() => {
+                                    if (selectedServingPayload?.ok) {
+                                        logSearchResult.mutate(selectedServingPayload.payload);
+                                    }
+                                }}
+                                accessibilityLabel={`Log ${selectedSearchItem.name}`}
+                            />
+                        </View>
+                    )}
                     <View style={styles.list}>
                         {recentFoodMatches.length > 0 && (
                             <>
@@ -408,14 +524,16 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                             </>
                         )}
                         {recentFoodsQuery.isLoading && <AppText variant="muted">Checking recent foods...</AppText>}
-                        {results.length > 0 && <AppText variant="label">Search results</AppText>}
-                        {results.slice(0, 8).map((result) => (
+                        {searchResults.length > 0 && <AppText variant="label">Search results</AppText>}
+                        {searchResults.slice(0, 8).map((result) => (
                             <FoodActionRow
                                 key={`${result.source ?? 'food'}-${result.id}`}
                                 title={result.name}
-                                subtitle={[result.brand, result.servingSize, foodResultCalories(result)].filter(Boolean).join(' | ')}
-                                disabled={isDayComplete || isSubmitting || !hasValidServings}
-                                onPress={() => logSearchResult.mutate(result)}
+                                subtitle={describeSearchedFood(result)}
+                                accessibilityLabel={`Choose serving for ${result.name}`}
+                                icon="chevron-forward"
+                                disabled={isDayComplete || isSubmitting}
+                                onPress={() => selectSearchItem(result)}
                             />
                         ))}
                         {!searchFood.isPending && hasQuery && searchFood.data && !hasResults && (
@@ -494,6 +612,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                 onChange={(nextMode) => {
                     setMode(nextMode);
                     setIsMealSelectorOpen(false);
+                    setIsMeasureSelectorOpen(false);
                 }}
             />
             <View style={styles.modeContent}>{renderModeContent()}</View>
@@ -504,13 +623,23 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
 type FoodActionRowProps = {
     title: string;
     subtitle: string;
+    accessibilityLabel?: string;
+    icon?: React.ComponentProps<typeof Ionicons>['name'];
     disabled?: boolean;
     onPress: () => void;
 };
 
-const FoodActionRow: React.FC<FoodActionRowProps> = ({ title, subtitle, disabled, onPress }) => (
+const FoodActionRow: React.FC<FoodActionRowProps> = ({
+    title,
+    subtitle,
+    accessibilityLabel,
+    icon = 'add',
+    disabled,
+    onPress
+}) => (
     <Pressable
         accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
         disabled={disabled}
         onPress={onPress}
         style={({ pressed }) => [styles.foodRow, disabled && styles.disabledButton, pressed && styles.pressed]}
@@ -520,7 +649,7 @@ const FoodActionRow: React.FC<FoodActionRowProps> = ({ title, subtitle, disabled
             <AppText variant="caption" numberOfLines={1}>{subtitle}</AppText>
         </View>
         <View style={styles.addIcon}>
-            <Ionicons name="add" size={18} color="#ffffff" />
+            <Ionicons name={icon} size={18} color="#ffffff" />
         </View>
     </Pressable>
 );
@@ -578,6 +707,33 @@ const styles = StyleSheet.create({
         flex: 1,
         minWidth: 0,
         gap: spacing.xs
+    },
+    servingCard: {
+        gap: spacing.md,
+        borderRadius: radius.md,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: colors.border,
+        backgroundColor: colors.surfaceAlt,
+        padding: spacing.md
+    },
+    servingHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.md
+    },
+    clearSelection: {
+        width: 44,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: radius.md,
+        backgroundColor: colors.surface
+    },
+    servingSummary: {
+        gap: spacing.xs,
+        borderRadius: radius.md,
+        backgroundColor: colors.primarySoft,
+        padding: spacing.md
     },
     addIcon: {
         width: 34,

--- a/mobile/src/components/AddFoodSheet.tsx
+++ b/mobile/src/components/AddFoodSheet.tsx
@@ -20,6 +20,7 @@ import { useOfflineOutbox } from '../offline/provider';
 import { formatDateOnlyForDisplay } from '../utils/dates';
 import { formatCalories, formatMealPeriod } from '../utils/format';
 import { MEAL_OPTIONS } from '../utils/meals';
+import { selectQuickRecentFoods } from '../utils/myFoods';
 import { colors, radius, spacing } from '../theme';
 
 type AddFoodSheetProps = {
@@ -31,6 +32,7 @@ type AddFoodSheetProps = {
 };
 
 type AddFoodMode = 'quick' | 'search' | 'recipes';
+type SavedFoodLogRequest = { item: MyFoodSummary; servings: number };
 
 const ADD_FOOD_MODES: Array<{ value: AddFoodMode; label: string }> = [
     { value: 'quick', label: 'Quick' },
@@ -41,6 +43,7 @@ const ADD_FOOD_MODES: Array<{ value: AddFoodMode; label: string }> = [
 const SERVINGS_STEP = 0.1; // Food servings match the PWA precision and provider serving snapshots.
 const DEFAULT_RECENT_LIMIT = 5;
 const DEFAULT_RECIPE_LIMIT = 6;
+const DEFAULT_PINNED_LIMIT = 6;
 const ADD_FOOD_MODE_MIN_HEIGHT = 360; // Stabilizes the sheet while switching between Quick, Search, and Recipes.
 
 function foodResultCalories(result: FoodSearchResult): string {
@@ -154,10 +157,15 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
         queryFn: () => api.getRecentFoods({ q: query, limit: DEFAULT_RECENT_LIMIT }),
         enabled: visible && mode === 'search' && query.trim().length >= 2
     });
+    const quickRecentFoodsQuery = useQuery({
+        queryKey: ['mobile-recent-foods', 'quick'],
+        queryFn: () => api.getRecentFoods({ limit: DEFAULT_RECENT_LIMIT }),
+        enabled: visible && mode === 'quick'
+    });
     const myFoodsQuery = useQuery({
         queryKey: ['mobile-my-foods'],
         queryFn: () => api.getMyFoods(),
-        enabled: visible && mode === 'recipes'
+        enabled: visible && (mode === 'quick' || mode === 'recipes')
     });
     const isDayComplete = foodDayQuery.data?.is_complete ?? false;
 
@@ -218,12 +226,12 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     });
 
     const logMyFood = useMutation({
-        mutationFn: (item: MyFoodSummary) =>
+        mutationFn: ({ item, servings: requestedServings }: SavedFoodLogRequest) =>
             createFoodLog({
                 date,
                 meal_period: meal,
                 my_food_id: item.id,
-                servings_consumed: parsePositiveServings(servings)
+                servings_consumed: requestedServings
             }),
         onSuccess: () => confirmLogged(true)
     });
@@ -255,6 +263,12 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     const servingsError = servings.trim().length > 0 && !hasValidServings ? 'Servings must be a positive number.' : null;
     const recentFoodMatches = recentFoodsQuery.data?.items ?? [];
     const savedFoods = myFoodsQuery.data ?? [];
+    const pinnedFoods = savedFoods.filter((item) => item.is_pinned).slice(0, DEFAULT_PINNED_LIMIT);
+    const quickRecentFoods = selectQuickRecentFoods(
+        quickRecentFoodsQuery.data?.items ?? [],
+        pinnedFoods,
+        DEFAULT_RECENT_LIMIT
+    );
     const recipes = savedFoods.filter((item) => item.type === 'RECIPE');
     const recipeSearchText = recipeQuery.trim().toLowerCase();
     const visibleRecipes = recipes
@@ -270,6 +284,33 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
         if (mode === 'quick') {
             return (
                 <View style={styles.section}>
+                    {(pinnedFoods.length > 0 || quickRecentFoods.length > 0) && (
+                        <View style={styles.list}>
+                            {pinnedFoods.length > 0 && <AppText variant="label">Pinned</AppText>}
+                            {pinnedFoods.map((item) => (
+                                <FoodActionRow
+                                    key={`pinned-${item.id}`}
+                                    title={item.name}
+                                    subtitle={`${formatCalories(item.calories_per_serving)} per ${item.serving_size_quantity} ${item.serving_unit_label}`}
+                                    disabled={isDayComplete || isSubmitting}
+                                    onPress={() => logMyFood.mutate({ item, servings: 1 })}
+                                />
+                            ))}
+                            {quickRecentFoods.length > 0 && <AppText variant="label">Recent</AppText>}
+                            {quickRecentFoods.map((recent) => (
+                                <FoodActionRow
+                                    key={`quick-recent-${recent.id}`}
+                                    title={recent.name}
+                                    subtitle={`${formatCalories(recent.calories)} | ${recent.times_logged}x`}
+                                    disabled={isDayComplete || isSubmitting}
+                                    onPress={() => logRecentFood.mutate(recent)}
+                                />
+                            ))}
+                        </View>
+                    )}
+                    {(myFoodsQuery.isLoading || quickRecentFoodsQuery.isLoading) && (
+                        <AppText variant="muted">Loading pinned and recent foods...</AppText>
+                    )}
                     <AppText variant="label">Quick entry</AppText>
                     <TextField label="Food name" value={name} onChangeText={setName} editable={!isDayComplete && !isSubmitting} />
                     <NumberStepperField
@@ -411,7 +452,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                             title={item.name}
                             subtitle={`${formatCalories(item.calories_per_serving)} per ${item.serving_size_quantity} ${item.serving_unit_label}`}
                             disabled={isDayComplete || isSubmitting || !hasValidServings}
-                            onPress={() => logMyFood.mutate(item)}
+                            onPress={() => logMyFood.mutate({ item, servings: parsePositiveServings(servings) })}
                         />
                     ))}
                     {myFoodsQuery.isLoading && <AppText variant="muted">Loading recipes...</AppText>}

--- a/mobile/src/components/AppButton.tsx
+++ b/mobile/src/components/AppButton.tsx
@@ -12,12 +12,18 @@ export const AppButton: React.FC<PressableProps & {
     variant = 'primary',
     leftIcon,
     disabled,
+    accessibilityLabel,
+    accessibilityRole,
+    accessibilityState,
     style,
     ...props
 }) => (
     <Pressable
         {...props}
         disabled={disabled}
+        accessibilityLabel={accessibilityLabel ?? title}
+        accessibilityRole={accessibilityRole ?? 'button'}
+        accessibilityState={{ ...accessibilityState, disabled: Boolean(disabled) }}
         style={({ pressed }) => [
             styles.base,
             styles[variant],

--- a/mobile/src/components/AppErrorBoundary.test.tsx
+++ b/mobile/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import { AppErrorBoundary } from './AppErrorBoundary';
+
+const AlwaysThrows = () => {
+    throw new Error('Example render failure');
+};
+
+describe('AppErrorBoundary', () => {
+    let consoleError: jest.SpyInstance;
+
+    beforeEach(() => {
+        consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        consoleError.mockRestore();
+    });
+
+    it('shows an accessible branded fallback when a descendant crashes', () => {
+        const view = render(
+            <AppErrorBoundary>
+                <AlwaysThrows />
+            </AppErrorBoundary>
+        );
+
+        expect(view.getByRole('alert')).toHaveProp(
+            'accessibilityLabel',
+            'Calibrate encountered an unexpected error'
+        );
+        expect(view.getByRole('header')).toHaveTextContent('Calibrate hit a snag');
+        expect(view.getByLabelText('Calibrate')).toBeTruthy();
+        expect(view.getByLabelText('Try loading Calibrate again')).toHaveProp('accessibilityRole', 'button');
+        expect(view.getByLabelText('Restart Calibrate')).toHaveProp('accessibilityRole', 'button');
+        expect(view.getByTestId('app-error-detail')).toHaveTextContent('Example render failure');
+    });
+
+    it('resets and remounts the app subtree without reloading the process', () => {
+        let shouldThrow = true;
+        const RecoverableChild = () => {
+            if (shouldThrow) throw new Error('Recoverable failure');
+            return <Text>Recovered app</Text>;
+        };
+        const view = render(
+            <AppErrorBoundary>
+                <RecoverableChild />
+            </AppErrorBoundary>
+        );
+
+        shouldThrow = false;
+        fireEvent.press(view.getByLabelText('Try loading Calibrate again'));
+
+        expect(view.getByText('Recovered app')).toBeTruthy();
+        expect(view.queryByRole('alert')).toBeNull();
+    });
+
+    it('offers a full app restart when resetting is not enough', () => {
+        const restartApp = jest.fn();
+        const view = render(
+            <AppErrorBoundary restartApp={restartApp}>
+                <AlwaysThrows />
+            </AppErrorBoundary>
+        );
+
+        fireEvent.press(view.getByLabelText('Restart Calibrate'));
+
+        expect(restartApp).toHaveBeenCalledTimes(1);
+    });
+});

--- a/mobile/src/components/AppErrorBoundary.tsx
+++ b/mobile/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import {
+    DevSettings,
+    Pressable,
+    StatusBar,
+    StyleSheet,
+    Text,
+    View
+} from 'react-native';
+import { colors, radius, shadows, spacing, typography } from '../theme';
+
+type AppErrorBoundaryProps = {
+    children: React.ReactNode;
+    /** Override exists for deterministic tests and alternate native reload hosts. */
+    restartApp?: () => void;
+};
+
+type AppErrorBoundaryState = {
+    error: Error | null;
+    resetVersion: number;
+};
+
+const FALLBACK_MAX_WIDTH = 420; // Keeps recovery copy readable on tablets and unfolded devices.
+const BRAND_MARK_SIZE = 52; // Gives the emergency shell a recognizable mark without loading SVG/native modules.
+
+const defaultRestartApp = (): void => {
+    DevSettings.reload();
+};
+
+/**
+ * Last-resort native shell for render and lifecycle failures below the app root.
+ *
+ * The fallback intentionally uses only React Native core primitives so it remains
+ * available when navigation, providers, or feature components are what failed.
+ */
+export class AppErrorBoundary extends React.Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+    state: AppErrorBoundaryState = {
+        error: null,
+        resetVersion: 0
+    };
+
+    static getDerivedStateFromError(error: unknown): Partial<AppErrorBoundaryState> {
+        return {
+            error: error instanceof Error ? error : new Error('An unexpected error occurred.')
+        };
+    }
+
+    componentDidCatch(error: Error, info: React.ErrorInfo): void {
+        if (__DEV__) {
+            console.error('[calibrate] Unhandled app render error', error, info.componentStack);
+        }
+    }
+
+    private resetAppShell = (): void => {
+        this.setState((state) => ({
+            error: null,
+            resetVersion: state.resetVersion + 1
+        }));
+    };
+
+    private restartApp = (): void => {
+        (this.props.restartApp ?? defaultRestartApp)();
+    };
+
+    render(): React.ReactNode {
+        if (this.state.error) {
+            return (
+                <View
+                    style={styles.screen}
+                    accessible
+                    accessibilityRole="alert"
+                    accessibilityLiveRegion="assertive"
+                    accessibilityLabel="Calibrate encountered an unexpected error"
+                >
+                    <StatusBar barStyle="dark-content" backgroundColor={colors.background} />
+                    <View style={styles.card}>
+                        <View style={styles.brandRow}>
+                            <View
+                                style={styles.brandMark}
+                                accessibilityRole="image"
+                                accessibilityLabel="Calibrate"
+                            >
+                                <Text style={styles.brandMarkText}>C</Text>
+                            </View>
+                            <Text style={styles.brandName}>calibrate</Text>
+                        </View>
+
+                        <Text accessibilityRole="header" style={styles.title}>Calibrate hit a snag</Text>
+                        <Text style={styles.description}>
+                            Your saved data is safe. Try loading the app again, or restart Calibrate if the problem continues.
+                        </Text>
+                        {__DEV__ ? (
+                            <Text selectable style={styles.developmentError} testID="app-error-detail">
+                                {this.state.error.message}
+                            </Text>
+                        ) : null}
+
+                        <View style={styles.actions}>
+                            <Pressable
+                                accessibilityRole="button"
+                                accessibilityLabel="Try loading Calibrate again"
+                                onPress={this.resetAppShell}
+                                style={({ pressed }) => [styles.button, styles.primaryButton, pressed && styles.pressed]}
+                            >
+                                <Text style={styles.primaryButtonLabel}>Try again</Text>
+                            </Pressable>
+                            <Pressable
+                                accessibilityRole="button"
+                                accessibilityLabel="Restart Calibrate"
+                                onPress={this.restartApp}
+                                style={({ pressed }) => [styles.button, styles.secondaryButton, pressed && styles.pressed]}
+                            >
+                                <Text style={styles.secondaryButtonLabel}>Restart app</Text>
+                            </Pressable>
+                        </View>
+                    </View>
+                </View>
+            );
+        }
+
+        return <React.Fragment key={this.state.resetVersion}>{this.props.children}</React.Fragment>;
+    }
+}
+
+const styles = StyleSheet.create({
+    screen: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors.background,
+        padding: spacing.xxl
+    },
+    card: {
+        width: '100%',
+        maxWidth: FALLBACK_MAX_WIDTH,
+        padding: spacing.xxl,
+        borderRadius: radius.md,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: colors.border,
+        backgroundColor: colors.surface,
+        ...shadows.card
+    },
+    brandRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.lg,
+        marginBottom: spacing.xxl
+    },
+    brandMark: {
+        width: BRAND_MARK_SIZE,
+        height: BRAND_MARK_SIZE,
+        borderRadius: BRAND_MARK_SIZE / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors.primary
+    },
+    brandMarkText: {
+        color: colors.surface,
+        fontSize: typography.title,
+        fontWeight: '900'
+    },
+    brandName: {
+        color: colors.text,
+        fontSize: typography.screenTitle,
+        fontWeight: '900'
+    },
+    title: {
+        color: colors.text,
+        fontSize: typography.title,
+        fontWeight: '900',
+        marginBottom: spacing.lg
+    },
+    description: {
+        color: colors.muted,
+        fontSize: typography.body,
+        lineHeight: 21
+    },
+    developmentError: {
+        color: colors.dangerMuted,
+        fontSize: typography.caption,
+        marginTop: spacing.xl
+    },
+    actions: {
+        gap: spacing.lg,
+        marginTop: spacing.xxl
+    },
+    button: {
+        minHeight: 48,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: radius.md,
+        paddingHorizontal: spacing.xl,
+        paddingVertical: spacing.lg
+    },
+    primaryButton: {
+        backgroundColor: colors.primary,
+        ...shadows.button
+    },
+    secondaryButton: {
+        backgroundColor: colors.surfaceAlt,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: colors.border
+    },
+    primaryButtonLabel: {
+        color: colors.surface,
+        fontSize: typography.body,
+        fontWeight: '800'
+    },
+    secondaryButtonLabel: {
+        color: colors.text,
+        fontSize: typography.body,
+        fontWeight: '800'
+    },
+    pressed: {
+        opacity: 0.86,
+        transform: [{ translateY: 1 }]
+    }
+});

--- a/mobile/src/components/BottomSheetModal.tsx
+++ b/mobile/src/components/BottomSheetModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Animated, Easing, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, StyleSheet, View, type ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { colors, radius, shadows, spacing } from '../theme';
+import { useReducedMotionPreference } from '../hooks/useReducedMotionPreference';
 
 type BottomSheetModalProps = {
     visible: boolean;
@@ -22,6 +23,7 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
     maxHeight = '88%'
 }) => {
     const insets = useSafeAreaInsets();
+    const reduceMotion = useReducedMotionPreference();
     const [shouldRender, setShouldRender] = useState(visible);
     const backdropOpacity = useRef(new Animated.Value(0)).current;
     const sheetProgress = useRef(new Animated.Value(1)).current;
@@ -34,13 +36,13 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
             Animated.parallel([
                 Animated.timing(backdropOpacity, {
                     toValue: 1,
-                    duration: 160,
+                    duration: reduceMotion ? 0 : 160,
                     easing: Easing.out(Easing.ease),
                     useNativeDriver: true
                 }),
                 Animated.timing(sheetProgress, {
                     toValue: 0,
-                    duration: 220,
+                    duration: reduceMotion ? 0 : 220,
                     easing: Easing.out(Easing.cubic),
                     useNativeDriver: true
                 })
@@ -53,13 +55,13 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
         Animated.parallel([
             Animated.timing(backdropOpacity, {
                 toValue: 0,
-                duration: 140,
+                duration: reduceMotion ? 0 : 140,
                 easing: Easing.in(Easing.ease),
                 useNativeDriver: true
             }),
             Animated.timing(sheetProgress, {
                 toValue: 1,
-                duration: 160,
+                duration: reduceMotion ? 0 : 160,
                 easing: Easing.in(Easing.cubic),
                 useNativeDriver: true
             })
@@ -68,7 +70,7 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
                 setShouldRender(false);
             }
         });
-    }, [backdropOpacity, sheetProgress, shouldRender, visible]);
+    }, [backdropOpacity, reduceMotion, sheetProgress, shouldRender, visible]);
 
     if (!shouldRender) return null;
 
@@ -87,6 +89,7 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
                     <Animated.View style={[styles.backdrop, { opacity: backdropOpacity }]} />
                 </Pressable>
                 <Animated.View
+                    accessibilityViewIsModal
                     style={[
                         styles.sheet,
                         {

--- a/mobile/src/components/ServerUrlControl.test.tsx
+++ b/mobile/src/components/ServerUrlControl.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { ServerUrlControl } from './ServerUrlControl';
+import { HOSTED_SERVER_URL, type ServerConnectionState } from '../config/server';
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+
+const idleConnection: ServerConnectionState = {
+    status: 'idle',
+    testedInput: null,
+    testedUrl: null,
+    message: 'Test the connection before signing in.'
+};
+
+describe('ServerUrlControl', () => {
+    it('expands self-hosted controls and invokes an explicit connection test', () => {
+        const onTestConnection = jest.fn(async () => true);
+        const view = render(
+            <ServerUrlControl
+                value="http://10.0.2.2:3000"
+                onChangeText={jest.fn()}
+                connection={idleConnection}
+                onTestConnection={onTestConnection}
+            />
+        );
+
+        fireEvent.press(view.getByLabelText('Change server URL'));
+        fireEvent.press(view.getByLabelText('Test Calibrate server connection'));
+
+        expect(view.getByLabelText('Server URL')).toHaveProp('keyboardType', 'url');
+        expect(onTestConnection).toHaveBeenCalledWith('http://10.0.2.2:3000');
+    });
+
+    it('announces the confirmed compatibility result for the current candidate', () => {
+        const connected: ServerConnectionState = {
+            status: 'connected',
+            testedInput: 'https://self-hosted.example',
+            testedUrl: 'https://self-hosted.example',
+            message: 'Connected to Calibrate 1.2.3 (API v1).'
+        };
+        const view = render(
+            <ServerUrlControl
+                value="https://self-hosted.example/path"
+                onChangeText={jest.fn()}
+                connection={connected}
+                onTestConnection={jest.fn(async () => true)}
+            />
+        );
+
+        expect(view.getByLabelText(connected.message)).toHaveProp('accessibilityLiveRegion', 'polite');
+        expect(view.getByText(connected.message)).toBeTruthy();
+    });
+
+    it('does not show a stale success after the candidate changes and can restore hosted service', () => {
+        const onChangeText = jest.fn();
+        const connected: ServerConnectionState = {
+            status: 'connected',
+            testedInput: 'https://old.example',
+            testedUrl: 'https://old.example',
+            message: 'Connected to Calibrate 1.2.3 (API v1).'
+        };
+        const view = render(
+            <ServerUrlControl
+                value="https://new.example"
+                onChangeText={onChangeText}
+                connection={connected}
+                onTestConnection={jest.fn(async () => true)}
+            />
+        );
+
+        expect(view.queryByText(connected.message)).toBeNull();
+        expect(view.getByText('Test this address before signing in.')).toBeTruthy();
+
+        fireEvent.press(view.getByLabelText('Change server URL'));
+        fireEvent.press(view.getByLabelText('Use hosted Calibrate server'));
+        expect(onChangeText).toHaveBeenCalledWith(HOSTED_SERVER_URL);
+    });
+});

--- a/mobile/src/components/ServerUrlControl.tsx
+++ b/mobile/src/components/ServerUrlControl.tsx
@@ -4,10 +4,33 @@ import { Ionicons } from '@expo/vector-icons';
 import { AppText } from './AppText';
 import { TextField } from './TextField';
 import { colors, radius, spacing } from '../theme';
+import {
+    HOSTED_SERVER_URL,
+    normalizeServerUrl,
+    type ServerConnectionState
+} from '../config/server';
 
 type ServerUrlControlProps = ViewProps & {
     value: string;
     onChangeText: (value: string) => void;
+    connection: ServerConnectionState;
+    onTestConnection: (value: string) => Promise<boolean>;
+};
+
+const resolveStatusPresentation = (status: ServerConnectionState['status']): {
+    icon: React.ComponentProps<typeof Ionicons>['name'];
+    color: string;
+} => {
+    switch (status) {
+        case 'connected':
+            return { icon: 'checkmark-circle', color: colors.success };
+        case 'error':
+            return { icon: 'alert-circle', color: colors.danger };
+        case 'testing':
+            return { icon: 'sync-circle', color: colors.info };
+        default:
+            return { icon: 'information-circle', color: colors.muted };
+    }
 };
 
 /**
@@ -19,10 +42,26 @@ type ServerUrlControlProps = ViewProps & {
 export const ServerUrlControl: React.FC<ServerUrlControlProps> = ({
     value,
     onChangeText,
+    connection,
+    onTestConnection,
     style,
     ...props
 }) => {
     const [isEditing, setIsEditing] = useState(false);
+    const normalizedValue = normalizeServerUrl(value);
+    const matchesTestedCandidate = normalizedValue
+        ? normalizedValue === connection.testedUrl
+        : value.trim() === connection.testedInput;
+    const visibleConnection = matchesTestedCandidate
+        ? connection
+        : {
+              status: 'idle' as const,
+              testedInput: null,
+              testedUrl: null,
+              message: 'Test this address before signing in.'
+          };
+    const statusPresentation = resolveStatusPresentation(visibleConnection.status);
+    const isTesting = visibleConnection.status === 'testing';
 
     return (
         <View {...props} style={[styles.root, style]}>
@@ -43,15 +82,54 @@ export const ServerUrlControl: React.FC<ServerUrlControlProps> = ({
             </Pressable>
 
             {isEditing && (
-                <TextField
-                    label="Server URL"
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    value={value}
-                    onChangeText={onChangeText}
-                    helperText="Use the hosted service or enter a LAN/self-hosted backend URL."
-                />
+                <View style={styles.editor}>
+                    <TextField
+                        label="Server URL"
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                        keyboardType="url"
+                        value={value}
+                        onChangeText={onChangeText}
+                        helperText="Remote servers require HTTPS. Localhost, 10.0.2.2, and private LAN addresses may use HTTP."
+                    />
+                    <View style={styles.editorActions}>
+                        <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel="Use hosted Calibrate server"
+                            onPress={() => onChangeText(HOSTED_SERVER_URL)}
+                            style={({ pressed }) => [styles.secondaryAction, pressed && styles.pressed]}
+                        >
+                            <AppText style={styles.secondaryActionText}>Use hosted</AppText>
+                        </Pressable>
+                        <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel="Test Calibrate server connection"
+                            disabled={isTesting}
+                            onPress={() => void onTestConnection(value)}
+                            style={({ pressed }) => [
+                                styles.testAction,
+                                isTesting && styles.disabled,
+                                pressed && !isTesting && styles.pressed
+                            ]}
+                        >
+                            <Ionicons name="pulse" size={16} color={colors.surface} />
+                            <AppText style={styles.testActionText}>{isTesting ? 'Testing...' : 'Test connection'}</AppText>
+                        </Pressable>
+                    </View>
+                </View>
             )}
+
+            <View
+                accessible
+                accessibilityLiveRegion="polite"
+                accessibilityLabel={visibleConnection.message}
+                style={styles.connectionStatus}
+            >
+                <Ionicons name={statusPresentation.icon} size={17} color={statusPresentation.color} />
+                <AppText style={[styles.connectionStatusText, { color: statusPresentation.color }]}>
+                    {visibleConnection.message}
+                </AppText>
+            </View>
         </View>
     );
 };
@@ -90,6 +168,52 @@ const styles = StyleSheet.create({
     changeText: {
         color: colors.primaryDark,
         fontWeight: '900'
+    },
+    editor: {
+        gap: spacing.md
+    },
+    editorActions: {
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        gap: spacing.md
+    },
+    secondaryAction: {
+        minHeight: 42,
+        justifyContent: 'center',
+        paddingHorizontal: spacing.lg,
+        borderRadius: radius.md
+    },
+    secondaryActionText: {
+        color: colors.primaryDark,
+        fontWeight: '800'
+    },
+    testAction: {
+        minHeight: 42,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: spacing.sm,
+        paddingHorizontal: spacing.lg,
+        borderRadius: radius.md,
+        backgroundColor: colors.primary
+    },
+    testActionText: {
+        color: colors.surface,
+        fontWeight: '800'
+    },
+    connectionStatus: {
+        minHeight: 22,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.sm
+    },
+    connectionStatusText: {
+        flex: 1,
+        fontSize: 12
+    },
+    disabled: {
+        opacity: 0.55
     },
     pressed: {
         backgroundColor: colors.surfacePressed

--- a/mobile/src/components/TextField.tsx
+++ b/mobile/src/components/TextField.tsx
@@ -11,6 +11,7 @@ export const TextField: React.FC<TextInputProps & { label: string; helperText?: 
     style,
     onBlur,
     onFocus,
+    accessibilityLabel,
     ...props
 }) => {
     const [isFocused, setIsFocused] = useState(false);
@@ -20,6 +21,7 @@ export const TextField: React.FC<TextInputProps & { label: string; helperText?: 
             {!hideLabel && <AppText variant="label">{label}</AppText>}
             <TextInput
                 {...props}
+                accessibilityLabel={accessibilityLabel ?? label}
                 onBlur={(event) => {
                     setIsFocused(false);
                     onBlur?.(event);

--- a/mobile/src/components/WeightEntrySheet.tsx
+++ b/mobile/src/components/WeightEntrySheet.tsx
@@ -99,7 +99,13 @@ export const WeightEntrySheet: React.FC<WeightEntrySheetProps> = ({ visible, dat
             if (!existingMetric) {
                 throw new Error('No weight entry exists for this day.');
             }
-            return api.deleteMetric(existingMetric.id);
+            const payload = { id: existingMetric.id };
+            return executeOrQueueMutation({
+                operation: OFFLINE_MUTATION_OPERATIONS.DELETE_METRIC,
+                payload,
+                execute: (operationId) => api.deleteMetric(existingMetric.id, operationId),
+                enqueue
+            });
         },
         onSuccess: async () => {
             setWeight('');

--- a/mobile/src/components/accessibilityPrimitives.test.tsx
+++ b/mobile/src/components/accessibilityPrimitives.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { AppButton } from './AppButton';
+import { TextField } from './TextField';
+
+describe('mobile accessibility primitives', () => {
+    it('gives buttons a useful default role, label, and disabled state', () => {
+        const { getByRole } = render(<AppButton title="Save meal" disabled />);
+        const button = getByRole('button', { name: 'Save meal' });
+        expect(button.props.accessibilityState).toEqual(expect.objectContaining({ disabled: true }));
+    });
+
+    it('uses a text field label as its accessible name even when the visual label is hidden', () => {
+        const { getByLabelText } = render(
+            <TextField label="Search foods" hideLabel value="" onChangeText={jest.fn()} />
+        );
+        expect(getByLabelText('Search foods')).toBeTruthy();
+    });
+
+    it('preserves explicit accessible names supplied by feature screens', () => {
+        const { getByRole, getByLabelText } = render(
+            <>
+                <AppButton title="Save" accessibilityLabel="Save today's weigh-in" />
+                <TextField label="Server" accessibilityLabel="Self-hosted server URL" />
+            </>
+        );
+        expect(getByRole('button', { name: "Save today's weigh-in" })).toBeTruthy();
+        expect(getByLabelText('Self-hosted server URL')).toBeTruthy();
+    });
+});

--- a/mobile/src/config/server.test.ts
+++ b/mobile/src/config/server.test.ts
@@ -1,18 +1,107 @@
-import { getConfiguredServerUrl, normalizeServerUrl } from './server';
+import {
+    getConfiguredServerUrl,
+    normalizeServerUrl,
+    parseServerUrl,
+    testCalibrateServerConnection
+} from './server';
 
-describe('normalizeServerUrl', () => {
-    it('normalizes valid hosted and local server origins', () => {
+const compatibleConfig = {
+    api_version: 1,
+    api_versions: {
+        current: 'v1',
+        supported: ['v1'],
+        legacy_alias: '/api',
+        legacy_deprecation: 'none'
+    },
+    server_version: '1.2.3',
+    hosted_origin: 'https://calibrate.example',
+    min_supported_mobile_version: '0.1.0',
+    capabilities: {
+        self_hosted_server_url: true,
+        native_push: true,
+        wear_os_ready: false
+    }
+};
+
+describe('server URL parsing', () => {
+    it('normalizes hosted origins and defaults scheme-less remote hosts to HTTPS', () => {
         expect(normalizeServerUrl('https://calibratehealth.app/settings')).toBe('https://calibratehealth.app');
-        expect(normalizeServerUrl('http://10.0.2.2:3000/')).toBe('http://10.0.2.2:3000');
+        expect(normalizeServerUrl('self-hosted.example:3443/api')).toBe('https://self-hosted.example:3443');
     });
 
-    it('rejects unsupported protocols and empty input', () => {
-        expect(normalizeServerUrl('')).toBeNull();
+    it('supports Android emulator, localhost, and private LAN HTTP development servers', () => {
+        expect(normalizeServerUrl('10.0.2.2:3000')).toBe('http://10.0.2.2:3000');
+        expect(normalizeServerUrl('localhost:3000/api')).toBe('http://localhost:3000');
+        expect(normalizeServerUrl('http://127.0.0.1:3000')).toBe('http://127.0.0.1:3000');
+        expect(normalizeServerUrl('http://192.168.0.160:3000/api')).toBe('http://192.168.0.160:3000');
+    });
+
+    it('rejects unsafe remote HTTP, credentials, unsupported protocols, and empty input', () => {
+        expect(parseServerUrl('http://public.example')).toEqual(expect.objectContaining({ ok: false }));
+        expect(parseServerUrl('https://user:secret@calibrate.example')).toEqual(expect.objectContaining({ ok: false }));
         expect(normalizeServerUrl('file:///tmp/calibrate')).toBeNull();
+        expect(normalizeServerUrl('')).toBeNull();
     });
 
     it('reads an optional Expo public server override', () => {
         expect(getConfiguredServerUrl('http://192.168.0.160:3000/api')).toBe('http://192.168.0.160:3000');
         expect(getConfiguredServerUrl('not a url')).toBeNull();
+    });
+});
+
+describe('testCalibrateServerConnection', () => {
+    it('tests the versioned client-config endpoint and accepts a compatible server', async () => {
+        const fetchImpl = jest.fn(async () => new Response(JSON.stringify(compatibleConfig), { status: 200 }));
+
+        const result = await testCalibrateServerConnection('https://calibrate.example', {
+            fetchImpl: fetchImpl as typeof fetch,
+            mobileVersion: '0.2.0'
+        });
+
+        expect(result).toEqual(expect.objectContaining({
+            ok: true,
+            url: 'https://calibrate.example',
+            message: 'Connected to Calibrate 1.2.3 (API v1).'
+        }));
+        expect(fetchImpl).toHaveBeenCalledWith(
+            'https://calibrate.example/api/v1/client-config',
+            expect.objectContaining({ method: 'GET' })
+        );
+    });
+
+    it('reports unreachable and non-Calibrate servers clearly', async () => {
+        const unreachable = await testCalibrateServerConnection('https://offline.example', {
+            fetchImpl: jest.fn(async () => { throw new TypeError('Network request failed'); }) as typeof fetch
+        });
+        expect(unreachable).toEqual(expect.objectContaining({ ok: false, code: 'unreachable' }));
+
+        const wrongServer = await testCalibrateServerConnection('https://files.example', {
+            fetchImpl: jest.fn(async () => new Response('<html />', { status: 200 })) as typeof fetch
+        });
+        expect(wrongServer).toEqual(expect.objectContaining({ ok: false, code: 'not_calibrate' }));
+    });
+
+    it('rejects unsupported APIs and mobile versions without switching', async () => {
+        const oldApi = {
+            ...compatibleConfig,
+            api_versions: { ...compatibleConfig.api_versions, supported: ['v2'] }
+        };
+        const unsupported = await testCalibrateServerConnection('https://future.example', {
+            fetchImpl: jest.fn(async () => new Response(JSON.stringify(oldApi), { status: 200 })) as typeof fetch
+        });
+        expect(unsupported).toEqual(expect.objectContaining({ ok: false, code: 'incompatible' }));
+
+        const upgradeRequired = await testCalibrateServerConnection('https://newer.example', {
+            fetchImpl: jest.fn(async () => new Response(JSON.stringify({
+                ...compatibleConfig,
+                min_supported_mobile_version: '2.0.0'
+            }), { status: 200 })) as typeof fetch,
+            mobileVersion: '1.9.9'
+        });
+        expect(upgradeRequired).toEqual(expect.objectContaining({
+            ok: false,
+            code: 'incompatible',
+            message: 'This server requires Calibrate 2.0.0 or newer.'
+        }));
     });
 });

--- a/mobile/src/config/server.ts
+++ b/mobile/src/config/server.ts
@@ -1,46 +1,229 @@
 import { Platform } from 'react-native';
+import type { ClientConfigResponse } from '@calibrate/api-client';
 
 export const HOSTED_SERVER_URL = 'https://calibratehealth.app';
 export const ANDROID_EMULATOR_SERVER_URL = 'http://10.0.2.2:3000';
 export const CALIBRATE_SERVER_URL_ENV = 'EXPO_PUBLIC_CALIBRATE_SERVER_URL';
+export const MOBILE_API_VERSION = 'v1';
+
+const SERVER_CONNECTION_TIMEOUT_MS = 8000; // Fails quickly enough to keep sign-in setup responsive on bad LAN addresses.
+
+export type ServerUrlResult =
+    | { ok: true; url: string }
+    | { ok: false; message: string };
+
+export type ServerConnectionResult =
+    | {
+          ok: true;
+          url: string;
+          config: ClientConfigResponse;
+          message: string;
+      }
+    | {
+          ok: false;
+          url: string | null;
+          code: 'invalid_url' | 'unreachable' | 'not_calibrate' | 'incompatible';
+          message: string;
+      };
+
+export type ServerConnectionState = {
+    status: 'idle' | 'testing' | 'connected' | 'error';
+    testedInput: string | null;
+    testedUrl: string | null;
+    message: string;
+};
+
+export const INITIAL_SERVER_CONNECTION_STATE: ServerConnectionState = {
+    status: 'idle',
+    testedInput: null,
+    testedUrl: null,
+    message: 'Test the connection before signing in.'
+};
+
+const hasExplicitScheme = (value: string): boolean => /^[a-z][a-z\d+.-]*:\/\//i.test(value);
+
+/** Allow cleartext HTTP only for emulator, loopback, and private-network development hosts. */
+export function isLocalServerHostname(hostname: string): boolean {
+    const normalized = hostname.toLowerCase();
+    if (
+        normalized === 'localhost'
+        || normalized === '127.0.0.1'
+        || normalized === '10.0.2.2'
+        || normalized === '::1'
+        || normalized === '[::1]'
+        || normalized.endsWith('.local')
+    ) {
+        return true;
+    }
+    if (normalized.startsWith('192.168.') || normalized.startsWith('10.')) return true;
+    return /^172\.(1[6-9]|2\d|3[01])\./.test(normalized);
+}
 
 /**
- * Allow local Expo Go sessions on physical devices to point at a LAN backend without code edits.
+ * Parse a user-entered server address into the API origin.
+ *
+ * Scheme-less public hosts default to HTTPS, while local development hosts default to HTTP.
  */
+export function parseServerUrl(value: string): ServerUrlResult {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return { ok: false, message: 'Enter a Calibrate server URL.' };
+    }
+
+    try {
+        const explicitScheme = hasExplicitScheme(trimmed);
+        const url = new URL(explicitScheme ? trimmed : `https://${trimmed}`);
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+            return { ok: false, message: 'Use an http or https server URL.' };
+        }
+        if (url.username || url.password) {
+            return { ok: false, message: 'Server URLs cannot include a username or password.' };
+        }
+
+        const isLocalHost = isLocalServerHostname(url.hostname);
+        if (!explicitScheme && isLocalHost) {
+            url.protocol = 'http:';
+        }
+        if (url.protocol === 'http:' && !isLocalHost) {
+            return {
+                ok: false,
+                message: 'Use HTTPS for remote servers. HTTP is allowed only for local or private-network development.'
+            };
+        }
+
+        return { ok: true, url: url.origin };
+    } catch {
+        return { ok: false, message: 'Enter a valid Calibrate server URL.' };
+    }
+}
+
+/** Allow local Expo sessions on physical devices to point at a LAN backend without code edits. */
 export function getConfiguredServerUrl(value = process.env.EXPO_PUBLIC_CALIBRATE_SERVER_URL): string | null {
     if (!value) return null;
     return normalizeServerUrl(value);
 }
 
-/**
- * Default to an explicit Expo public env value, the hosted instance in production, and the emulator loopback in
- * Android dev builds.
- */
+/** Default to an explicit env value, hosted production, or Android emulator loopback in development. */
 export function getDefaultServerUrl(): string {
     const configuredServerUrl = getConfiguredServerUrl();
     if (configuredServerUrl) return configuredServerUrl;
-
-    if (__DEV__ && Platform.OS === 'android') {
-        return ANDROID_EMULATOR_SERVER_URL;
-    }
-
+    if (__DEV__ && Platform.OS === 'android') return ANDROID_EMULATOR_SERVER_URL;
     return HOSTED_SERVER_URL;
 }
 
-/**
- * Normalize self-hosted server input so API calls can safely append paths.
- */
+/** Normalize self-hosted server input so API calls can safely append versioned paths. */
 export function normalizeServerUrl(value: string): string | null {
-    const trimmed = value.trim();
-    if (!trimmed) return null;
+    const result = parseServerUrl(value);
+    return result.ok ? result.url : null;
+}
 
-    try {
-        const url = new URL(trimmed);
-        if (url.protocol !== 'https:' && url.protocol !== 'http:') {
-            return null;
-        }
-        return url.origin;
-    } catch {
-        return null;
+const parseVersion = (value: string): number[] | null => {
+    const match = value.trim().match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
+    if (!match) return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+};
+
+const compareVersions = (left: string, right: string): number | null => {
+    const leftParts = parseVersion(left);
+    const rightParts = parseVersion(right);
+    if (!leftParts || !rightParts) return null;
+    for (let index = 0; index < leftParts.length; index += 1) {
+        const difference = leftParts[index] - rightParts[index];
+        if (difference !== 0) return difference;
     }
+    return 0;
+};
+
+const isClientConfigResponse = (value: unknown): value is ClientConfigResponse => {
+    if (!value || typeof value !== 'object') return false;
+    const record = value as Partial<ClientConfigResponse>;
+    return record.api_version === 1
+        && Boolean(record.api_versions && Array.isArray(record.api_versions.supported))
+        && typeof record.min_supported_mobile_version === 'string'
+        && typeof record.server_version === 'string';
+};
+
+/** Check the version document before credentials or persisted server state are changed. */
+export async function testCalibrateServerConnection(
+    value: string,
+    options: {
+        fetchImpl?: typeof fetch;
+        mobileVersion?: string | null;
+        timeoutMs?: number;
+    } = {}
+): Promise<ServerConnectionResult> {
+    const parsed = parseServerUrl(value);
+    if (!parsed.ok) {
+        return { ok: false, url: null, code: 'invalid_url', message: parsed.message };
+    }
+
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs ?? SERVER_CONNECTION_TIMEOUT_MS);
+    let response: Response;
+    try {
+        response = await fetchImpl(`${parsed.url}/api/v1/client-config`, {
+            method: 'GET',
+            headers: { accept: 'application/json' },
+            signal: controller.signal
+        });
+    } catch {
+        return {
+            ok: false,
+            url: parsed.url,
+            code: 'unreachable',
+            message: 'Could not reach this server. Check the address, network, and whether Calibrate is running.'
+        };
+    } finally {
+        clearTimeout(timeoutId);
+    }
+
+    if (!response.ok) {
+        return {
+            ok: false,
+            url: parsed.url,
+            code: response.status === 404 ? 'not_calibrate' : 'unreachable',
+            message: response.status === 404
+                ? 'This server does not expose the Calibrate v1 API. Update the server and try again.'
+                : `The server responded with HTTP ${response.status}. Check its Calibrate configuration.`
+        };
+    }
+
+    const body = await response.json().catch(() => null);
+    if (!isClientConfigResponse(body)) {
+        return {
+            ok: false,
+            url: parsed.url,
+            code: 'not_calibrate',
+            message: 'The response was not a compatible Calibrate server document.'
+        };
+    }
+    if (!body.api_versions.supported.includes(MOBILE_API_VERSION)) {
+        return {
+            ok: false,
+            url: parsed.url,
+            code: 'incompatible',
+            message: 'This server does not support the Calibrate v1 mobile API.'
+        };
+    }
+
+    const mobileVersion = options.mobileVersion;
+    const versionComparison = mobileVersion
+        ? compareVersions(mobileVersion, body.min_supported_mobile_version)
+        : null;
+    if (versionComparison !== null && versionComparison < 0) {
+        return {
+            ok: false,
+            url: parsed.url,
+            code: 'incompatible',
+            message: `This server requires Calibrate ${body.min_supported_mobile_version} or newer.`
+        };
+    }
+
+    return {
+        ok: true,
+        url: parsed.url,
+        config: body,
+        message: `Connected to Calibrate ${body.server_version} (API v1).`
+    };
 }

--- a/mobile/src/food/serving.test.ts
+++ b/mobile/src/food/serving.test.ts
@@ -1,0 +1,100 @@
+import { MEAL_PERIODS } from '@calibrate/shared';
+import {
+    buildSearchedFoodLogPayload,
+    calculateFoodServing,
+    getPreferredFoodMeasureIndex,
+    normalizeSearchedFoodItem
+} from './serving';
+
+const providerItem = {
+    id: 'provider-food-1',
+    source: 'fatsecret',
+    description: 'Greek yogurt',
+    brand: 'Example Dairy',
+    barcode: '12345',
+    locale: 'en-US',
+    availableMeasures: [
+        { label: 'per 100g', gramWeight: 100, quantity: 100, unit: 'g' },
+        { label: '1 container', gramWeight: 170, quantity: 1, unit: 'container' }
+    ],
+    nutrientsPer100g: { calories: 59, protein: 10 }
+};
+
+describe('searched food serving calculations', () => {
+    it('normalizes provider measures and prefers a practical one-serving default', () => {
+        const item = normalizeSearchedFoodItem(providerItem);
+
+        expect(item).not.toBeNull();
+        expect(item?.name).toBe('Greek yogurt');
+        expect(item?.measures).toHaveLength(2);
+        expect(getPreferredFoodMeasureIndex(item!)).toBe(1);
+    });
+
+    it('recomputes calories and grams deterministically for fractional quantities', () => {
+        const item = normalizeSearchedFoodItem(providerItem)!;
+        const calculation = calculateFoodServing(item, item.measures[1], 1.5);
+
+        expect(calculation).toEqual({
+            quantity: 1.5,
+            calories: 150,
+            caloriesPerMeasure: 100.3,
+            gramsPerMeasure: 170,
+            gramsTotal: 255
+        });
+    });
+
+    it('preserves the complete immutable serving and provider snapshot', () => {
+        const item = normalizeSearchedFoodItem(providerItem)!;
+        const result = buildSearchedFoodLogPayload({
+            item,
+            measure: item.measures[1],
+            quantity: 1.5,
+            date: '2026-07-12',
+            meal: MEAL_PERIODS.BREAKFAST
+        });
+
+        expect(result).toEqual({
+            ok: true,
+            calculation: expect.objectContaining({ calories: 150, gramsTotal: 255 }),
+            payload: {
+                date: '2026-07-12',
+                meal_period: MEAL_PERIODS.BREAKFAST,
+                name: 'Greek yogurt',
+                calories: 150,
+                servings_consumed: 1.5,
+                serving_size_quantity_snapshot: 1,
+                serving_unit_label_snapshot: 'container',
+                calories_per_serving_snapshot: 100.3,
+                external_source: 'fatsecret',
+                external_id: 'provider-food-1',
+                brand: 'Example Dairy',
+                locale: 'en-US',
+                barcode: '12345',
+                measure_label: '1 container',
+                grams_per_measure_snapshot: 170,
+                measure_quantity_snapshot: 1.5,
+                grams_total_snapshot: 255
+            }
+        });
+    });
+
+    it('rejects missing measures, nutrients, and invalid quantities without inventing snapshots', () => {
+        const noData = normalizeSearchedFoodItem({ id: 'x', description: 'Unknown', availableMeasures: [] })!;
+        expect(buildSearchedFoodLogPayload({
+            item: noData,
+            measure: null,
+            quantity: 1,
+            date: '2026-07-12',
+            meal: MEAL_PERIODS.LUNCH
+        })).toEqual({ ok: false, message: 'This food does not include a usable serving measure.' });
+
+        const item = normalizeSearchedFoodItem(providerItem)!;
+        expect(buildSearchedFoodLogPayload({
+            item,
+            measure: item.measures[0],
+            quantity: 0,
+            date: '2026-07-12',
+            meal: MEAL_PERIODS.LUNCH
+        })).toEqual({ ok: false, message: 'Quantity must be a positive number.' });
+    });
+});

--- a/mobile/src/food/serving.ts
+++ b/mobile/src/food/serving.ts
@@ -1,0 +1,172 @@
+import type { FoodLogCreatePayload } from '@calibrate/api-client';
+import type { MealPeriod } from '@calibrate/shared';
+
+export type ProviderFoodMeasure = {
+    label: string;
+    gramWeight: number;
+    quantity: number | null;
+    unit: string | null;
+};
+
+export type SearchedFoodItem = {
+    id: string;
+    name: string;
+    source: string | null;
+    brand: string | null;
+    barcode: string | null;
+    locale: string | null;
+    measures: ProviderFoodMeasure[];
+    caloriesPer100g: number | null;
+};
+
+export type FoodServingCalculation = {
+    quantity: number;
+    calories: number;
+    caloriesPerMeasure: number;
+    gramsPerMeasure: number;
+    gramsTotal: number;
+};
+
+export type FoodServingPayloadResult =
+    | { ok: true; payload: FoodLogCreatePayload; calculation: FoodServingCalculation }
+    | { ok: false; message: string };
+
+const roundTo = (value: number, decimalPlaces: number): number => {
+    const scale = 10 ** decimalPlaces;
+    return Math.round((value + Number.EPSILON) * scale) / scale;
+};
+
+const optionalText = (value: unknown): string | null => {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed || null;
+};
+
+const optionalPositiveNumber = (value: unknown): number | null =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+
+const optionalNonNegativeNumber = (value: unknown): number | null =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+
+/** Normalize the provider wire object without trusting optional third-party fields. */
+export function normalizeSearchedFoodItem(value: unknown): SearchedFoodItem | null {
+    if (!value || typeof value !== 'object') return null;
+    const record = value as Record<string, unknown>;
+    const id = optionalText(record.id);
+    const name = optionalText(record.description) ?? optionalText(record.name);
+    if (!id || !name) return null;
+
+    let rawMeasures: unknown[] = [];
+    if (Array.isArray(record.availableMeasures)) {
+        rawMeasures = record.availableMeasures;
+    } else if (Array.isArray(record.measures)) {
+        rawMeasures = record.measures;
+    }
+    const measures = rawMeasures.flatMap((rawMeasure): ProviderFoodMeasure[] => {
+        if (!rawMeasure || typeof rawMeasure !== 'object') return [];
+        const measure = rawMeasure as Record<string, unknown>;
+        const label = optionalText(measure.label);
+        const gramWeight = optionalPositiveNumber(measure.gramWeight);
+        if (!label || !gramWeight) return [];
+        return [{
+            label,
+            gramWeight,
+            quantity: optionalPositiveNumber(measure.quantity),
+            unit: optionalText(measure.unit)
+        }];
+    });
+
+    const nutrients = record.nutrientsPer100g;
+    const caloriesPer100g = nutrients && typeof nutrients === 'object'
+        ? optionalNonNegativeNumber((nutrients as Record<string, unknown>).calories)
+        : null;
+
+    return {
+        id,
+        name,
+        source: optionalText(record.source),
+        brand: optionalText(record.brand),
+        barcode: optionalText(record.barcode),
+        locale: optionalText(record.locale),
+        measures,
+        caloriesPer100g
+    };
+}
+
+/** Prefer a practical serving over a provider's generic per-100g measure. */
+export function getPreferredFoodMeasureIndex(item: SearchedFoodItem): number | null {
+    if (item.measures.length === 0) return null;
+    const practicalIndex = item.measures.findIndex(
+        (measure) => measure.label.trim().toLowerCase() !== 'per 100g'
+    );
+    return practicalIndex >= 0 ? practicalIndex : 0;
+}
+
+/** Scale provider per-100g energy into the selected measure and user-entered quantity. */
+export function calculateFoodServing(
+    item: SearchedFoodItem,
+    measure: ProviderFoodMeasure,
+    quantity: number
+): FoodServingCalculation | null {
+    if (!Number.isFinite(quantity) || quantity <= 0 || item.caloriesPer100g === null) return null;
+
+    const gramsPerMeasure = roundTo(measure.gramWeight, 3);
+    const gramsTotal = roundTo(gramsPerMeasure * quantity, 3);
+    const caloriesPerMeasure = roundTo((item.caloriesPer100g * gramsPerMeasure) / 100, 1);
+    const caloriesTotal = (item.caloriesPer100g * gramsTotal) / 100;
+    return {
+        quantity,
+        calories: Math.round(caloriesTotal),
+        caloriesPerMeasure,
+        gramsPerMeasure,
+        gramsTotal
+    };
+}
+
+const getServingUnitLabel = (measure: ProviderFoodMeasure): string =>
+    measure.unit ?? measure.label.replace(/^per\s+/i, '').trim();
+
+/** Build an immutable external-food snapshot from one deterministic serving calculation. */
+export function buildSearchedFoodLogPayload(options: {
+    item: SearchedFoodItem;
+    measure: ProviderFoodMeasure | null;
+    quantity: number;
+    date: string;
+    meal: MealPeriod;
+}): FoodServingPayloadResult {
+    if (!options.measure) {
+        return { ok: false, message: 'This food does not include a usable serving measure.' };
+    }
+    if (!Number.isFinite(options.quantity) || options.quantity <= 0) {
+        return { ok: false, message: 'Quantity must be a positive number.' };
+    }
+
+    const calculation = calculateFoodServing(options.item, options.measure, options.quantity);
+    if (!calculation) {
+        return { ok: false, message: 'This food does not include enough nutrition data to calculate calories.' };
+    }
+
+    return {
+        ok: true,
+        calculation,
+        payload: {
+            date: options.date,
+            meal_period: options.meal,
+            name: options.item.name,
+            calories: calculation.calories,
+            servings_consumed: calculation.quantity,
+            serving_size_quantity_snapshot: options.measure.quantity ?? 1,
+            serving_unit_label_snapshot: getServingUnitLabel(options.measure),
+            calories_per_serving_snapshot: calculation.caloriesPerMeasure,
+            external_source: options.item.source,
+            external_id: options.item.id,
+            brand: options.item.brand,
+            locale: options.item.locale,
+            barcode: options.item.barcode,
+            measure_label: options.measure.label,
+            grams_per_measure_snapshot: calculation.gramsPerMeasure,
+            measure_quantity_snapshot: calculation.quantity,
+            grams_total_snapshot: calculation.gramsTotal
+        }
+    };
+}

--- a/mobile/src/hooks/useNativePushRegistration.ts
+++ b/mobile/src/hooks/useNativePushRegistration.ts
@@ -1,57 +1,122 @@
-import { useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Linking, Platform } from 'react-native';
 import Constants from 'expo-constants';
 import { NATIVE_PUSH_PLATFORMS, NATIVE_PUSH_PROVIDERS } from '@calibrate/shared';
 import { useAuth } from '../auth/AuthContext';
+import {
+    getNotificationPermissionState,
+    isNativePushEnvironmentSupported,
+    NATIVE_PUSH_STATES,
+    type NativePushState
+} from '../notifications/workflow';
+
+type NativePushRegistrationContextValue = {
+    state: NativePushState;
+    requestPermission: () => Promise<void>;
+    openSettings: () => Promise<void>;
+    refreshPermission: () => Promise<void>;
+    retryRegistration: () => Promise<void>;
+};
+
+const NativePushRegistrationContext = createContext<NativePushRegistrationContextValue | null>(null);
+
+/** Configure foreground behavior consistently before registering or listening for native pushes. */
+async function loadNotificationsModule() {
+    const Notifications = await import('expo-notifications');
+    Notifications.setNotificationHandler({
+        handleNotification: async () => ({
+            shouldShowBanner: true,
+            shouldShowList: true,
+            shouldPlaySound: false,
+            shouldSetBadge: true
+        })
+    });
+    return Notifications;
+}
 
 /**
- * Register the current Android install with the backend for native reminder push.
- *
- * Expo Go no longer supports Android remote push, so we skip registration there
- * and keep the code path for development builds and release builds.
+ * Own native notification permission and registration state for the signed-in Android install.
+ * Permission prompts remain user initiated; already-granted devices register automatically.
  */
-export function useNativePushRegistration() {
+export function NativePushRegistrationProvider({ children }: { children: React.ReactNode }) {
     const { api, user } = useAuth();
+    const [state, setState] = useState<NativePushState>(NATIVE_PUSH_STATES.CHECKING);
+    const activeRun = useRef(0);
 
-    useEffect(() => {
-        if (!user) return;
+    const synchronize = useCallback(async (requestPermission: boolean) => {
+        const run = ++activeRun.current;
+        if (!user) {
+            setState(NATIVE_PUSH_STATES.SIGNED_OUT);
+            return;
+        }
+        if (!isNativePushEnvironmentSupported(Constants.appOwnership, Platform.OS)) {
+            setState(NATIVE_PUSH_STATES.UNSUPPORTED);
+            return;
+        }
 
-        let cancelled = false;
+        setState(NATIVE_PUSH_STATES.CHECKING);
+        try {
+            const Notifications = await loadNotificationsModule();
+            const permission = requestPermission
+                ? await Notifications.requestPermissionsAsync()
+                : await Notifications.getPermissionsAsync();
+            if (run !== activeRun.current) return;
 
-        async function register() {
-            if (Constants.appOwnership === 'expo') {
+            const permissionState = getNotificationPermissionState(permission);
+            if (permissionState !== NATIVE_PUSH_STATES.REGISTERING) {
+                setState(permissionState);
                 return;
             }
 
-            const Notifications = await import('expo-notifications');
-            Notifications.setNotificationHandler({
-                handleNotification: async () => ({
-                    shouldShowBanner: true,
-                    shouldShowList: true,
-                    shouldPlaySound: false,
-                    shouldSetBadge: true
-                })
-            });
-
-            const permissions = await Notifications.requestPermissionsAsync();
-            if (permissions.status !== 'granted') return;
-
+            setState(NATIVE_PUSH_STATES.REGISTERING);
             const token = await Notifications.getExpoPushTokenAsync();
-            if (!token.data) return;
-            if (cancelled) return;
+            if (run !== activeRun.current) return;
+            if (!token.data) throw new Error('Expo did not return a push token.');
 
             await api.registerNativePushSubscription({
                 token: token.data,
                 platform: NATIVE_PUSH_PLATFORMS.ANDROID,
                 provider: NATIVE_PUSH_PROVIDERS.EXPO
             });
+            if (run === activeRun.current) setState(NATIVE_PUSH_STATES.REGISTERED);
+        } catch {
+            if (run === activeRun.current) setState(NATIVE_PUSH_STATES.ERROR);
         }
-
-        void register().catch(() => {
-            // Push registration should never block the core app shell.
-        });
-
-        return () => {
-            cancelled = true;
-        };
     }, [api, user]);
+
+    useEffect(() => {
+        void synchronize(false);
+        return () => {
+            activeRun.current += 1;
+        };
+    }, [synchronize]);
+
+    const requestPermission = useCallback(() => synchronize(true), [synchronize]);
+    const refreshPermission = useCallback(() => synchronize(false), [synchronize]);
+    const retryRegistration = useCallback(() => synchronize(false), [synchronize]);
+    const openSettings = useCallback(async () => {
+        try {
+            await Linking.openSettings();
+        } catch {
+            setState(NATIVE_PUSH_STATES.ERROR);
+        }
+    }, []);
+
+    const value = useMemo<NativePushRegistrationContextValue>(() => ({
+        state,
+        requestPermission,
+        openSettings,
+        refreshPermission,
+        retryRegistration
+    }), [openSettings, refreshPermission, requestPermission, retryRegistration, state]);
+
+    return React.createElement(NativePushRegistrationContext.Provider, { value }, children);
+}
+
+export function useNativePushRegistration(): NativePushRegistrationContextValue {
+    const context = useContext(NativePushRegistrationContext);
+    if (!context) {
+        throw new Error('useNativePushRegistration must be used within NativePushRegistrationProvider.');
+    }
+    return context;
 }

--- a/mobile/src/hooks/useReducedMotionPreference.test.tsx
+++ b/mobile/src/hooks/useReducedMotionPreference.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { AccessibilityInfo } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { AppText } from '../components/AppText';
+import { useReducedMotionPreference } from './useReducedMotionPreference';
+
+function Probe() {
+    const reduced = useReducedMotionPreference();
+    return <AppText>{reduced ? 'reduced' : 'animated'}</AppText>;
+}
+
+describe('useReducedMotionPreference', () => {
+    it('hydrates and responds to the Android reduce-motion preference', async () => {
+        let listener: ((enabled: boolean) => void) | undefined;
+        jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(true);
+        jest.spyOn(AccessibilityInfo as any, 'addEventListener').mockImplementation((...args: unknown[]) => {
+            const [event, callback] = args;
+            if (event === 'reduceMotionChanged') listener = callback as (enabled: boolean) => void;
+            return { remove: jest.fn() };
+        });
+
+        const view = render(<Probe />);
+        await waitFor(() => expect(view.getByText('reduced')).toBeTruthy());
+        act(() => listener?.(false));
+        await waitFor(() => expect(view.getByText('animated')).toBeTruthy());
+    });
+});

--- a/mobile/src/hooks/useReducedMotionPreference.ts
+++ b/mobile/src/hooks/useReducedMotionPreference.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+/** Tracks the OS reduce-motion preference for custom native animations. */
+export function useReducedMotionPreference(): boolean {
+    const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState(false);
+
+    useEffect(() => {
+        let active = true;
+        void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+            if (active) setIsReducedMotionEnabled(enabled);
+        });
+        const subscription = AccessibilityInfo.addEventListener(
+            'reduceMotionChanged',
+            setIsReducedMotionEnabled
+        );
+        return () => {
+            active = false;
+            subscription.remove();
+        };
+    }, []);
+
+    return isReducedMotionEnabled;
+}

--- a/mobile/src/notifications/useNotificationTapRouting.ts
+++ b/mobile/src/notifications/useNotificationTapRouting.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import { router, type Href } from 'expo-router';
+import { getNotificationAction, getNotificationResponseActionUrl } from './workflow';
+
+type NotificationResponseLike = {
+    actionIdentifier?: string;
+    notification: {
+        request: {
+            identifier: string;
+            content: { data?: unknown };
+        };
+    };
+};
+
+/** Route foreground/background and cold-start notification taps through the same safe allowlist. */
+export function useNotificationTapRouting(enabled: boolean): void {
+    const handledResponses = useRef(new Set<string>());
+
+    useEffect(() => {
+        if (!enabled) return;
+        let active = true;
+        let removeListener: (() => void) | undefined;
+
+        const handleResponse = (response: NotificationResponseLike) => {
+            if (!active) return;
+            const responseKey = `${response.notification.request.identifier}:${response.actionIdentifier ?? 'default'}`;
+            if (handledResponses.current.has(responseKey)) return;
+            handledResponses.current.add(responseKey);
+
+            const data = response.notification.request.content.data;
+            const actionUrl = getNotificationResponseActionUrl(data, response.actionIdentifier);
+            router.push(getNotificationAction(actionUrl).href as Href);
+        };
+
+        void import('expo-notifications').then(async (Notifications) => {
+            if (!active) return;
+            const subscription = Notifications.addNotificationResponseReceivedListener(handleResponse);
+            removeListener = () => subscription.remove();
+
+            const lastResponse = await Notifications.getLastNotificationResponseAsync();
+            if (lastResponse) {
+                handleResponse(lastResponse);
+                await Notifications.clearLastNotificationResponseAsync();
+            }
+        }).catch(() => {
+            // Notification routing is an enhancement; normal in-app navigation remains available.
+        });
+
+        return () => {
+            active = false;
+            removeListener?.();
+        };
+    }, [enabled]);
+}

--- a/mobile/src/notifications/workflow.test.ts
+++ b/mobile/src/notifications/workflow.test.ts
@@ -1,0 +1,64 @@
+import {
+    getNotificationAction,
+    getNotificationPermissionState,
+    getNotificationResponseActionUrl,
+    getPushStatusPresentation,
+    isNativePushEnvironmentSupported,
+    NATIVE_PUSH_STATES
+} from './workflow';
+
+describe('native notification workflow', () => {
+    it('distinguishes permission retry from blocked settings recovery', () => {
+        expect(getNotificationPermissionState({ granted: true, canAskAgain: true })).toBe(NATIVE_PUSH_STATES.REGISTERING);
+        expect(getNotificationPermissionState({ granted: false, canAskAgain: true })).toBe(NATIVE_PUSH_STATES.PERMISSION_REQUIRED);
+        expect(getNotificationPermissionState({ granted: false, canAskAgain: false })).toBe(NATIVE_PUSH_STATES.BLOCKED);
+        expect(getPushStatusPresentation(NATIVE_PUSH_STATES.PERMISSION_REQUIRED).action).toBe('request');
+        expect(getPushStatusPresentation(NATIVE_PUSH_STATES.BLOCKED).action).toBe('settings');
+    });
+
+    it('marks Expo Go and non-Android environments unsupported', () => {
+        expect(isNativePushEnvironmentSupported('expo', 'android')).toBe(false);
+        expect(isNativePushEnvironmentSupported('standalone', 'ios')).toBe(false);
+        expect(isNativePushEnvironmentSupported('standalone', 'android')).toBe(true);
+    });
+
+    it('maps food, weight, and goal actions to allowlisted native routes', () => {
+        expect(getNotificationAction('/log?quickAdd=food', '2026-07-12')).toEqual({
+            label: 'Log food',
+            href: { pathname: '/(tabs)/log', params: { date: '2026-07-12' } }
+        });
+        expect(getNotificationAction('/log?quickAdd=weight', '2026-07-12')).toEqual({
+            label: 'Log weight',
+            href: { pathname: '/(tabs)/weight', params: { date: '2026-07-12' } }
+        });
+        expect(getNotificationAction('/goals')).toEqual({ label: 'Open goals', href: '/(tabs)/progress' });
+    });
+
+    it.each([
+        'https://evil.example/log?quickAdd=weight',
+        '//evil.example/log',
+        'javascript:alert(1)',
+        '/unknown/path',
+        '/log\\..\\settings',
+        undefined
+    ])('falls back safely for invalid or external action URL %p', (actionUrl) => {
+        expect(getNotificationAction(actionUrl)).toEqual({
+            label: 'Open Calibrate',
+            href: '/(tabs)/today'
+        });
+    });
+
+    it('uses a tapped action URL before the notification default', () => {
+        const data = {
+            url: '/log',
+            actionUrls: {
+                log_weight: '/log?quickAdd=weight',
+                external: 'https://evil.example'
+            }
+        };
+
+        expect(getNotificationResponseActionUrl(data, 'log_weight')).toBe('/log?quickAdd=weight');
+        expect(getNotificationResponseActionUrl(data, 'unknown')).toBe('/log');
+        expect(getNotificationAction(getNotificationResponseActionUrl(data, 'external')).href).toBe('/(tabs)/today');
+    });
+});

--- a/mobile/src/notifications/workflow.ts
+++ b/mobile/src/notifications/workflow.ts
@@ -1,0 +1,148 @@
+const INTERNAL_ROUTE_ORIGIN = 'https://calibrate.invalid';
+
+export const NATIVE_PUSH_STATES = {
+    SIGNED_OUT: 'signed-out',
+    CHECKING: 'checking',
+    PERMISSION_REQUIRED: 'permission-required',
+    BLOCKED: 'blocked',
+    REGISTERING: 'registering',
+    REGISTERED: 'registered',
+    UNSUPPORTED: 'unsupported',
+    ERROR: 'error'
+} as const;
+
+export type NativePushState = (typeof NATIVE_PUSH_STATES)[keyof typeof NATIVE_PUSH_STATES];
+
+export type NotificationRoute =
+    | '/(tabs)/today'
+    | '/(tabs)/progress'
+    | { pathname: '/(tabs)/log' | '/(tabs)/weight'; params?: { date: string } };
+
+export type NotificationAction = {
+    label: string;
+    href: NotificationRoute;
+};
+
+export type PushStatusPresentation = {
+    message: string;
+    action: 'request' | 'settings' | 'retry' | null;
+    isError: boolean;
+};
+
+/** Remote push is unavailable in Expo Go and outside the native Android target. */
+export function isNativePushEnvironmentSupported(appOwnership: string | null | undefined, platform: string): boolean {
+    return appOwnership !== 'expo' && platform === 'android';
+}
+
+export function getNotificationPermissionState(permission: {
+    granted: boolean;
+    canAskAgain: boolean;
+}): NativePushState {
+    if (permission.granted) return NATIVE_PUSH_STATES.REGISTERING;
+    return permission.canAskAgain ? NATIVE_PUSH_STATES.PERMISSION_REQUIRED : NATIVE_PUSH_STATES.BLOCKED;
+}
+
+/** Keep permission/registration status copy and recovery actions consistent in Settings. */
+export function getPushStatusPresentation(state: NativePushState): PushStatusPresentation {
+    switch (state) {
+        case NATIVE_PUSH_STATES.CHECKING:
+            return { message: 'Checking notification access...', action: null, isError: false };
+        case NATIVE_PUSH_STATES.PERMISSION_REQUIRED:
+            return {
+                message: 'Allow notifications on this device to receive enabled food and weight reminders.',
+                action: 'request',
+                isError: false
+            };
+        case NATIVE_PUSH_STATES.BLOCKED:
+            return {
+                message: 'Notifications are blocked for Calibrate. Enable them in Android settings, then check again.',
+                action: 'settings',
+                isError: true
+            };
+        case NATIVE_PUSH_STATES.REGISTERING:
+            return { message: 'Registering this device for reminders...', action: null, isError: false };
+        case NATIVE_PUSH_STATES.REGISTERED:
+            return { message: 'Push reminders are ready on this device.', action: null, isError: false };
+        case NATIVE_PUSH_STATES.UNSUPPORTED:
+            return {
+                message: 'Remote push is unavailable in Expo Go. Use an Android development or release build.',
+                action: null,
+                isError: false
+            };
+        case NATIVE_PUSH_STATES.ERROR:
+            return {
+                message: 'Push registration failed. Check the server connection and try again.',
+                action: 'retry',
+                isError: true
+            };
+        default:
+            return { message: 'Sign in to configure notifications.', action: null, isError: false };
+    }
+}
+
+const isLocalDate = (value: string | undefined): value is string =>
+    typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+
+const withOptionalDate = (
+    pathname: '/(tabs)/log' | '/(tabs)/weight',
+    localDate?: string
+): NotificationRoute => isLocalDate(localDate) ? { pathname, params: { date: localDate } } : { pathname };
+
+/** Resolve only known relative app routes; absolute, protocol-relative, and malformed URLs stay in-app. */
+export function getNotificationAction(actionUrl: unknown, localDate?: string): NotificationAction {
+    const fallback: NotificationAction = { label: 'Open Calibrate', href: '/(tabs)/today' };
+    if (typeof actionUrl !== 'string') return fallback;
+
+    const candidate = actionUrl.trim();
+    if (!candidate.startsWith('/') || candidate.startsWith('//') || candidate.includes('\\')) return fallback;
+
+    let parsed: URL;
+    try {
+        parsed = new URL(candidate, INTERNAL_ROUTE_ORIGIN);
+    } catch {
+        return fallback;
+    }
+    if (parsed.origin !== INTERNAL_ROUTE_ORIGIN) return fallback;
+
+    const pathname = parsed.pathname.replace(/\/$/, '') || '/';
+    const quickAdd = parsed.searchParams.get('quickAdd')?.trim().toLowerCase();
+    if (pathname === '/log' && quickAdd === 'weight') {
+        return { label: 'Log weight', href: withOptionalDate('/(tabs)/weight', localDate) };
+    }
+    if (pathname === '/log' && quickAdd === 'food') {
+        return { label: 'Log food', href: withOptionalDate('/(tabs)/log', localDate) };
+    }
+
+    switch (pathname) {
+        case '/weight':
+            return { label: 'Log weight', href: withOptionalDate('/(tabs)/weight', localDate) };
+        case '/food':
+        case '/log':
+            return { label: 'Log food', href: withOptionalDate('/(tabs)/log', localDate) };
+        case '/goal':
+        case '/goals':
+        case '/progress':
+            return { label: 'Open goals', href: '/(tabs)/progress' };
+        case '/':
+        case '/dashboard':
+        case '/today':
+            return { label: 'Open Calibrate', href: '/(tabs)/today' };
+        default:
+            return fallback;
+    }
+}
+
+/** Prefer a tapped notification action's URL, then the notification's default URL. */
+export function getNotificationResponseActionUrl(
+    data: unknown,
+    actionIdentifier: string | null | undefined
+): unknown {
+    if (!data || typeof data !== 'object') return undefined;
+    const record = data as Record<string, unknown>;
+    const actionUrls = record.actionUrls;
+    if (actionIdentifier && actionUrls && typeof actionUrls === 'object') {
+        const actionUrl = (actionUrls as Record<string, unknown>)[actionIdentifier];
+        if (typeof actionUrl === 'string') return actionUrl;
+    }
+    return record.url;
+}

--- a/mobile/src/offline/operations.test.ts
+++ b/mobile/src/offline/operations.test.ts
@@ -91,7 +91,10 @@ describe('createQueuedMutationExecutor', () => {
     it('replays all supported operations with the persisted operation ID', async () => {
         const api = {
             createFoodLog: jest.fn(async () => undefined),
+            updateFoodLog: jest.fn(async () => undefined),
+            deleteFoodLog: jest.fn(async () => undefined),
             addMetric: jest.fn(async () => undefined),
+            deleteMetric: jest.fn(async () => undefined),
             updateFoodDay: jest.fn(async () => undefined)
         } as unknown as CalibrateApiClient;
         const execute = createQueuedMutationExecutor(api);
@@ -102,12 +105,24 @@ describe('createQueuedMutationExecutor', () => {
         await execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.ADD_METRIC, {
             date: '2026-07-11', weight: 82.5
         }));
+        await execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.UPDATE_FOOD_LOG, {
+            id: 42, update: { name: 'Updated dinner', calories: 550, meal_period: 'DINNER' }
+        }));
+        await execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.DELETE_FOOD_LOG, { id: 43 }));
+        await execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.DELETE_METRIC, { id: 44 }));
         await execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.UPDATE_FOOD_DAY, {
             date: '2026-07-11', is_complete: true
         }));
 
         expect(api.createFoodLog).toHaveBeenCalledWith(expect.objectContaining({ name: 'Dinner' }), 'stable-operation-id');
         expect(api.addMetric).toHaveBeenCalledWith({ date: '2026-07-11', weight: 82.5 }, 'stable-operation-id');
+        expect(api.updateFoodLog).toHaveBeenCalledWith(
+            42,
+            { name: 'Updated dinner', calories: 550, meal_period: 'DINNER' },
+            'stable-operation-id'
+        );
+        expect(api.deleteFoodLog).toHaveBeenCalledWith(43, 'stable-operation-id');
+        expect(api.deleteMetric).toHaveBeenCalledWith(44, 'stable-operation-id');
         expect(api.updateFoodDay).toHaveBeenCalledWith(
             { date: '2026-07-11', is_complete: true },
             'stable-operation-id'
@@ -119,5 +134,9 @@ describe('createQueuedMutationExecutor', () => {
         await expect(execute(queuedMutation('unknown.operation', {}))).rejects.toThrow('Unsupported');
         await expect(execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.ADD_METRIC, { weight: 'bad' })))
             .rejects.toThrow('metric.add payload is invalid');
+        await expect(execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.DELETE_FOOD_LOG, { id: 0 })))
+            .rejects.toThrow('food.delete payload is invalid');
+        await expect(execute(queuedMutation(OFFLINE_MUTATION_OPERATIONS.UPDATE_FOOD_LOG, { id: 1, update: null })))
+            .rejects.toThrow('food.update payload is invalid');
     });
 });

--- a/mobile/src/offline/operations.ts
+++ b/mobile/src/offline/operations.ts
@@ -1,10 +1,18 @@
-import { ApiError, type CalibrateApiClient, type FoodLogCreatePayload } from '@calibrate/api-client';
+import {
+    ApiError,
+    type CalibrateApiClient,
+    type FoodLogCreatePayload,
+    type FoodLogUpdatePayload
+} from '@calibrate/api-client';
 import * as Crypto from 'expo-crypto';
 import type { QueuedMutationExecutor } from './reconciler';
 
 export const OFFLINE_MUTATION_OPERATIONS = {
     CREATE_FOOD_LOG: 'food.create',
+    UPDATE_FOOD_LOG: 'food.update',
+    DELETE_FOOD_LOG: 'food.delete',
     ADD_METRIC: 'metric.add',
+    DELETE_METRIC: 'metric.delete',
     UPDATE_FOOD_DAY: 'food-day.update'
 } as const;
 
@@ -29,6 +37,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function requireRecordPayload(value: unknown, operation: string): Record<string, unknown> {
     if (!isRecord(value)) throw new Error(`Queued ${operation} payload is invalid.`);
+    return value;
+}
+
+function requirePositiveInteger(value: unknown, operation: string): number {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+        throw new Error(`Queued ${operation} payload is invalid.`);
+    }
     return value;
 }
 
@@ -68,11 +83,23 @@ export function createQueuedMutationExecutor(api: CalibrateApiClient): QueuedMut
             case OFFLINE_MUTATION_OPERATIONS.CREATE_FOOD_LOG:
                 await api.createFoodLog(payload as FoodLogCreatePayload, mutation.id);
                 return;
+            case OFFLINE_MUTATION_OPERATIONS.UPDATE_FOOD_LOG: {
+                const id = requirePositiveInteger(payload.id, mutation.operation);
+                const update = requireRecordPayload(payload.update, mutation.operation) as FoodLogUpdatePayload;
+                await api.updateFoodLog(id, update, mutation.id);
+                return;
+            }
+            case OFFLINE_MUTATION_OPERATIONS.DELETE_FOOD_LOG:
+                await api.deleteFoodLog(requirePositiveInteger(payload.id, mutation.operation), mutation.id);
+                return;
             case OFFLINE_MUTATION_OPERATIONS.ADD_METRIC:
                 if (typeof payload.weight !== 'number' || typeof payload.date !== 'string') {
                     throw new Error('Queued metric.add payload is invalid.');
                 }
                 await api.addMetric({ weight: payload.weight, date: payload.date }, mutation.id);
+                return;
+            case OFFLINE_MUTATION_OPERATIONS.DELETE_METRIC:
+                await api.deleteMetric(requirePositiveInteger(payload.id, mutation.operation), mutation.id);
                 return;
             case OFFLINE_MUTATION_OPERATIONS.UPDATE_FOOD_DAY:
                 if (typeof payload.date !== 'string' || typeof payload.is_complete !== 'boolean') {

--- a/mobile/src/utils/dates.test.ts
+++ b/mobile/src/utils/dates.test.ts
@@ -1,0 +1,33 @@
+import {
+    addDaysToDateOnly,
+    getLocalDateForTimestamp
+} from './dates';
+
+describe('mobile local-day handling', () => {
+    it('keeps spring-forward timestamps on the correct Los Angeles calendar day', () => {
+        expect(getLocalDateForTimestamp('2026-03-08T07:30:00.000Z', 'America/Los_Angeles'))
+            .toBe('2026-03-07');
+        expect(getLocalDateForTimestamp('2026-03-08T10:30:00.000Z', 'America/Los_Angeles'))
+            .toBe('2026-03-08');
+    });
+
+    it('maps both repeated fall-back hours to the same calendar day', () => {
+        expect(getLocalDateForTimestamp('2026-11-01T08:30:00.000Z', 'America/Los_Angeles'))
+            .toBe('2026-11-01');
+        expect(getLocalDateForTimestamp('2026-11-01T09:30:00.000Z', 'America/Los_Angeles'))
+            .toBe('2026-11-01');
+    });
+
+    it('re-groups a timestamp when the profile timezone changes', () => {
+        const timestamp = '2026-07-11T01:00:00.000Z';
+        expect(getLocalDateForTimestamp(timestamp, 'America/Los_Angeles')).toBe('2026-07-10');
+        expect(getLocalDateForTimestamp(timestamp, 'Asia/Tokyo')).toBe('2026-07-11');
+    });
+
+    it('advances date-only values by calendar day without DST-hour arithmetic', () => {
+        expect(addDaysToDateOnly('2026-03-07', 1)).toBe('2026-03-08');
+        expect(addDaysToDateOnly('2026-03-08', 1)).toBe('2026-03-09');
+        expect(addDaysToDateOnly('2026-10-31', 1)).toBe('2026-11-01');
+        expect(addDaysToDateOnly('2026-11-01', 1)).toBe('2026-11-02');
+    });
+});

--- a/mobile/src/utils/myFoodEditing.test.ts
+++ b/mobile/src/utils/myFoodEditing.test.ts
@@ -1,0 +1,33 @@
+import type { MyFoodDetail, MyFoodSummary } from '@calibrate/api-client';
+import { hydrateRecipeIngredientDrafts, serializeRecipeIngredientDrafts } from './myFoodEditing';
+
+const savedFood = { id: 4, name: 'Oats', type: 'FOOD', is_pinned: false } as MyFoodSummary;
+
+test('recipe editing restores live source foods and preserves orphan snapshots', () => {
+    const detail = {
+        recipe_ingredients: [
+            { id: 1, source: 'MY_FOOD', source_my_food_id: 4, quantity_servings: 2 },
+            {
+                id: 2,
+                source: 'MY_FOOD',
+                source_my_food_id: null,
+                quantity_servings: 1,
+                name_snapshot: 'Deleted food',
+                calories_total_snapshot: 90,
+                external_source: null,
+                external_id: null,
+                brand_snapshot: null,
+                locale_snapshot: null,
+                barcode_snapshot: null,
+                measure_label_snapshot: null,
+                grams_per_measure_snapshot: null,
+                measure_quantity_snapshot: null,
+                grams_total_snapshot: null
+            }
+        ]
+    } as unknown as MyFoodDetail;
+    const drafts = hydrateRecipeIngredientDrafts(detail, [savedFood]);
+    const serialized = serializeRecipeIngredientDrafts(drafts);
+    expect(serialized[0]).toEqual(expect.objectContaining({ source: 'MY_FOOD', my_food_id: 4, quantity_servings: 2 }));
+    expect(serialized[1]).toEqual(expect.objectContaining({ source: 'EXTERNAL', name: 'Deleted food', calories_total: 90 }));
+});

--- a/mobile/src/utils/myFoodEditing.ts
+++ b/mobile/src/utils/myFoodEditing.ts
@@ -1,0 +1,68 @@
+import type { CreateRecipePayload, MyFoodDetail, MyFoodSummary } from '@calibrate/api-client';
+
+export type RecipeIngredientDraft =
+    | { key: string; source: 'MY_FOOD'; myFood: MyFoodSummary; servings: number }
+    | {
+          key: string;
+          source: 'EXTERNAL';
+          name: string;
+          caloriesTotal: number;
+          snapshot: Omit<Extract<CreateRecipePayload['ingredients'][number], { source: 'EXTERNAL' }>, 'source' | 'sort_order' | 'name' | 'calories_total'>;
+      };
+
+/** Restores editable live references and preserves orphan/external ingredient snapshots verbatim. */
+export function hydrateRecipeIngredientDrafts(
+    detail: MyFoodDetail,
+    savedFoods: MyFoodSummary[]
+): RecipeIngredientDraft[] {
+    return (detail.recipe_ingredients ?? []).map((ingredient) => {
+        const sourceFood = ingredient.source_my_food_id
+            ? savedFoods.find(({ id }) => id === ingredient.source_my_food_id)
+            : undefined;
+        if (ingredient.source === 'MY_FOOD' && sourceFood && ingredient.quantity_servings) {
+            return {
+                key: `existing-${ingredient.id}`,
+                source: 'MY_FOOD' as const,
+                myFood: sourceFood,
+                servings: ingredient.quantity_servings
+            };
+        }
+        return {
+            key: `existing-${ingredient.id}`,
+            source: 'EXTERNAL' as const,
+            name: ingredient.name_snapshot,
+            caloriesTotal: ingredient.calories_total_snapshot,
+            snapshot: {
+                external_source: ingredient.external_source,
+                external_id: ingredient.external_id,
+                brand: ingredient.brand_snapshot,
+                locale: ingredient.locale_snapshot,
+                barcode: ingredient.barcode_snapshot,
+                measure_label: ingredient.measure_label_snapshot,
+                grams_per_measure: ingredient.grams_per_measure_snapshot,
+                measure_quantity: ingredient.measure_quantity_snapshot,
+                grams_total: ingredient.grams_total_snapshot
+            }
+        };
+    });
+}
+
+export function serializeRecipeIngredientDrafts(
+    drafts: RecipeIngredientDraft[]
+): CreateRecipePayload['ingredients'] {
+    return drafts.map((draft, index) => draft.source === 'MY_FOOD'
+        ? {
+              source: 'MY_FOOD',
+              sort_order: index + 1,
+              my_food_id: draft.myFood.id,
+              quantity_servings: draft.servings
+          }
+        : {
+              source: 'EXTERNAL',
+              sort_order: index + 1,
+              name: draft.name,
+              calories_total: draft.caloriesTotal,
+              ...draft.snapshot
+          }
+    );
+}

--- a/mobile/src/utils/myFoods.test.ts
+++ b/mobile/src/utils/myFoods.test.ts
@@ -1,0 +1,30 @@
+import type { MyFoodSummary, RecentFoodSummary } from '@calibrate/api-client';
+import { selectQuickRecentFoods, sortMyFoodsPinnedFirst } from './myFoods';
+
+function item(id: number, name: string, isPinned: boolean): MyFoodSummary {
+    return {
+        id,
+        name,
+        is_pinned: isPinned,
+        type: 'FOOD',
+        serving_size_quantity: 1,
+        serving_unit_label: 'serving',
+        calories_per_serving: 100
+    };
+}
+
+test('sortMyFoodsPinnedFirst is deterministic with pinned items first', () => {
+    const original = [item(3, 'banana', false), item(2, 'Apple', true), item(1, 'Apple', true)];
+    expect(sortMyFoodsPinnedFirst(original).map(({ id }) => id)).toEqual([1, 2, 3]);
+    expect(original.map(({ id }) => id)).toEqual([3, 2, 1]);
+});
+
+test('selectQuickRecentFoods removes pinned duplicates without reordering recency', () => {
+    const recent = [
+        { id: 'recent-1', my_food_id: 2, name: 'Apple' },
+        { id: 'recent-2', my_food_id: null, name: 'Soup' },
+        { id: 'recent-3', my_food_id: 3, name: 'Banana' }
+    ] as unknown as RecentFoodSummary[];
+    expect(selectQuickRecentFoods(recent, [item(2, 'Apple', true)], 2).map(({ id }) => id))
+        .toEqual(['recent-2', 'recent-3']);
+});

--- a/mobile/src/utils/myFoods.ts
+++ b/mobile/src/utils/myFoods.ts
@@ -1,0 +1,31 @@
+import type { MyFoodSummary, RecentFoodSummary } from '@calibrate/api-client';
+
+function compareNames(left: string, right: string): number {
+    const normalizedLeft = left.toLowerCase();
+    const normalizedRight = right.toLowerCase();
+    if (normalizedLeft < normalizedRight) return -1;
+    if (normalizedLeft > normalizedRight) return 1;
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+}
+
+/** Mirrors the API's pinned/name/id order while updating the React Query cache. */
+export function sortMyFoodsPinnedFirst(items: MyFoodSummary[]): MyFoodSummary[] {
+    return [...items].sort((left, right) => {
+        if (left.is_pinned !== right.is_pinned) return left.is_pinned ? -1 : 1;
+        return compareNames(left.name, right.name) || left.id - right.id;
+    });
+}
+
+/** Avoids showing the same saved item in both quick-log sections while preserving recency order. */
+export function selectQuickRecentFoods(
+    recentFoods: RecentFoodSummary[],
+    pinnedFoods: MyFoodSummary[],
+    limit: number
+): RecentFoodSummary[] {
+    const pinnedIds = new Set(pinnedFoods.map(({ id }) => id));
+    return recentFoods
+        .filter((recent) => !recent.my_food_id || !pinnedIds.has(recent.my_food_id))
+        .slice(0, limit);
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:backend": "npm --prefix backend test",
     "test:frontend": "npm --prefix frontend test",
     "test:mobile": "npm --prefix mobile test",
+    "test:android:e2e": "node scripts/android-e2e.mjs",
     "test:coverage": "npm run test:coverage:backend && npm run test:coverage:frontend",
     "test:coverage:backend": "npm --prefix backend run test:coverage",
     "test:coverage:frontend": "npm --prefix frontend run test:coverage"

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,6 +1,7 @@
 import type {
     AccountExport,
     ClientConfigResponse,
+    CreateMyFoodPayload,
     FoodLogCreatePayload,
     FoodLogDay,
     FoodLogEntry,
@@ -21,6 +22,7 @@ import type {
     RecentFoodsResponse,
     SyncChangesResponse,
     TrendMetricsResponse,
+    UpdateMyFoodPayload,
     UserClientPayload,
     UserProfileResponse
 } from './types';
@@ -369,7 +371,7 @@ export class CalibrateApiClient {
         });
     }
 
-    createMyFood(payload: Record<string, unknown>): Promise<MyFoodSummary> {
+    createMyFood(payload: CreateMyFoodPayload): Promise<MyFoodSummary> {
         return this.request<MyFoodSummary>('/api/my-foods/foods', {
             method: 'POST',
             json: payload
@@ -380,6 +382,19 @@ export class CalibrateApiClient {
         return this.request<MyFoodSummary>('/api/my-foods/recipes', {
             method: 'POST',
             json: payload
+        });
+    }
+
+    updateMyFood(id: number, payload: UpdateMyFoodPayload): Promise<MyFoodSummary> {
+        return this.request<MyFoodSummary>(`/api/my-foods/${encodeURIComponent(String(id))}`, {
+            method: 'PATCH',
+            json: payload
+        });
+    }
+
+    deleteMyFood(id: number): Promise<void> {
+        return this.request<void>(`/api/my-foods/${encodeURIComponent(String(id))}`, {
+            method: 'DELETE'
         });
     }
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -139,6 +139,10 @@ export class CalibrateApiClient {
         const callerSignal = options.signal;
         const abortFromCaller = () => timeoutController.abort();
         callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+        if (callerSignal?.aborted) {
+            // An abort event that fired before listener registration must still cancel this request.
+            abortFromCaller();
+        }
 
         let response: Response;
         try {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -362,6 +362,13 @@ export class CalibrateApiClient {
         return this.request<MyFoodDetail>(`/api/my-foods/${encodeURIComponent(String(id))}`);
     }
 
+    setMyFoodPinned(id: number, isPinned: boolean): Promise<MyFoodSummary> {
+        return this.request<MyFoodSummary>(`/api/my-foods/${encodeURIComponent(String(id))}/pin`, {
+            method: 'PATCH',
+            json: { is_pinned: isPinned }
+        });
+    }
+
     createMyFood(payload: Record<string, unknown>): Promise<MyFoodSummary> {
         return this.request<MyFoodSummary>('/api/my-foods/foods', {
             method: 'POST',

--- a/packages/api-client/src/generated/v1.ts
+++ b/packages/api-client/src/generated/v1.ts
@@ -282,6 +282,7 @@ export interface components {
             serving_size_quantity: number;
             serving_unit_label: string;
             calories_per_serving: number;
+            is_pinned: boolean;
             recipe_total_calories: number | null;
             yield_servings: number | null;
             /** Format: date-time */

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -101,6 +101,7 @@ export type AccountExport = {
         serving_size_quantity: number;
         serving_unit_label: string;
         calories_per_serving: number;
+        is_pinned: boolean;
         recipe_total_calories: number | null;
         yield_servings: number | null;
         created_at: string;
@@ -364,6 +365,7 @@ export type MyFoodSummary = {
     serving_size_quantity: number;
     serving_unit_label: string;
     calories_per_serving: number;
+    is_pinned: boolean;
     recipe_total_calories?: number | null;
     yield_servings?: number | null;
 };

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -379,10 +379,31 @@ export type RecipeIngredientSummary = {
     source: RecipeIngredientSource;
     name_snapshot: string;
     calories_total_snapshot: number;
+    source_my_food_id: number | null;
+    quantity_servings: number | null;
+    serving_size_quantity_snapshot: number | null;
+    serving_unit_label_snapshot: string | null;
+    calories_per_serving_snapshot: number | null;
+    external_source: string | null;
+    external_id: string | null;
+    brand_snapshot: string | null;
+    locale_snapshot: string | null;
+    barcode_snapshot: string | null;
+    measure_label_snapshot: string | null;
+    grams_per_measure_snapshot: number | null;
+    measure_quantity_snapshot: number | null;
+    grams_total_snapshot: number | null;
 };
 
 export type MyFoodDetail = MyFoodSummary & {
     recipe_ingredients?: RecipeIngredientSummary[];
+};
+
+export type CreateMyFoodPayload = {
+    name: string;
+    serving_size_quantity: number;
+    serving_unit_label: string;
+    calories_per_serving: number;
 };
 
 export type CreateRecipePayload = {
@@ -414,6 +435,8 @@ export type CreateRecipePayload = {
           }
     >;
 };
+
+export type UpdateMyFoodPayload = CreateMyFoodPayload | CreateRecipePayload;
 
 export type TrendMetricEntry = MetricEntry & {
     user_id: number;

--- a/packages/api-client/test/client-operation-id.test.ts
+++ b/packages/api-client/test/client-operation-id.test.ts
@@ -84,6 +84,39 @@ test('updatePreferences sends the caller operation ID', async () => {
     assert.equal(getOperationId(requests[0]), 'preferences-operation-1');
 });
 
+test('updateFoodLog sends the caller operation ID', async () => {
+    const requests: CapturedRequest[] = [];
+    const client = createClient(requests);
+
+    await client.updateFoodLog(42, { calories: 420 }, 'food-update-operation-1');
+
+    assert.equal(requests[0]?.url, 'https://calibrate.example/api/v1/food/42');
+    assert.equal(requests[0]?.init.method, 'PATCH');
+    assert.equal(getOperationId(requests[0]), 'food-update-operation-1');
+});
+
+test('deleteFoodLog sends the caller operation ID', async () => {
+    const requests: CapturedRequest[] = [];
+    const client = createClient(requests);
+
+    await client.deleteFoodLog(42, 'food-delete-operation-1');
+
+    assert.equal(requests[0]?.url, 'https://calibrate.example/api/v1/food/42');
+    assert.equal(requests[0]?.init.method, 'DELETE');
+    assert.equal(getOperationId(requests[0]), 'food-delete-operation-1');
+});
+
+test('deleteMetric sends the caller operation ID', async () => {
+    const requests: CapturedRequest[] = [];
+    const client = createClient(requests);
+
+    await client.deleteMetric(24, 'metric-delete-operation-1');
+
+    assert.equal(requests[0]?.url, 'https://calibrate.example/api/v1/metrics/24');
+    assert.equal(requests[0]?.init.method, 'DELETE');
+    assert.equal(getOperationId(requests[0]), 'metric-delete-operation-1');
+});
+
 test('operation ID header is omitted when callers do not provide one', async () => {
     const requests: CapturedRequest[] = [];
     const client = createClient(requests);

--- a/packages/api-client/test/my-food-editing.test.ts
+++ b/packages/api-client/test/my-food-editing.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CalibrateApiClient } from '../src/client.ts';
+
+test('updateMyFood patches the owned resource with a typed snapshot definition', async () => {
+    let request: { url: string; init: RequestInit } | undefined;
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        fetchImpl: (async (input, init) => {
+            request = { url: String(input), init: init ?? {} };
+            return new Response(JSON.stringify({ id: 5 }), { status: 200 });
+        }) as typeof fetch
+    });
+    const payload = {
+        name: 'Oats',
+        serving_size_quantity: 1,
+        serving_unit_label: 'bowl',
+        calories_per_serving: 180
+    };
+    await client.updateMyFood(5, payload);
+    assert.equal(request?.url, 'https://calibrate.example/api/v1/my-foods/5');
+    assert.equal(request?.init.method, 'PATCH');
+    assert.deepEqual(JSON.parse(String(request?.init.body)), payload);
+});
+
+test('deleteMyFood deletes the resource and accepts an empty response', async () => {
+    let request: { url: string; init: RequestInit } | undefined;
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        fetchImpl: (async (input, init) => {
+            request = { url: String(input), init: init ?? {} };
+            return new Response(null, { status: 204 });
+        }) as typeof fetch
+    });
+    await client.deleteMyFood(5);
+    assert.equal(request?.url, 'https://calibrate.example/api/v1/my-foods/5');
+    assert.equal(request?.init.method, 'DELETE');
+});

--- a/packages/api-client/test/my-food-pinning.test.ts
+++ b/packages/api-client/test/my-food-pinning.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CalibrateApiClient } from '../src/client.ts';
+
+test('setMyFoodPinned sends an ownership-safe resource patch payload', async () => {
+    let capturedUrl = '';
+    let capturedInit: RequestInit = {};
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        fetchImpl: (async (input, init) => {
+            capturedUrl = String(input);
+            capturedInit = init ?? {};
+            return new Response(JSON.stringify({
+                id: 42,
+                type: 'FOOD',
+                name: 'Oats',
+                serving_size_quantity: 1,
+                serving_unit_label: 'serving',
+                calories_per_serving: 180,
+                is_pinned: true
+            }), { status: 200, headers: { 'content-type': 'application/json' } });
+        }) as typeof fetch
+    });
+
+    const result = await client.setMyFoodPinned(42, true);
+
+    assert.equal(capturedUrl, 'https://calibrate.example/api/v1/my-foods/42/pin');
+    assert.equal(capturedInit.method, 'PATCH');
+    assert.deepEqual(JSON.parse(String(capturedInit.body)), { is_pinned: true });
+    assert.equal(result.is_pinned, true);
+});

--- a/packages/api-client/test/transport.test.ts
+++ b/packages/api-client/test/transport.test.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ApiError, CalibrateApiClient } from '../src/client.ts';
+
+type InternalRequest = <T>(
+    path: string,
+    options?: RequestInit & { auth?: boolean; json?: unknown }
+) => Promise<T>;
+
+const getInternalRequest = (client: CalibrateApiClient): InternalRequest =>
+    (client as unknown as { request: InternalRequest }).request.bind(client);
+
+const abortError = (): Error => {
+    const error = new Error('The operation was aborted.');
+    error.name = 'AbortError';
+    return error;
+};
+
+const createAbortAwareFetch = (): typeof fetch =>
+    (async (_input, init) => {
+        const signal = init?.signal;
+        if (signal?.aborted) throw abortError();
+
+        return new Promise<Response>((_resolve, reject) => {
+            signal?.addEventListener('abort', () => reject(abortError()), { once: true });
+        });
+    }) as typeof fetch;
+
+test('request timeout reports a connection timeout rather than a caller abort', async () => {
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        fetchImpl: createAbortAwareFetch(),
+        requestTimeoutMs: 5
+    });
+
+    await assert.rejects(
+        () => client.getClientConfig(),
+        (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /^Request timed out while connecting to https:\/\/calibrate\.example\./);
+            assert.notEqual(error.name, 'AbortError');
+            return true;
+        }
+    );
+});
+
+test('caller abort remains an AbortError and is not rewritten as a timeout', async () => {
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        fetchImpl: createAbortAwareFetch(),
+        requestTimeoutMs: 1_000
+    });
+    const controller = new AbortController();
+    const pending = getInternalRequest(client)('/api/client-config', {
+        auth: false,
+        signal: controller.signal
+    });
+
+    controller.abort();
+
+    await assert.rejects(
+        () => pending,
+        (error) => {
+            assert.ok(error instanceof Error);
+            assert.equal(error.name, 'AbortError');
+            assert.doesNotMatch(error.message, /timed out/i);
+            return true;
+        }
+    );
+});
+
+test('a signal aborted before the request reaches fetch is still honored', async () => {
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        fetchImpl: createAbortAwareFetch(),
+        requestTimeoutMs: 1_000
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await assert.rejects(
+        () => getInternalRequest(client)('/api/client-config', { auth: false, signal: controller.signal }),
+        (error) => {
+            assert.ok(error instanceof Error);
+            assert.equal(error.name, 'AbortError');
+            return true;
+        }
+    );
+});
+
+for (const responseBody of ['upstream unavailable', '<html><body>Bad gateway</body></html>', '{"message":']) {
+    test(`non-JSON error body is retained without masking HTTP status: ${responseBody.slice(0, 20)}`, async () => {
+        const client = new CalibrateApiClient({
+            baseUrl: 'https://calibrate.example',
+            fetchImpl: (async () => new Response(responseBody, { status: 502 })) as typeof fetch
+        });
+
+        await assert.rejects(
+            () => client.getClientConfig(),
+            (error) => {
+                assert.ok(error instanceof ApiError);
+                assert.equal(error.status, 502);
+                assert.equal(error.message, 'Request failed with status 502');
+                assert.equal(error.body, responseBody);
+                return true;
+            }
+        );
+    });
+}
+
+test('one successful refresh retries the original request with the replacement token', async () => {
+    const authorizationHeaders: Array<string | null> = [];
+    let accessToken = 'expired-token';
+    let refreshCalls = 0;
+    let unauthorizedCalls = 0;
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        getAccessToken: () => accessToken,
+        refreshAccessToken: async () => {
+            refreshCalls += 1;
+            accessToken = 'replacement-token';
+            return true;
+        },
+        onUnauthorized: () => {
+            unauthorizedCalls += 1;
+        },
+        fetchImpl: (async (_input, init) => {
+            authorizationHeaders.push(new Headers(init?.headers).get('authorization'));
+            if (authorizationHeaders.length === 1) {
+                return new Response('{"message":"expired"}', { status: 401 });
+            }
+            return new Response('{"user":{"id":7}}', { status: 200 });
+        }) as typeof fetch
+    });
+
+    const result = await client.getMe();
+
+    assert.equal(result.user.id, 7);
+    assert.deepEqual(authorizationHeaders, ['Bearer expired-token', 'Bearer replacement-token']);
+    assert.equal(refreshCalls, 1);
+    assert.equal(unauthorizedCalls, 0);
+});
+
+test('a retried 401 does not start another refresh loop', async () => {
+    let accessToken = 'expired-token';
+    let fetchCalls = 0;
+    let refreshCalls = 0;
+    let unauthorizedCalls = 0;
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        getAccessToken: () => accessToken,
+        refreshAccessToken: async () => {
+            refreshCalls += 1;
+            accessToken = 'replacement-token';
+            return true;
+        },
+        onUnauthorized: () => {
+            unauthorizedCalls += 1;
+        },
+        fetchImpl: (async () => {
+            fetchCalls += 1;
+            return new Response('{"message":"still unauthorized"}', { status: 401 });
+        }) as typeof fetch
+    });
+
+    await assert.rejects(
+        () => client.getMe(),
+        (error) => {
+            assert.ok(error instanceof ApiError);
+            assert.equal(error.status, 401);
+            assert.equal(error.message, 'still unauthorized');
+            return true;
+        }
+    );
+    assert.equal(fetchCalls, 2);
+    assert.equal(refreshCalls, 1);
+    assert.equal(unauthorizedCalls, 1);
+});

--- a/scripts/android-e2e.mjs
+++ b/scripts/android-e2e.mjs
@@ -1,0 +1,219 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const API_URL = process.env.CALIBRATE_E2E_API_URL ?? 'http://127.0.0.1:3000';
+const TEST_EMAIL = process.env.CALIBRATE_E2E_EMAIL ?? 'test@calibratehealth.app';
+const TEST_PASSWORD = process.env.CALIBRATE_E2E_PASSWORD ?? 'password123';
+const APP_ID = 'app.calibratehealth.mobile';
+const UI_DUMP_PATH = '/sdcard/calibrate-e2e-window.xml';
+const ADB = process.env.ADB
+  ?? path.join(process.env.LOCALAPPDATA ?? '', 'Android', 'Sdk', 'platform-tools', 'adb.exe');
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function adb(args, options = {}) {
+  return execFileSync(ADB, args, {
+    encoding: 'utf8',
+    stdio: options.quiet ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'pipe', 'inherit']
+  }).trim();
+}
+
+async function waitFor(label, check, timeoutMs = 30_000, intervalMs = 500) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const result = await check();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${label}.${lastError ? ` Last error: ${lastError.message}` : ''}`);
+}
+
+function decodeXml(value) {
+  return value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
+}
+
+function readAttribute(node, name) {
+  const match = node.match(new RegExp(`${name}="([^"]*)"`));
+  return match ? decodeXml(match[1]) : '';
+}
+
+function parseBounds(value) {
+  const match = value.match(/^\[(\d+),(\d+)]\[(\d+),(\d+)]$/);
+  if (!match) throw new Error(`Invalid Android bounds: ${value}`);
+  const [, left, top, right, bottom] = match.map(Number);
+  return { x: Math.round((left + right) / 2), y: Math.round((top + bottom) / 2) };
+}
+
+function dumpUi() {
+  adb(['shell', 'uiautomator', 'dump', UI_DUMP_PATH], { quiet: true });
+  return adb(['exec-out', 'cat', UI_DUMP_PATH], { quiet: true });
+}
+
+function findNode(xml, predicate) {
+  const nodes = xml.match(/<node\b[^>]*>/g) ?? [];
+  for (const node of nodes) {
+    const candidate = {
+      text: readAttribute(node, 'text'),
+      label: readAttribute(node, 'content-desc'),
+      bounds: readAttribute(node, 'bounds'),
+      clickable: readAttribute(node, 'clickable') === 'true'
+    };
+    if (predicate(candidate)) return candidate;
+  }
+  return null;
+}
+
+async function waitForNode(label, predicate, timeoutMs = 30_000) {
+  return waitFor(label, async () => findNode(dumpUi(), predicate), timeoutMs, 750);
+}
+
+async function tapNode(label, predicate, timeoutMs = 30_000) {
+  const node = await waitForNode(label, predicate, timeoutMs);
+  const point = parseBounds(node.bounds);
+  adb(['shell', 'input', 'tap', String(point.x), String(point.y)], { quiet: true });
+}
+
+async function requestJson(pathname, options = {}) {
+  const method = options.method ?? 'GET';
+  const attempts = method === 'GET' ? 3 : 1;
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetch(`${API_URL}${pathname}`, options);
+      const body = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(`${method} ${pathname} returned ${response.status}`);
+      return body;
+    } catch (error) {
+      lastError = error;
+      // The local dev server may retire an idle keep-alive socket while the emulator boots.
+      if (attempt < attempts) await sleep(250 * attempt);
+    }
+  }
+  throw lastError;
+}
+
+async function loginApi() {
+  return requestJson('/auth/mobile/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      email: TEST_EMAIL,
+      password: TEST_PASSWORD,
+      device_id: 'android-e2e-probe',
+      device_platform: 'android_phone',
+      device_name: 'Android E2E probe'
+    })
+  });
+}
+
+function localDateFor(timeZone) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).formatToParts(new Date());
+  const value = (type) => parts.find((part) => part.type === type)?.value;
+  return `${value('year')}-${value('month')}-${value('day')}`;
+}
+
+async function countFood(accessToken, date, name) {
+  const logs = await requestJson(`/api/v1/food?date=${encodeURIComponent(date)}`, {
+    headers: { authorization: `Bearer ${accessToken}` }
+  });
+  return logs.filter((entry) => entry.name === name).length;
+}
+
+async function waitForFoodCount(accessToken, date, name, expected, timeoutMs = 30_000) {
+  return waitFor(`${name} count ${expected}`, async () => {
+    const count = await countFood(accessToken, date, name);
+    return count === expected ? count : null;
+  }, timeoutMs, 750);
+}
+
+async function launchAndWaitForLog() {
+  adb(['shell', 'am', 'force-stop', APP_ID], { quiet: true });
+  adb(['shell', 'monkey', '-p', APP_ID, '-c', 'android.intent.category.LAUNCHER', '1'], { quiet: true });
+  await waitForNode('authenticated Log screen', (node) => node.clickable && node.label === 'Add food', 45_000);
+}
+
+async function logRecentFood(name) {
+  await tapNode('Add food button', (node) => node.clickable && node.label === 'Add food');
+  await tapNode(`${name} recent row`, (node) => node.clickable && node.label.startsWith(`${name},`));
+  await waitForNode('Add food sheet to close', (node) => node.clickable && node.label === 'Add food', 25_000);
+}
+
+async function main() {
+  const health = await requestJson('/api/v1/healthz');
+  if (!health.ok) throw new Error('Calibrate E2E backend health check failed.');
+  const metroStatus = await fetch('http://127.0.0.1:8081/status').then((response) => response.text());
+  if (!metroStatus.includes('packager-status:running')) {
+    throw new Error('Metro is not running on port 8081. Start the mobile dev server first.');
+  }
+
+  const session = await loginApi();
+  const date = localDateFor(session.user.timezone);
+  adb(['wait-for-device'], { quiet: true });
+  adb(['reverse', 'tcp:8081', 'tcp:8081'], { quiet: true });
+  adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'disable'], { quiet: true });
+  // Scope the crash assertion to this run so stale emulator crashes do not cause a false failure.
+  adb(['logcat', '-c'], { quiet: true });
+  adb(['shell', 'pm', 'clear', APP_ID], { quiet: true });
+
+  try {
+    await launchAndWaitForLog();
+
+    const onlineName = 'Latte';
+    const onlineBefore = await countFood(session.access_token, date, onlineName);
+    await logRecentFood(onlineName);
+    await waitForFoodCount(session.access_token, date, onlineName, onlineBefore + 1);
+    console.log(`PASS online one-tap logging: ${onlineName} ${onlineBefore} -> ${onlineBefore + 1}`);
+
+    const offlineName = 'Protein shake';
+    const offlineBefore = await countFood(session.access_token, date, offlineName);
+    adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'enable'], { quiet: true });
+    await logRecentFood(offlineName);
+    const pendingBadge = await waitForNode(
+      'offline pending badge',
+      (node) => node.clickable && node.label.includes('offline changes pending'),
+      25_000
+    );
+    if (!pendingBadge) throw new Error('Queued write was not exposed in the account accessibility label.');
+    if (await countFood(session.access_token, date, offlineName) !== offlineBefore) {
+      throw new Error('Offline write reached the server before reconnect.');
+    }
+
+    adb(['shell', 'am', 'force-stop', APP_ID], { quiet: true });
+    adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'disable'], { quiet: true });
+    await launchAndWaitForLog();
+    await waitForFoodCount(session.access_token, date, offlineName, offlineBefore + 1, 45_000);
+    console.log(`PASS process-death replay: ${offlineName} ${offlineBefore} -> ${offlineBefore + 1}`);
+
+    await launchAndWaitForLog();
+    await sleep(3_000);
+    const finalCount = await countFood(session.access_token, date, offlineName);
+    if (finalCount !== offlineBefore + 1) {
+      throw new Error(`Replay duplicated ${offlineName}: expected ${offlineBefore + 1}, received ${finalCount}`);
+    }
+    const crashes = adb(['logcat', '-b', 'crash', '-d', '-v', 'brief'], { quiet: true });
+    if (/FATAL EXCEPTION|AndroidRuntime/i.test(crashes)) throw new Error(`Android crash buffer is not empty:\n${crashes}`);
+    console.log(`PASS exactly-once replay after second restart: ${offlineName} remained ${finalCount}`);
+  } finally {
+    adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'disable'], { quiet: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- extend durable offline handling to food/weight edits and deletes, with visible pending/failed state
- harden self-hosted server validation/switching, barcode recovery, notification permission/tap routing, accessibility, DST handling, and crash recovery
- add pinned/recent one-tap logging plus searched-food serving/measure selection
- add ownership-safe My Foods and recipe edit/delete while preserving historical snapshots
- define reproducible signed APK/AAB release and upgrade-preservation procedures

## Local validation
- backend build + Prisma validate + 295 tests
- mobile typecheck + 100 tests
- API-client 22 tests
- OpenAPI generated-contract check
- Expo SDK config/prebuild validation
- Pixel 10 / API 36 Metro QA: self-host editor rendered, offline server preserved session, process alive, empty crash buffer

## Notes
- Stacked on Phase 1 PR #224.
- Hosted CI remains non-blocking; local Android validation is the development gate.
- Does not restore removed AWS/Terraform deployment code.

Tracks #218