### PR TITLE
Fix mobile PWA navigation and chart interactions

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -33,7 +33,9 @@ const HIDDEN_TAB_OPTIONS = {
     href: null
 } as const;
 
-const TAB_BAR_BASE_HEIGHT = 64; // Material-style navigation height before Android gesture/navigation safe-area padding.
+const TAB_BAR_CONTENT_HEIGHT = 56; // Keeps the UIKit icon, label, and built-in item padding from clipping.
+const TAB_BAR_VERTICAL_PADDING = spacing.sm; // Separates tab content from both bar edges before safe-area padding.
+const TAB_BAR_BASE_HEIGHT = TAB_BAR_CONTENT_HEIGHT + (TAB_BAR_VERTICAL_PADDING * 2);
 const HEADER_ROW_MIN_HEIGHT = 56; // Standard compact Android app-bar height before large-text expansion.
 const LARGE_TEXT_HEIGHT_INCREMENT = 18; // Adds vertical room as Android font scale grows toward 200%.
 const DESKTOP_NAV_BREAKPOINT = 1024;
@@ -168,8 +170,8 @@ export default function TabsLayout() {
                                     backgroundColor: theme.colors.surface,
                                     borderTopColor: theme.colors.border,
                                     height: tabBarHeight,
-                                    paddingBottom: Math.max(insets.bottom, spacing.sm),
-                                    paddingTop: spacing.sm,
+                                    paddingBottom: insets.bottom + TAB_BAR_VERTICAL_PADDING,
+                                    paddingTop: TAB_BAR_VERTICAL_PADDING,
                                     paddingHorizontal: spacing.md
                                 },
                             tabBarItemStyle: [styles.tabBarItem, usesNavigationRail && styles.navigationRailItem],
@@ -358,7 +360,7 @@ function createStyles(colors: AppThemeColors, shadows: AppTheme['shadows']) {
         flex: 1
     },
     tabBarItem: {
-        minHeight: 48
+        minHeight: TAB_BAR_CONTENT_HEIGHT
     },
     navigationRail: {
         width: DESKTOP_NAV_RAIL_WIDTH,

--- a/mobile/app/+html.tsx
+++ b/mobile/app/+html.tsx
@@ -8,7 +8,7 @@ export default function RootHtml({ children }: PropsWithChildren) {
             <head>
                 <meta charSet="utf-8" />
                 <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-                <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+                <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
                 <meta name="theme-color" content="#2E7D32" />
                 <meta name="color-scheme" content="light dark" />
                 <meta

--- a/mobile/src/components/WeightTrendCard.test.tsx
+++ b/mobile/src/components/WeightTrendCard.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { useQuery } from '@tanstack/react-query';
+import type { TrendMetricEntry } from '@calibrate/api-client';
+import { WeightTrendCard } from './WeightTrendCard';
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn() }));
+jest.mock('../auth/AuthContext', () => ({
+    useAuth: () => ({
+        api: { getTrendMetrics: jest.fn() },
+        user: { weight_unit: 'lb' }
+    })
+}));
+
+const METRICS: TrendMetricEntry[] = [
+    createMetric(3, '2026-07-15', 168.3),
+    createMetric(2, '2026-07-14', 168.7),
+    createMetric(1, '2026-07-13', 169.8)
+];
+
+function createMetric(id: number, date: string, weight: number): TrendMetricEntry {
+    return {
+        id,
+        user_id: 1,
+        date,
+        weight,
+        body_fat_percent: null,
+        trend_weight: 168.2,
+        trend_ci_lower: 167.1,
+        trend_ci_upper: 169.3,
+        trend_std: 0.4
+    };
+}
+
+describe('WeightTrendCard', () => {
+    beforeEach(() => {
+        (useQuery as jest.Mock).mockReturnValue({
+            data: {
+                metrics: METRICS,
+                meta: {
+                    weekly_rate: 0.19,
+                    volatility: 'low',
+                    total_points: METRICS.length,
+                    total_span_days: 2
+                }
+            },
+            error: null,
+            isLoading: false
+        });
+    });
+
+    it('selects individual points from React Native Web offset coordinates', () => {
+        const { getByLabelText, getByText } = render(<WeightTrendCard />);
+        const chart = getByLabelText('Show nearest weigh-in details');
+
+        expect(getByText('Jul 15, 2026')).toBeTruthy();
+
+        fireEvent.press(chart, { nativeEvent: { offsetX: 170 } });
+        expect(getByText('Jul 14, 2026')).toBeTruthy();
+
+        fireEvent.press(chart, { nativeEvent: { offsetX: 18 } });
+        expect(getByText('Jul 13, 2026')).toBeTruthy();
+    });
+
+    it('keeps the current selection when a press has no usable coordinate', () => {
+        const { getByLabelText, getByText } = render(<WeightTrendCard />);
+
+        fireEvent.press(getByLabelText('Show nearest weigh-in details'), { nativeEvent: {} });
+
+        expect(getByText('Jul 15, 2026')).toBeTruthy();
+    });
+});

