### PR TITLE
Harden Android release validation

### DIFF
--- a/docs/android-e2e.md
+++ b/docs/android-e2e.md
@@ -8,7 +8,7 @@ The adb-driven E2E test exercises a real debug client, backend, Postgres databas
 - the queued write survives process death;
 - reconnect and relaunch replay it exactly once;
 - a second relaunch does not duplicate it;
-- the app process remains alive with an empty Android crash buffer.
+- the app process remains alive with no Calibrate process entry in Android's crash buffer.
 
 ## Prerequisites
 

--- a/mobile/src/components/WearPairingCard.tsx
+++ b/mobile/src/components/WearPairingCard.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import type { WearNode } from '@calibrate/wear-pairing';
 import { useAuth } from '../auth/AuthContext';
 import {
+    getWearPairingErrorMessage,
     getReachableWearNodes,
     processWearPairingInbox,
     readStoredWearPairing,
@@ -60,7 +61,7 @@ export function WearPairingCard() {
             } else setStatus('No compatible reachable Calibrate watch app was found.');
         } catch (error) {
             if (activeScope.current === checkedScope) {
-                setStatus(error instanceof Error ? error.message : 'Unable to check for a Wear OS watch.');
+                setStatus(getWearPairingErrorMessage(error));
             }
         } finally {
             if (activeScope.current === checkedScope) setIsChecking(false);

--- a/mobile/src/wear/pairing.test.ts
+++ b/mobile/src/wear/pairing.test.ts
@@ -12,6 +12,7 @@ jest.mock('expo-crypto', () => ({ randomUUID: jest.fn(() => 'generated-request')
 jest.mock('@calibrate/wear-pairing', () => ({ __esModule: true, default: null }));
 
 import {
+    getWearPairingErrorMessage,
     parseWearAccountDisconnectAck,
     parsePairingHello,
     processWearPairingInbox,
@@ -91,6 +92,22 @@ describe('Wear phone pairing coordinator', () => {
     beforeEach(() => {
         mockStorage.clear();
         jest.clearAllMocks();
+    });
+
+    it('maps unavailable Play Services and raw native failures to actionable pairing guidance', () => {
+        expect(getWearPairingErrorMessage(new Error(
+            "Call to function 'CalibrateWearPairing.getPairingNodes' has been rejected. " +
+            'Caused by: com.google.android.gms.common.api.ApiException: 17: API: Wearable.API is not available ' +
+            'on this device. Connection failed with statusCode=API_UNAVAILABLE'
+        ))).toBe(
+            'Wear OS pairing is unavailable on this phone. Pair a Wear OS watch in Android and update Google Play services, then try again.'
+        );
+        expect(getWearPairingErrorMessage(new Error(
+            'Call to function failed. Caused by: java.lang.IllegalStateException'
+        ))).toBe(
+            'Unable to check for a Wear OS watch. Confirm Bluetooth and Google Play services are available, then try again.'
+        );
+        expect(getWearPairingErrorMessage(new Error('Watch unavailable'))).toBe('Watch unavailable');
     });
 
     it('validates the server-bound, expiring watch hello contract', () => {

--- a/mobile/src/wear/pairing.ts
+++ b/mobile/src/wear/pairing.ts
@@ -81,6 +81,22 @@ const ACCOUNT_DISCONNECT_ACK_TIMEOUT_MS = 8_000;
 const ACCOUNT_DISCONNECT_ACK_POLL_MS = 100;
 const MESSAGE_CLOCK_SKEW_MS = 30_000;
 
+const WEAR_PAIRING_FALLBACK_MESSAGE =
+    'Unable to check for a Wear OS watch. Confirm Bluetooth and Google Play services are available, then try again.';
+
+/** Convert native Play Services failures into actionable copy without exposing implementation details. */
+export function getWearPairingErrorMessage(error: unknown): string {
+    if (!(error instanceof Error) || !error.message.trim()) return WEAR_PAIRING_FALLBACK_MESSAGE;
+    const message = error.message.trim();
+    if (/Wearable\.API is not available|statusCode=API_UNAVAILABLE|ApiException:\s*17/i.test(message)) {
+        return 'Wear OS pairing is unavailable on this phone. Pair a Wear OS watch in Android and update Google Play services, then try again.';
+    }
+    if (/Call to function|Caused by:|com\.google\.android\.gms|\bjava\.[a-z]/i.test(message)) {
+        return WEAR_PAIRING_FALLBACK_MESSAGE;
+    }
+    return message;
+}
+
 function accountScope(serverOrigin: string, userId: number): string {
     return `${encodeURIComponent(new URL(serverOrigin).origin)}/${userId}`;
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "release:check:production": "node scripts/postgres-backup-restore-smoke.mjs && node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs --strict && node scripts/verify-risk-evidence.mjs --release",
     "release:metadata": "node scripts/release-config.mjs metadata",
     "test:release": "node --test scripts/release-config.test.mjs scripts/dependency-advisory-exceptions.test.mjs",
-    "test:native-release": "node --test scripts/native-release-build.test.mjs",
+    "test:native-release": "node --test scripts/native-release-build.test.mjs scripts/android-e2e.test.mjs",
     "test:mobile-build-tools": "node --test scripts/xcode-uuid-compatibility.test.mjs",
     "test:native:upgrade": "node scripts/native-upgrade-rehearsal.mjs",
     "test:native:upgrade:unit": "node --test scripts/native-upgrade-rehearsal.test.mjs",

--- a/scripts/android-e2e.mjs
+++ b/scripts/android-e2e.mjs
@@ -1,13 +1,22 @@
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const API_URL = process.env.CALIBRATE_E2E_API_URL ?? 'http://127.0.0.1:3000';
 const TEST_EMAIL = process.env.CALIBRATE_E2E_EMAIL ?? 'test@calibratehealth.app';
 const TEST_PASSWORD = process.env.CALIBRATE_E2E_PASSWORD ?? 'password123';
 const APP_ID = 'app.calibratehealth.mobile';
+const ONLINE_FOOD = { name: 'Android E2E latte', calories: 190 };
+const OFFLINE_FOOD = { name: 'Android E2E protein shake', calories: 240 };
 const UI_DUMP_PATH = '/sdcard/calibrate-e2e-window.xml';
 const ADB = process.env.ADB
   ?? path.join(process.env.LOCALAPPDATA ?? '', 'Android', 'Sdk', 'platform-tools', 'adb.exe');
+const release = JSON.parse(readFileSync(new URL('../shared/release.json', import.meta.url), 'utf8'));
+const NATIVE_CLIENT_HEADERS = {
+  PLATFORM: 'x-calibrate-client-platform',
+  VERSION: 'x-calibrate-client-version'
+};
 
 const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
@@ -83,13 +92,29 @@ async function tapNode(label, predicate, timeoutMs = 30_000) {
   adb(['shell', 'input', 'tap', String(point.x), String(point.y)], { quiet: true });
 }
 
+/** Attach the release-candidate phone identity to direct API assertions made outside the app. */
+export function buildE2eRequestHeaders(initialHeaders = {}) {
+  const headers = new Headers(initialHeaders);
+  headers.set(NATIVE_CLIENT_HEADERS.PLATFORM, 'android_phone');
+  headers.set(NATIVE_CLIENT_HEADERS.VERSION, release.android.mobile.version_name);
+  return headers;
+}
+
+/** Ignore shell/test-runner crashes while still failing on the Calibrate application process. */
+export function crashBufferContainsCalibrateProcess(crashBuffer) {
+  return /Process:\s+app\.calibratehealth\.mobile(?:[:,\s]|$)/i.test(crashBuffer);
+}
+
 async function requestJson(pathname, options = {}) {
   const method = options.method ?? 'GET';
   const attempts = method === 'GET' ? 3 : 1;
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      const response = await fetch(`${API_URL}${pathname}`, options);
+      const response = await fetch(`${API_URL}${pathname}`, {
+        ...options,
+        headers: buildE2eRequestHeaders(options.headers)
+      });
       const body = await response.json().catch(() => null);
       if (!response.ok) throw new Error(`${method} ${pathname} returned ${response.status}`);
       return body;
@@ -134,6 +159,23 @@ async function countFood(accessToken, date, name) {
   return logs.filter((entry) => entry.name === name).length;
 }
 
+/** Put known rows at the front of Quick recents without relying on mutable seed history. */
+async function seedRecentFood(accessToken, date, food) {
+  await requestJson('/api/v1/food', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      meal_period: 'DINNER',
+      name: food.name,
+      calories: food.calories,
+      date
+    })
+  });
+}
+
 async function waitForFoodCount(accessToken, date, name, expected, timeoutMs = 30_000) {
   return waitFor(`${name} count ${expected}`, async () => {
     const count = await countFood(accessToken, date, name);
@@ -163,6 +205,8 @@ async function main() {
 
   const session = await loginApi();
   const date = localDateFor(session.user.timezone);
+  await seedRecentFood(session.access_token, date, ONLINE_FOOD);
+  await seedRecentFood(session.access_token, date, OFFLINE_FOOD);
   adb(['wait-for-device'], { quiet: true });
   adb(['reverse', 'tcp:8081', 'tcp:8081'], { quiet: true });
   adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'disable'], { quiet: true });
@@ -173,13 +217,13 @@ async function main() {
   try {
     await launchAndWaitForLog();
 
-    const onlineName = 'Latte';
+    const onlineName = ONLINE_FOOD.name;
     const onlineBefore = await countFood(session.access_token, date, onlineName);
     await logRecentFood(onlineName);
     await waitForFoodCount(session.access_token, date, onlineName, onlineBefore + 1);
     console.log(`PASS online one-tap logging: ${onlineName} ${onlineBefore} -> ${onlineBefore + 1}`);
 
-    const offlineName = 'Protein shake';
+    const offlineName = OFFLINE_FOOD.name;
     const offlineBefore = await countFood(session.access_token, date, offlineName);
     adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'enable'], { quiet: true });
     await logRecentFood(offlineName);
@@ -205,15 +249,24 @@ async function main() {
     if (finalCount !== offlineBefore + 1) {
       throw new Error(`Replay duplicated ${offlineName}: expected ${offlineBefore + 1}, received ${finalCount}`);
     }
+    const finalPid = adb(['shell', 'pidof', '-s', APP_ID], { quiet: true });
+    if (!finalPid) throw new Error('Calibrate process is not alive after the final replay check.');
     const crashes = adb(['logcat', '-b', 'crash', '-d', '-v', 'brief'], { quiet: true });
-    if (/FATAL EXCEPTION|AndroidRuntime/i.test(crashes)) throw new Error(`Android crash buffer is not empty:\n${crashes}`);
+    if (crashBufferContainsCalibrateProcess(crashes)) {
+      throw new Error(`Calibrate appears in the Android crash buffer:\n${crashes}`);
+    }
     console.log(`PASS exactly-once replay after second restart: ${offlineName} remained ${finalCount}`);
   } finally {
     adb(['shell', 'cmd', 'connectivity', 'airplane-mode', 'disable'], { quiet: true });
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack : error);
-  process.exitCode = 1;
-});
+const isMain = process.argv[1]
+  && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/android-e2e.test.mjs
+++ b/scripts/android-e2e.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { buildE2eRequestHeaders, crashBufferContainsCalibrateProcess } from './android-e2e.mjs';
+
+const release = JSON.parse(readFileSync(new URL('../shared/release.json', import.meta.url), 'utf8'));
+
+test('Android E2E API probes identify the current phone release', () => {
+  const headers = buildE2eRequestHeaders({
+    authorization: 'Bearer test-token',
+    'x-calibrate-client-platform': 'wear_os',
+    'x-calibrate-client-version': '0.0.0'
+  });
+
+  assert.equal(headers.get('authorization'), 'Bearer test-token');
+  assert.equal(headers.get('x-calibrate-client-platform'), 'android_phone');
+  assert.equal(headers.get('x-calibrate-client-version'), release.android.mobile.version_name);
+});
+
+test('Android E2E crash checks ignore uiautomator but catch the Calibrate process', () => {
+  const uiautomatorCrash = `
+E/AndroidRuntime( 4036): FATAL EXCEPTION: main
+E/AndroidRuntime( 4036): PID: 4036
+E/AndroidRuntime( 4036): java.lang.RuntimeException: Timeout while connecting UiAutomation`;
+  const calibrateCrash = `
+E/AndroidRuntime( 8123): FATAL EXCEPTION: main
+E/AndroidRuntime( 8123): Process: app.calibratehealth.mobile, PID: 8123`;
+
+  assert.equal(crashBufferContainsCalibrateProcess(uiautomatorCrash), false);
+  assert.equal(crashBufferContainsCalibrateProcess(calibrateCrash), true);
+});


### PR DESCRIPTION
## What changed

- make the adb-driven Android E2E flow seed deterministic recent foods and identify itself as the current Android phone release when probing the API
- narrow crash-buffer assertions to the Calibrate process and verify that the app remains alive after replay
- replace raw Wearable API and native exception text with actionable Wear OS pairing guidance
- add focused regression tests and document the crash-buffer contract

## Why

Release-candidate emulator validation exposed three harness assumptions: API probes lacked native client identity, mutable seed history controlled Quick recents, and unrelated `uiautomator` failures could be mistaken for application crashes. The same run also showed raw Google Play services implementation details in the Wear pairing UI when Data Layer was unavailable.

## Impact

Android release validation is deterministic and fails only on Calibrate process crashes. Users receive useful pairing recovery guidance instead of native exception text.

## Validation

- `npm.cmd --prefix mobile test -- --runInBand` (39 suites, 183 tests)
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd run test:native-release` (7 tests)
- `npm.cmd run release:check`
- `npm.cmd run test:release` (13 tests)
- adb-driven Android phone E2E passed online logging, process-death offline replay, and exactly-once replay on the current emulator build
- Wear emulator smoke passed cold start, launch, Tile registration, permissions, and crash checks

## Remaining release boundary

Physical Galaxy phone and Galaxy Watch Ultra Data Layer, Samsung Health, reconnect, and long-running dogfood evidence remain tracked separately and are not claimed by this PR.
