### PR TITLE
Fix single-point weight trend rendering

### DIFF
--- a/mobile/src/components/WeightTrendCard.test.tsx
+++ b/mobile/src/components/WeightTrendCard.test.tsx
@@ -72,6 +72,27 @@ describe('WeightTrendCard', () => {
         expect(getByText('Jul 15, 2026')).toBeTruthy();
     });
 
+    it('renders the first-weigh-in state for a single metric', () => {
+        (useQuery as jest.Mock).mockReturnValue({
+            data: {
+                metrics: [METRICS[0]],
+                meta: {
+                    weekly_rate: 0,
+                    volatility: 'low',
+                    total_points: 1,
+                    total_span_days: 0
+                }
+            },
+            error: null,
+            isLoading: false
+        });
+
+        const { getByText } = render(<WeightTrendCard />);
+
+        expect(getByText('First weigh-in recorded')).toBeTruthy();
+        expect(getByText('168.3 lb on Jul 15, 2026')).toBeTruthy();
+    });
+
     it('labels the chart scale, dates, and visual series', () => {
         const { getAllByText, getByLabelText } = render(<WeightTrendCard />);
 

--- a/mobile/src/components/WeightTrendCard.tsx
+++ b/mobile/src/components/WeightTrendCard.tsx
@@ -171,7 +171,9 @@ function getChartLayout(metrics: TrendMetricEntry[], canvasWidth: number): Chart
     const firstYear = getDatePart(chronologicalMetrics[0].date).slice(0, 4);
     const lastYear = getDatePart(chronologicalMetrics[chronologicalMetrics.length - 1].date).slice(0, 4);
     const includeYear = firstYear !== lastYear;
-    const middleIndex = Math.round(lastIndex / 2);
+    // `lastIndex` is clamped for point spacing, so derive tick indices from the
+    // actual collection bounds to keep a single weigh-in at index zero.
+    const middleIndex = Math.round((chronologicalMetrics.length - 1) / 2);
     const tickIndices = Array.from(new Set([0, middleIndex, chronologicalMetrics.length - 1]));
     const xTicks = tickIndices.map((index, tickIndex) => {
         let textAnchor: ChartLayout['xTicks'][number]['textAnchor'] = 'middle';


### PR DESCRIPTION
## Summary

- keep single-entry weight trends within the metric collection bounds
- preserve the clamped chart spacing behavior
- add regression coverage for the first-weigh-in state

## Root cause

The chart reused a spacing index clamped to at least one when selecting the middle date tick. With exactly one weight metric, that selected index 1 from a one-element collection and crashed the Progress screen.

## Validation

- `npm.cmd --prefix mobile test -- --runInBand` (75 suites, 299 tests)
- `npm.cmd --prefix mobile run typecheck`
- phone and Wear debug APK rebuilds
- fresh reinstall and emulator smoke test on phone and Wear
- Progress renders the single-weight `First weigh-in recorded` state
- empty phone and Wear crash buffers after relaunch

This is a JavaScript-only client correction and does not change the native runtime contract or release manifest.