--- a/mobile/src/components/WeightTrendCard.tsx
+++ b/mobile/src/components/WeightTrendCard.tsx
@@ -45,6 +45,11 @@ type ChartPoint = {
     upperY: number;
 };
 
+type ChartPressNativeEvent = {
+    locationX?: unknown;
+    offsetX?: unknown;
+};
+
 function getDatePart(value: string): string {
     return value.split('T')[0] ?? value;
 }
@@ -61,6 +66,14 @@ function buildBandPoints(points: ChartPoint[]): string {
     const upper = points.map((point) => `${point.x.toFixed(2)},${point.upperY.toFixed(2)}`);
     const lower = points.slice().reverse().map((point) => `${point.x.toFixed(2)},${point.lowerY.toFixed(2)}`);
     return [...upper, ...lower].join(' ');
+}
+
+/** React Native reports locationX, while React Native Web forwards the browser click's offsetX. */
+function getChartPressX(nativeEvent: ChartPressNativeEvent): number | null {
+    const pressX = typeof nativeEvent.locationX === 'number'
+        ? nativeEvent.locationX
+        : nativeEvent.offsetX;
+    return typeof pressX === 'number' && Number.isFinite(pressX) ? pressX : null;
 }
 
 function getChartPoints(metrics: TrendMetricEntry[]): ChartPoint[] {
@@ -159,8 +172,8 @@ export const WeightTrendCard: React.FC<WeightTrendCardProps> = ({
         };
     }, [chartPoints]);
 
-    function selectNearestPoint(locationX: number) {
-        if (chartPoints.length === 0) return;
+    function selectNearestPoint(locationX: number | null) {
+        if (chartPoints.length === 0 || locationX === null) return;
         const scaledX = (locationX / Math.max(chartCanvasWidth, 1)) * CHART_WIDTH;
         const nearestPoint = chartPoints.reduce((nearest, point) => {
             return Math.abs(point.x - scaledX) < Math.abs(nearest.x - scaledX) ? point : nearest;
@@ -248,7 +261,7 @@ export const WeightTrendCard: React.FC<WeightTrendCardProps> = ({
                         <Pressable
                             accessibilityRole="button"
                             accessibilityLabel="Show nearest weigh-in details"
-                            onPress={(event) => selectNearestPoint(event.nativeEvent.locationX)}
+                            onPress={(event) => selectNearestPoint(getChartPressX(event.nativeEvent))}
                             style={StyleSheet.absoluteFill}
                         />
                     </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.0",
+    "version": "0.12.1",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- reserve enough content height for the mobile bottom tab bar and apply device safe-area padding separately
- enable `viewport-fit=cover` so installed PWAs report display insets
- map weight-chart taps from both native `locationX` and React Native Web `offsetX` coordinates
- keep the latest chart point selected when a press lacks usable coordinates
- add regression coverage for selecting individual weight data points on web
- bump the canonical server/PWA release from `0.12.0` to patch version `0.12.1`

## Root cause

The custom bottom tab bar left only 48 px for a UIKit icon, label, and built-in padding that require more vertical room, so labels could be clipped. The Expo web viewport also did not opt into full safe-area reporting.

React Native Web forwards `Pressable.onPress` as a browser click event with `offsetX`, while the chart read only React Native's `locationX`. That produced `NaN`, causing nearest-point selection to retain the leftmost item for every tap.

## Validation

- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile test -- --runInBand` (65 suites, 266 tests)
- `npm.cmd --prefix mobile run build:web`
- `npm.cmd run release:check`
- `npm.cmd run test:release` (18 tests)
- `git diff --check`