### PR TITLE
Build release image for AMD64 only

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -68,9 +68,6 @@ jobs:
             echo "source_sha=${SOURCE_SHA}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -98,11 +95,11 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push multi-architecture image
+      - name: Build and push AMD64 image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.app
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/docs/expo-web-parity.md
+++ b/docs/expo-web-parity.md
@@ -51,7 +51,7 @@ not delete it while any row is partial or blocked.
 | Localization | Mobile strings are hard-coded English. | Port EN/ES/FR/RU resources and language selection; every visible copy change remains synchronized. |
 | Responsive shell | Ready across compact phone, phone, tablet, and desktop release viewports. | Keep keyboard, overflow, and route-navigation checks in the release suite. |
 | PWA lifecycle | Ready: install metadata, explicit update activation/retry, offline/recovery UI, and backend cache bypass are implemented. | Validate two-version upgrade and installed-mode behavior on a production HTTPS host. |
-| Static delivery | Ready: the production image builds the validated Expo export, serves prerendered routes, preserves backend boundaries, and applies PWA-safe cache headers. | Keep the container smoke test and tagged multi-architecture build green. |
+| Static delivery | Ready: the production image builds the validated Expo export, serves prerendered routes, preserves backend boundaries, and applies PWA-safe cache headers. | Keep the container smoke test and tagged AMD64 build green. |
 
 ## Platform boundary
 

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -28,7 +28,8 @@ test('release images use the current GHCR-only workflow with an explicit immutab
   assert.match(workflow, /ref: \$\{\{ inputs\.release_tag \|\| github\.ref \}\}/);
   assert.match(workflow, /node scripts\/release-config\.mjs tag/);
   assert.match(workflow, /ghcr\.io/);
-  assert.match(workflow, /platforms: linux\/amd64,linux\/arm64/);
+  assert.match(workflow, /platforms: linux\/amd64/);
+  assert.doesNotMatch(workflow, /linux\/arm64|setup-qemu-action/);
   assert.doesNotMatch(workflow, /aws-actions|amazon-ecs|\bECR\b|\bECS\b|Deploy Staging|Deploy Prod/i);
 });
 


### PR DESCRIPTION
## Summary

- publish only the Linux AMD64 production image required by the self-hosted server
- remove QEMU setup and the ARM64 platform from the release workflow
- lock the architecture decision into the release workflow contract and parity docs

## Root cause

The v0.12.0 release job completed its AMD64 image but QEMU crashed with `Illegal instruction` during the ARM64 production dependency install. The emulated step then hung until the 30-minute job timeout cancelled the release.

## Validation

- `npm.cmd run test:release` (18 passing)
- workflow YAML parse
- `git diff --check`
- `docker build --platform linux/amd64 --file Dockerfile.app --tag calibrate:v0.12.0-amd64-check .`