### PR TITLE
Preserve self-hosted server through Android registration

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
-import { Link } from 'expo-router';
+import { Link, useLocalSearchParams } from 'expo-router';
 import { AppButton } from '../../src/components/AppButton';
 import { AppCard } from '../../src/components/AppCard';
 import { AppText } from '../../src/components/AppText';
@@ -10,22 +10,25 @@ import { SectionHeader } from '../../src/components/SectionHeader';
 import { TextField } from '../../src/components/TextField';
 import { useAuth } from '../../src/auth/AuthContext';
 import { accountDeletionCleanupGuidance } from '../../src/account/accountDeletionNotice';
+import { readAuthServerDraft } from '../../src/auth/authServerDraft';
 import { colors, spacing } from '../../src/theme';
 
 export default function LoginScreen() {
+    const params = useLocalSearchParams<{ serverUrl?: string | string[] }>();
     const {
         login, serverUrl, setServerUrl, testServerUrl, serverConnection, authError,
         accountDeletionCleanupNotice, acknowledgeAccountDeletionCleanupNotice
     } = useAuth();
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
-    const [serverInput, setServerInput] = useState(serverUrl);
+    const routedServerDraft = readAuthServerDraft(params.serverUrl);
+    const [serverInput, setServerInput] = useState(routedServerDraft ?? serverUrl);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        setServerInput(serverUrl);
-    }, [serverUrl]);
+        setServerInput(routedServerDraft ?? serverUrl);
+    }, [routedServerDraft, serverUrl]);
 
     async function handleLogin() {
         if (accountDeletionCleanupNotice) return;
@@ -93,11 +96,14 @@ export default function LoginScreen() {
             </AppCard>
 
             {!accountDeletionCleanupNotice && (
-                <Pressable>
-                    <Link href="/(auth)/register" asChild>
+                <Link
+                    href={{ pathname: '/(auth)/register', params: { serverUrl: serverInput } }}
+                    asChild
+                >
+                    <Pressable accessibilityRole="link">
                         <AppText style={styles.link}>Create an account</AppText>
-                    </Link>
-                </Pressable>
+                    </Pressable>
+                </Link>
             )}
         </Screen>
     );

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -16,7 +16,7 @@ import { colors, spacing } from '../../src/theme';
 export default function LoginScreen() {
     const params = useLocalSearchParams<{ serverUrl?: string | string[] }>();
     const {
-        login, serverUrl, setServerUrl, testServerUrl, serverConnection, authError,
+        login, serverUrl, testServerUrl, serverConnection, authError,
         accountDeletionCleanupNotice, acknowledgeAccountDeletionCleanupNotice
     } = useAuth();
     const [email, setEmail] = useState('');
@@ -35,9 +35,7 @@ export default function LoginScreen() {
         setIsSubmitting(true);
         setError(null);
         try {
-            const changedServer = await setServerUrl(serverInput);
-            if (!changedServer) return;
-            await login(email, password);
+            await login(email, password, serverInput);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unable to sign in.');
         } finally {

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
-import { Link } from 'expo-router';
+import { Link, useLocalSearchParams } from 'expo-router';
 import { AppButton } from '../../src/components/AppButton';
 import { AppCard } from '../../src/components/AppCard';
 import { AppText } from '../../src/components/AppText';
@@ -9,19 +9,22 @@ import { ServerUrlControl } from '../../src/components/ServerUrlControl';
 import { SectionHeader } from '../../src/components/SectionHeader';
 import { TextField } from '../../src/components/TextField';
 import { useAuth } from '../../src/auth/AuthContext';
+import { readAuthServerDraft } from '../../src/auth/authServerDraft';
 import { colors, spacing } from '../../src/theme';
 
 export default function RegisterScreen() {
+    const params = useLocalSearchParams<{ serverUrl?: string | string[] }>();
     const { register, serverUrl, setServerUrl, testServerUrl, serverConnection, authError } = useAuth();
-    const [serverInput, setServerInput] = useState(serverUrl);
+    const routedServerDraft = readAuthServerDraft(params.serverUrl);
+    const [serverInput, setServerInput] = useState(routedServerDraft ?? serverUrl);
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        setServerInput(serverUrl);
-    }, [serverUrl]);
+        setServerInput(routedServerDraft ?? serverUrl);
+    }, [routedServerDraft, serverUrl]);
 
     async function handleRegister() {
         setIsSubmitting(true);
@@ -64,11 +67,14 @@ export default function RegisterScreen() {
                 <AppButton title={isSubmitting ? 'Creating...' : 'Create account'} disabled={isSubmitting} onPress={() => void handleRegister()} />
             </AppCard>
 
-            <Pressable>
-                <Link href="/(auth)/login" asChild>
+            <Link
+                href={{ pathname: '/(auth)/login', params: { serverUrl: serverInput } }}
+                asChild
+            >
+                <Pressable accessibilityRole="link">
                     <AppText style={styles.link}>Back to sign in</AppText>
-                </Link>
-            </Pressable>
+                </Pressable>
+            </Link>
         </Screen>
     );
 }

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -14,7 +14,7 @@ import { colors, spacing } from '../../src/theme';
 
 export default function RegisterScreen() {
     const params = useLocalSearchParams<{ serverUrl?: string | string[] }>();
-    const { register, serverUrl, setServerUrl, testServerUrl, serverConnection, authError } = useAuth();
+    const { register, serverUrl, testServerUrl, serverConnection, authError } = useAuth();
     const routedServerDraft = readAuthServerDraft(params.serverUrl);
     const [serverInput, setServerInput] = useState(routedServerDraft ?? serverUrl);
     const [email, setEmail] = useState('');
@@ -30,9 +30,7 @@ export default function RegisterScreen() {
         setIsSubmitting(true);
         setError(null);
         try {
-            const changedServer = await setServerUrl(serverInput);
-            if (!changedServer) return;
-            await register(email, password);
+            await register(email, password, serverInput);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unable to create account.');
         } finally {

--- a/mobile/src/auth/AuthContext.tsx
+++ b/mobile/src/auth/AuthContext.tsx
@@ -15,7 +15,7 @@ import {
     type ServerConnectionResult,
     type ServerConnectionState
 } from '../config/server';
-import { confirmServerSwitch } from './serverSwitch';
+import { authenticateAgainstConfirmedServer, confirmServerSwitch } from './serverSwitch';
 import { getSessionRestoreErrorMessage } from './authErrors';
 import { MOBILE_CLIENT_IDENTITY } from '../config/nativeClient';
 import {
@@ -49,8 +49,8 @@ type AuthContextValue = {
     updateCurrentUser: (user: UserClientPayload) => void;
     setServerUrl: (value: string) => Promise<boolean>;
     testServerUrl: (value: string) => Promise<boolean>;
-    login: (email: string, password: string) => Promise<void>;
-    register: (email: string, password: string) => Promise<void>;
+    login: (email: string, password: string, serverCandidate: string) => Promise<boolean>;
+    register: (email: string, password: string, serverCandidate: string) => Promise<boolean>;
     logout: () => Promise<void>;
     clearLocalSession: () => Promise<void>;
     recheckClientCompatibility: () => Promise<boolean>;
@@ -315,7 +315,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return result.ok;
     }, [probeServerUrl]);
 
-    const updateServerUrl = useCallback(async (value: string): Promise<boolean> => {
+    const confirmSelectedServerUrl = useCallback(async (value: string): Promise<ServerConnectionResult> => {
         const result = await confirmServerSwitch({
             candidate: value,
             currentServerUrl: serverUrl,
@@ -325,50 +325,83 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         });
         if (!result.ok) {
             setAuthError(result.message);
-            return false;
+            return result;
         }
 
         setServerUrlState(result.url);
         setAuthError(null);
-        return true;
+        return result;
     }, [clearSession, probeServerUrl, serverUrl]);
+
+    const updateServerUrl = useCallback(async (value: string): Promise<boolean> => {
+        const result = await confirmSelectedServerUrl(value);
+        return result.ok;
+    }, [confirmSelectedServerUrl]);
 
     const updateCurrentUser = useCallback((nextUser: UserClientPayload) => {
         setUser(nextUser);
     }, []);
 
     const login = useCallback(
-        async (email: string, password: string) => {
+        async (email: string, password: string, serverCandidate: string): Promise<boolean> => {
             assertAccountDeletionCleanupAcknowledged(accountDeletionCleanupNotice);
             const nextDeviceId = deviceId ?? (await getOrCreateDeviceId());
             setDeviceId(nextDeviceId);
-            const payload = await api.loginMobile({
-                email,
-                password,
-                device_id: nextDeviceId,
-                device_platform: MOBILE_DEVICE_PLATFORMS.ANDROID_PHONE,
-                device_name: Application.applicationName ?? 'Android device'
+            const payload = await authenticateAgainstConfirmedServer({
+                candidate: serverCandidate,
+                confirmServer: confirmSelectedServerUrl,
+                authenticate: (confirmedServerUrl) => {
+                    const authClient = new CalibrateApiClient({
+                        baseUrl: confirmedServerUrl,
+                        clientIdentity: MOBILE_CLIENT_IDENTITY,
+                        onClientUpgradeRequired: handleClientUpgradeRequired
+                    });
+                    return authClient.loginMobile({
+                        email,
+                        password,
+                        device_id: nextDeviceId,
+                        device_platform: MOBILE_DEVICE_PLATFORMS.ANDROID_PHONE,
+                        device_name: Application.applicationName ?? 'Android device'
+                    });
+                }
             });
+            if (!payload) return false;
+
             await persistAuthPayload(payload);
+            return true;
         },
-        [accountDeletionCleanupNotice, api, deviceId, persistAuthPayload]
+        [accountDeletionCleanupNotice, confirmSelectedServerUrl, deviceId, handleClientUpgradeRequired, persistAuthPayload]
     );
 
     const register = useCallback(
-        async (email: string, password: string) => {
+        async (email: string, password: string, serverCandidate: string): Promise<boolean> => {
             assertAccountDeletionCleanupAcknowledged(accountDeletionCleanupNotice);
             const nextDeviceId = deviceId ?? (await getOrCreateDeviceId());
             setDeviceId(nextDeviceId);
-            const payload = await api.registerMobile({
-                email,
-                password,
-                device_id: nextDeviceId,
-                device_platform: MOBILE_DEVICE_PLATFORMS.ANDROID_PHONE,
-                device_name: Application.applicationName ?? 'Android device'
+            const payload = await authenticateAgainstConfirmedServer({
+                candidate: serverCandidate,
+                confirmServer: confirmSelectedServerUrl,
+                authenticate: (confirmedServerUrl) => {
+                    const authClient = new CalibrateApiClient({
+                        baseUrl: confirmedServerUrl,
+                        clientIdentity: MOBILE_CLIENT_IDENTITY,
+                        onClientUpgradeRequired: handleClientUpgradeRequired
+                    });
+                    return authClient.registerMobile({
+                        email,
+                        password,
+                        device_id: nextDeviceId,
+                        device_platform: MOBILE_DEVICE_PLATFORMS.ANDROID_PHONE,
+                        device_name: Application.applicationName ?? 'Android device'
+                    });
+                }
             });
+            if (!payload) return false;
+
             await persistAuthPayload(payload);
+            return true;
         },
-        [accountDeletionCleanupNotice, api, deviceId, persistAuthPayload]
+        [accountDeletionCleanupNotice, confirmSelectedServerUrl, deviceId, handleClientUpgradeRequired, persistAuthPayload]
     );
 
     const logout = useCallback(async () => {

--- a/mobile/src/auth/authScreenNavigation.test.tsx
+++ b/mobile/src/auth/authScreenNavigation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import LoginScreen from '../../app/(auth)/login';
 import RegisterScreen from '../../app/(auth)/register';
 import { useAuth } from './AuthContext';
@@ -27,8 +27,8 @@ const SELF_HOSTED_URL = 'http://127.0.0.1:3300';
 
 function authContextStub() {
     return {
-        register: jest.fn(async () => undefined),
-        login: jest.fn(async () => undefined),
+        register: jest.fn(async () => true),
+        login: jest.fn(async () => true),
         serverUrl: 'http://10.0.2.2:3000',
         setServerUrl: jest.fn(async () => true),
         testServerUrl: jest.fn(async () => true),
@@ -72,5 +72,33 @@ describe('auth screen server navigation', () => {
 
         expect(screen.getByText(SELF_HOSTED_URL)).toBeTruthy();
         expectAuthLink('/(auth)/login');
+    });
+
+    it('submits login credentials with the routed server draft', async () => {
+        const auth = authContextStub();
+        mockUseAuth.mockReturnValue(auth as unknown as ReturnType<typeof useAuth>);
+        const screen = render(<LoginScreen />);
+
+        fireEvent.changeText(screen.getByLabelText('Email'), 'user@example.com');
+        fireEvent.changeText(screen.getByLabelText('Password'), 'secret');
+        fireEvent.press(screen.getByLabelText('Sign in'));
+
+        await waitFor(() => {
+            expect(auth.login).toHaveBeenCalledWith('user@example.com', 'secret', SELF_HOSTED_URL);
+        });
+    });
+
+    it('submits registration credentials with the routed server draft', async () => {
+        const auth = authContextStub();
+        mockUseAuth.mockReturnValue(auth as unknown as ReturnType<typeof useAuth>);
+        const screen = render(<RegisterScreen />);
+
+        fireEvent.changeText(screen.getByLabelText('Email'), 'new@example.com');
+        fireEvent.changeText(screen.getByLabelText('Password'), 'secret');
+        fireEvent.press(screen.getByLabelText('Create account'));
+
+        await waitFor(() => {
+            expect(auth.register).toHaveBeenCalledWith('new@example.com', 'secret', SELF_HOSTED_URL);
+        });
     });
 });

--- a/mobile/src/auth/authScreenNavigation.test.tsx
+++ b/mobile/src/auth/authScreenNavigation.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import LoginScreen from '../../app/(auth)/login';
+import RegisterScreen from '../../app/(auth)/register';
+import { useAuth } from './AuthContext';
+import { Link, useLocalSearchParams } from 'expo-router';
+
+jest.mock('./AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../account/accountDeletionNotice', () => ({ accountDeletionCleanupGuidance: jest.fn(() => '') }));
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 })
+}));
+jest.mock('expo-router', () => {
+    const ReactActual = jest.requireActual<typeof React>('react');
+    return {
+        useLocalSearchParams: jest.fn(),
+        Link: jest.fn(({ children }: { children: React.ReactElement }) =>
+            ReactActual.createElement(ReactActual.Fragment, null, children))
+    };
+});
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUseLocalSearchParams = useLocalSearchParams as jest.MockedFunction<typeof useLocalSearchParams>;
+const mockLink = Link as unknown as jest.Mock;
+const SELF_HOSTED_URL = 'http://127.0.0.1:3300';
+
+function authContextStub() {
+    return {
+        register: jest.fn(async () => undefined),
+        login: jest.fn(async () => undefined),
+        serverUrl: 'http://10.0.2.2:3000',
+        setServerUrl: jest.fn(async () => true),
+        testServerUrl: jest.fn(async () => true),
+        serverConnection: {
+            status: 'connected' as const,
+            testedInput: SELF_HOSTED_URL,
+            testedUrl: SELF_HOSTED_URL,
+            message: 'Connected to Calibrate 1.0.0 (API v1).'
+        },
+        authError: null,
+        accountDeletionCleanupNotice: null,
+        acknowledgeAccountDeletionCleanupNotice: jest.fn(async () => undefined)
+    };
+}
+
+function expectAuthLink(pathname: string) {
+    const linkProps = mockLink.mock.calls[0][0];
+    expect(linkProps.href).toEqual({
+        pathname,
+        params: { serverUrl: SELF_HOSTED_URL }
+    });
+    expect(linkProps.children.props.accessibilityRole).toBe('link');
+}
+
+describe('auth screen server navigation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseLocalSearchParams.mockReturnValue({ serverUrl: SELF_HOSTED_URL });
+        mockUseAuth.mockReturnValue(authContextStub() as unknown as ReturnType<typeof useAuth>);
+    });
+
+    it('carries the login server draft into the registration link', () => {
+        const screen = render(<LoginScreen />);
+
+        expect(screen.getByText(SELF_HOSTED_URL)).toBeTruthy();
+        expectAuthLink('/(auth)/register');
+    });
+
+    it('carries the registration server draft back to the login link', () => {
+        const screen = render(<RegisterScreen />);
+
+        expect(screen.getByText(SELF_HOSTED_URL)).toBeTruthy();
+        expectAuthLink('/(auth)/login');
+    });
+});

--- a/mobile/src/auth/authServerDraft.test.ts
+++ b/mobile/src/auth/authServerDraft.test.ts
@@ -1,0 +1,14 @@
+import { readAuthServerDraft } from './authServerDraft';
+
+describe('readAuthServerDraft', () => {
+    it('preserves a server carried between auth routes', () => {
+        expect(readAuthServerDraft('http://127.0.0.1:3300')).toBe('http://127.0.0.1:3300');
+    });
+
+    it('uses the first Expo Router value and ignores blank drafts', () => {
+        expect(readAuthServerDraft(['https://first.example', 'https://second.example']))
+            .toBe('https://first.example');
+        expect(readAuthServerDraft('   ')).toBeNull();
+        expect(readAuthServerDraft(undefined)).toBeNull();
+    });
+});

--- a/mobile/src/auth/authServerDraft.ts
+++ b/mobile/src/auth/authServerDraft.ts
@@ -1,0 +1,5 @@
+/** Normalize Expo Router's scalar-or-array query value into one usable server draft. */
+export function readAuthServerDraft(value: string | string[] | undefined): string | null {
+    const candidate = Array.isArray(value) ? value[0] : value;
+    return candidate?.trim() ? candidate : null;
+}

--- a/mobile/src/auth/serverSwitch.test.ts
+++ b/mobile/src/auth/serverSwitch.test.ts
@@ -1,4 +1,4 @@
-import { confirmServerSwitch } from './serverSwitch';
+import { authenticateAgainstConfirmedServer, confirmServerSwitch } from './serverSwitch';
 import type { ServerConnectionResult } from '../config/server';
 
 const failedConnection: ServerConnectionResult = {
@@ -82,5 +82,44 @@ describe('confirmServerSwitch', () => {
 
         expect(clearCurrentSession).not.toHaveBeenCalled();
         expect(persistServerUrl).toHaveBeenCalledWith('https://new.example');
+    });
+});
+
+describe('authenticateAgainstConfirmedServer', () => {
+    it('authenticates against the normalized URL returned by confirmation', async () => {
+        const events: string[] = [];
+        const authenticate = jest.fn(async (confirmedServerUrl: string) => {
+            events.push(`authenticated:${confirmedServerUrl}`);
+            return 'session';
+        });
+
+        const result = await authenticateAgainstConfirmedServer({
+            candidate: 'https://new.example/',
+            confirmServer: async (candidate) => {
+                events.push(`confirmed:${candidate}`);
+                return successfulConnection;
+            },
+            authenticate
+        });
+
+        expect(result).toBe('session');
+        expect(events).toEqual([
+            'confirmed:https://new.example/',
+            'authenticated:https://new.example'
+        ]);
+        expect(authenticate).toHaveBeenCalledWith(successfulConnection.url);
+    });
+
+    it('does not send credentials when server confirmation fails', async () => {
+        const authenticate = jest.fn(async () => 'session');
+
+        const result = await authenticateAgainstConfirmedServer({
+            candidate: 'https://new.example',
+            confirmServer: async () => failedConnection,
+            authenticate
+        });
+
+        expect(result).toBeNull();
+        expect(authenticate).not.toHaveBeenCalled();
     });
 });

--- a/mobile/src/auth/serverSwitch.ts
+++ b/mobile/src/auth/serverSwitch.ts
@@ -8,6 +8,12 @@ type ConfirmServerSwitchOptions = {
     persistServerUrl: (serverUrl: string) => Promise<void>;
 };
 
+type AuthenticateAgainstConfirmedServerOptions<T> = {
+    candidate: string;
+    confirmServer: (candidate: string) => Promise<ServerConnectionResult>;
+    authenticate: (confirmedServerUrl: string) => Promise<T>;
+};
+
 /**
  * Confirm the candidate before mutating server-scoped credentials or persisted settings.
  *
@@ -22,4 +28,19 @@ export async function confirmServerSwitch(options: ConfirmServerSwitchOptions): 
     }
     await options.persistServerUrl(connection.url);
     return connection;
+}
+
+/**
+ * Authenticate against the exact normalized origin that passed the server probe.
+ *
+ * React state updates do not refresh callbacks synchronously, so the credential
+ * request must consume the confirmation result instead of a state-backed client.
+ */
+export async function authenticateAgainstConfirmedServer<T>(
+    options: AuthenticateAgainstConfirmedServerOptions<T>
+): Promise<T | null> {
+    const connection = await options.confirmServer(options.candidate);
+    if (!connection.ok) return null;
+
+    return options.authenticate(connection.url);
 }


### PR DESCRIPTION
## Summary
- preserve a tested self-hosted server draft while moving between sign-in and registration
- fix the Expo Router link touch targets on both auth screens
- add regression coverage for route-carried server selection and link structure

## Validation
- npm.cmd --prefix mobile test -- --runInBand (39 suites, 178 tests)
- npm.cmd --prefix mobile run typecheck
- Android API 36 emulator: custom server test -> registration -> six-step onboarding -> 350 kcal food log -> 199.5 lb weigh-in against an isolated production-like backend