### PR TITLE
Polish native tracking, harden Wear sync, and add safe OTA releases

### DIFF
--- a/.github/workflows/expo-ota-update.yml
+++ b/.github/workflows/expo-ota-update.yml
@@ -1,0 +1,101 @@
+name: Publish Expo OTA Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      native_build_ref:
+        description: Exact master commit or tag used to build the installed Android phone app
+        required: true
+        type: string
+      channel:
+        description: Update channel embedded in the installed Android phone build
+        required: true
+        default: internal
+        type: choice
+        options:
+          - internal
+          - production
+      message:
+        description: Short operator-facing description of this OTA update
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: expo-ota-${{ inputs.channel }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Validate and Publish Android OTA
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      EAS_ENVIRONMENT: ${{ inputs.channel == 'production' && 'production' || 'preview' }}
+      EXPO_NO_METRO_WORKSPACE_ROOT: '1'
+      EXPO_PUBLIC_EAS_PROJECT_ID: fda8f8c5-e646-47ac-82fb-35003c9cbec7
+      EXPO_UPDATES_CHANNEL: ${{ inputs.channel }}
+      NATIVE_BUILD_REF: ${{ inputs.native_build_ref }}
+      NODE_ENV: production
+      OTA_MESSAGE: ${{ inputs.message }}
+
+    steps:
+      - name: Require master and Expo authentication
+        shell: bash
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != "refs/heads/master" ]]; then
+            echo "OTA updates must be dispatched from the master branch; received ${GITHUB_REF}." >&2
+            exit 1
+          fi
+          if [[ -z "${EXPO_TOKEN}" ]]; then
+            echo "Add an EXPO_TOKEN repository secret before publishing an OTA update." >&2
+            exit 1
+          fi
+
+      - name: Checkout reviewed source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install mobile dependencies
+        run: npm ci --no-audit --fund=false
+
+      - name: Read selected EAS environment
+        working-directory: mobile
+        run: eas env:pull --environment "${EAS_ENVIRONMENT}" --path "${RUNNER_TEMP}/calibrate-eas-update.env" --non-interactive
+
+      - name: Verify native compatibility and environment targeting
+        run: >-
+          node scripts/native-ota-ci-preflight.mjs
+          --native-build-ref "${NATIVE_BUILD_REF}"
+          --channel "${EXPO_UPDATES_CHANNEL}"
+          --environment "${EAS_ENVIRONMENT}"
+          --environment-file "${RUNNER_TEMP}/calibrate-eas-update.env"
+
+      - name: Publish Android phone OTA update
+        working-directory: mobile
+        run: >-
+          eas update
+          --channel "${EXPO_UPDATES_CHANNEL}"
+          --message "${OTA_MESSAGE}"
+          --environment "${EAS_ENVIRONMENT}"
+          --platform android
+          --non-interactive

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.12.2",
       "license": "ISC",
       "dependencies": {
-        "@prisma/adapter-pg": "^7.1.0",
-        "@prisma/client": "^7.7.0",
+        "@prisma/adapter-pg": "^7.9.0",
+        "@prisma/client": "^7.9.0",
         "adm-zip": "^0.6.0",
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
-        "express": "^5.1.0",
+        "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "express-session": "^1.18.2",
         "helmet": "^8.2.0",
@@ -23,7 +23,7 @@
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "pg": "^8.14.1",
-        "prisma": "^7.7.0",
+        "prisma": "^7.9.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
@@ -94,43 +94,31 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
-      "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
+      "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
-      "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.3.tgz",
+      "integrity": "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==",
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
       },
       "peerDependencies": {
-        "@electric-sql/pglite": "0.4.1"
+        "@electric-sql/pglite": "0.4.3"
       }
     },
     "node_modules/@electric-sql/pglite-tools": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
-      "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.3.tgz",
+      "integrity": "sha512-AlzLJTRJ8+UFgK8CmxIpyIpJ0+YaFw02IiOSdYrqxwPXdSyeIShz8aa9Tq+tYFXdPwcaMp/Fc80mQZ1dkOQ/wg==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@electric-sql/pglite": "0.4.1"
-      }
-    },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
+        "@electric-sql/pglite": "0.4.3"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -189,12 +177,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -207,23 +189,24 @@
       }
     },
     "node_modules/@prisma/adapter-pg": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.1.0.tgz",
-      "integrity": "sha512-DSAnUwkKfX4bUzhkrjGN4IBQzwg0nvFw2W17H0Oa532I5w9nLtTJ9mAEGDs1nUBEGRAsa0c7qsf8CSgfJ4DsBQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.9.0.tgz",
+      "integrity": "sha512-kPYuFvNTlqnaFf2UpXBBG3ycTT3PL76uSZtLFBEwDytjMMUW8ZHrsb9cSNIarzdPW5EXWmBOeOq9/MVjMtbWkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/driver-adapter-utils": "7.1.0",
+        "@prisma/driver-adapter-utils": "7.9.0",
+        "@types/pg": "^8.16.0",
         "pg": "^8.16.3",
         "postgres-array": "3.0.4"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.7.0.tgz",
-      "integrity": "sha512-5Ar4OsZpJ54s21sy5oDNNW9gQtd4NuxCaiM7+JDTOU07D6VvlpLjYzAVCMB1+JzokN+08dAVomlx+b7bhJd3ww==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.0.tgz",
+      "integrity": "sha512-BTG/mB+WL/1sD2gWwdNc2uuVJjNNBgCDlPFdjco6jJArgbg4IAChtzVeW4debFa/NKBbsGedCjET316sjllWTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/client-runtime-utils": "7.7.0"
+        "@prisma/client-runtime-utils": "7.9.0"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0"
@@ -242,46 +225,44 @@
       }
     },
     "node_modules/@prisma/client-runtime-utils": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.7.0.tgz",
-      "integrity": "sha512-BLyd0UpFYOtyJFTHm7jS9vesHW7P83abibodQMiIofqjBKzDHQ1VAsQkdfvXyYDkPlONPfOTz7/rv3x/+CQqvQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.9.0.tgz",
+      "integrity": "sha512-kMVmS4ZEy3xlkca+TfxOEm/ToVVlOS2x1Tc6/wIRf/HfczBqENtSPcKszy4ZpFNzjJ8SRKvlU5V0rrpoFw2KOg==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.7.0.tgz",
-      "integrity": "sha512-hmPI3tKLO2aP0Y5vugbjcnA9qqlfJndiT6ds4tw28U5hNHLWg+mHJEWAhjsSPgxjtmxhJ/EDIeIlyh+3Us0OPg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.0.tgz",
+      "integrity": "sha512-CsoK2mhl0u+N4/8V+XroQMOUNIic4isqD+E2HBG8l1yGEKo62CFDu3FHo0FdwItjl6XkW+omA1STSzeN1DAXlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "c12": "3.1.0",
+        "c12": "3.3.4",
         "deepmerge-ts": "7.1.5",
         "effect": "3.20.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.1.0.tgz",
-      "integrity": "sha512-pPAckG6etgAsEBusmZiFwM9bldLSNkn++YuC4jCTJACdK5hLOVnOzX7eSL2FgaU6Gomd6wIw21snUX2dYroMZQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.0.tgz",
+      "integrity": "sha512-i0KdVQuKUE6N9NloHs+sUNAk2c9svR3myBndQbA3BoeoArsSpwtNgTdHZL+wBtCLCcdS2OOC/PKhgTe36jkF5A==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
-      "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
+      "version": "0.24.14",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.14.tgz",
+      "integrity": "sha512-NhFO49O2JPTdzYiLHvceQn/HiwmcKF/iGV39ko3CpYsoGqS3rz3ko6gzuxFSIeHNwNJeuNcDexyyGeTO3DW80A==",
       "license": "ISC",
       "dependencies": {
-        "@electric-sql/pglite": "0.4.1",
-        "@electric-sql/pglite-socket": "0.1.1",
-        "@electric-sql/pglite-tools": "0.3.1",
-        "@hono/node-server": "1.19.11",
+        "@electric-sql/pglite": "0.4.3",
+        "@electric-sql/pglite-socket": "0.1.3",
+        "@electric-sql/pglite-tools": "0.3.3",
         "@prisma/get-platform": "7.2.0",
         "@prisma/query-plan-executor": "7.2.0",
-        "@prisma/streams-local": "0.1.2",
+        "@prisma/streams-local": "0.1.11",
+        "find-my-way": "9.6.0",
         "foreground-child": "3.3.1",
         "get-port-please": "3.2.0",
-        "hono": "^4.12.8",
-        "http-status-codes": "2.3.0",
         "pathe": "2.0.3",
         "proper-lockfile": "4.1.2",
         "remeda": "2.33.4",
@@ -291,72 +272,60 @@
       }
     },
     "node_modules/@prisma/driver-adapter-utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.1.0.tgz",
-      "integrity": "sha512-AlVLzeXkw81+47MvQ9M8DvTiHkRfJ8xzklTbYjpskb0cTTDVHboTI/OVwT6Wcep/bNvfLKJYO0nylBiM5rxgww==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.9.0.tgz",
+      "integrity": "sha512-fFXujitfMyjk3kOd1Tbs5FXBm6i2OWwEhaP5lHgkUM99jHpPEQwCWj+z/WKPFq6EDMThE1zGzSlVegtR0Pmu2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.1.0"
+        "@prisma/debug": "7.9.0"
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.7.0.tgz",
-      "integrity": "sha512-7fmcbT7HHXBq/b+3h/dO1JI3fd8l8q7erf7xP7pRprh58hmSSnG8mg9K3yjW3h9WaHWUwngVFpSxxxivaitQ2w==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.0.tgz",
+      "integrity": "sha512-lDWJp/pgSWCLfYsupmmNo96jfsbQnH1yjia8XVM2Kh8nRZhD0bQU2jCHuy3ZTPMLR3apRD3k145ybENalAYjYw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.7.0",
-        "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-        "@prisma/fetch-engine": "7.7.0",
-        "@prisma/get-platform": "7.7.0"
+        "@prisma/debug": "7.9.0",
+        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+        "@prisma/fetch-engine": "7.9.0",
+        "@prisma/get-platform": "7.9.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711.tgz",
-      "integrity": "sha512-r51DLcJ8bDRSrBEJF3J4cinoWyGA7rfP2mG6lD90VqIbGNOkbfcLcXalSVjq5Y6brQS3vcjrq4GbyUb1Cb7vkw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/engines/node_modules/@prisma/debug": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
-      "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
+      "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
+      "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
-      "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
+      "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.7.0"
+        "@prisma/debug": "7.9.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.7.0.tgz",
-      "integrity": "sha512-TfyzveBQoK4xALzsTpVhB/0KG1N8zOK0ap+RnBMkzGUu3f98fnQ4QtXa2wlKPhsO2X8a3N5ugFQgcKNoHGmDfw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.0.tgz",
+      "integrity": "sha512-F0XlIgjbE3EywRVR/HpCerNI/dxo40vK66tHcWpsWYwH/Jk9+FsICEzATeMsZ7bdnpZz93hkD4sAb5rKLsCCpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.7.0",
-        "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-        "@prisma/get-platform": "7.7.0"
+        "@prisma/debug": "7.9.0",
+        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+        "@prisma/get-platform": "7.9.0"
       }
     },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
-      "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
-      "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
+      "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.7.0"
+        "@prisma/debug": "7.9.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -381,9 +350,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/streams-local": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
-      "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.11.tgz",
+      "integrity": "sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -392,18 +361,27 @@
         "proper-lockfile": "^4.1.2"
       },
       "engines": {
-        "bun": ">=1.3.6",
+        "bun": ">=1.2.0",
         "node": ">=22.0.0"
       }
     },
     "node_modules/@prisma/studio-core": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
-      "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.33.0.tgz",
+      "integrity": "sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-toggle": "1.1.10",
-        "chart.js": "4.5.1"
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/event": "4.0.1-alpha.0",
+        "@visx/grid": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/responsive": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/shape": "4.0.1-alpha.0",
+        "d3-array": "3.2.4",
+        "d3-shape": "3.2.0",
+        "elkjs": "0.11.1"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0",
@@ -705,6 +683,84 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
+      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+      "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.5.tgz",
@@ -740,6 +796,12 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -752,6 +814,12 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -775,7 +843,6 @@
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -819,7 +886,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -842,9 +908,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -892,6 +958,147 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@visx/curve": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "4.0.0-alpha.0"
+      }
+    },
+    "node_modules/@visx/event": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/event/-/event-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/point": "4.0.1-alpha.0"
+      }
+    },
+    "node_modules/@visx/grid": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/point": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/shape": "4.0.1-alpha.0",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/group": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/group/-/group-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/point": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/point/-/point-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@visx/responsive": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.13",
+        "@types/react": "*",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/scale": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "4.0.0-alpha.0"
+      }
+    },
+    "node_modules/@visx/shape": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.13",
+        "@types/react": "*",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/vendor": "4.0.0-alpha.0",
+        "classnames": "^2.3.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/vendor": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==",
+      "license": "MIT and ISC",
+      "dependencies": {
+        "@types/d3-array": "3.0.3",
+        "@types/d3-color": "3.1.0",
+        "@types/d3-delaunay": "6.0.1",
+        "@types/d3-format": "3.0.1",
+        "@types/d3-geo": "3.1.0",
+        "@types/d3-interpolate": "3.0.1",
+        "@types/d3-path": "3.1.1",
+        "@types/d3-scale": "4.0.2",
+        "@types/d3-shape": "3.1.7",
+        "@types/d3-time": "3.0.0",
+        "@types/d3-time-format": "2.1.0",
+        "d3-array": "3.2.1",
+        "d3-color": "3.1.0",
+        "d3-delaunay": "6.0.2",
+        "d3-format": "3.1.0",
+        "d3-geo": "3.1.0",
+        "d3-interpolate": "3.0.1",
+        "d3-path": "3.1.0",
+        "d3-scale": "4.0.2",
+        "d3-shape": "3.2.0",
+        "d3-time": "3.1.0",
+        "d3-time-format": "4.1.0",
+        "internmap": "2.0.3"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/accepts": {
@@ -952,9 +1159,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1075,9 +1282,9 @@
       }
     },
     "node_modules/better-result": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.8.2.tgz",
-      "integrity": "sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.10.0.tgz",
+      "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
@@ -1100,21 +1307,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1180,26 +1400,26 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
-      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^16.6.1",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.4.2",
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
-        "rc9": "^2.1.2"
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
@@ -1208,39 +1428,27 @@
       }
     },
     "node_modules/c12/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/c12/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/c12/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -1317,18 +1525,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1354,14 +1550,11 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1512,15 +1705,6 @@
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
     },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -1608,6 +1792,133 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1639,6 +1950,15 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/denque": {
       "version": "2.1.0",
@@ -1675,9 +1995,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1731,6 +2051,12 @@
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
       }
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1825,19 +2151,20 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -1926,9 +2253,9 @@
       "license": "MIT"
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "license": "MIT"
     },
     "node_modules/fast-check": {
@@ -1953,16 +2280,31 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
     "node_modules/fast-uri": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
-      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "funding": [
         {
           "type": "github",
@@ -2003,6 +2345,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -2143,18 +2499,10 @@
       }
     },
     "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
       "bin": {
         "giget": "dist/cli.mjs"
       }
@@ -2238,9 +2586,9 @@
       "license": "ISC"
     },
     "node_modules/grammex": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
-      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.13.tgz",
+      "integrity": "sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg==",
       "license": "MIT"
     },
     "node_modules/graphmatch": {
@@ -2295,16 +2643,6 @@
         "url": "https://github.com/sponsors/EvanHahn"
       }
     },
-    "node_modules/hono": {
-      "version": "4.12.29",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
-      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2340,12 +2678,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -2401,6 +2733,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -2573,9 +2914,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -2663,6 +3004,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -2917,12 +3264,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "license": "MIT"
-    },
     "node_modules/nodemon": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
@@ -2961,29 +3302,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.2.0",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3237,9 +3555,9 @@
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -3362,13 +3680,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -3435,17 +3753,17 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.7.0.tgz",
-      "integrity": "sha512-HlgwRBt1uEFB9LStHL4HLYDvoi4BNu1rYA0hPG0zCAEyK9SaZBqp7E5Rjpc3Qh8Lex/ye/svoHZ0OWoFNhWxuQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.0.tgz",
+      "integrity": "sha512-isQTJEK4pyOlAVzm6kBUDjzgdsgs0A/snpB38ycTHeOHW34qfepP+ClQltgDXqjZBnXALhEtE4duh9L3tN5fHw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@prisma/config": "7.7.0",
-        "@prisma/dev": "0.24.3",
-        "@prisma/engines": "7.7.0",
-        "@prisma/studio-core": "0.27.3",
+        "@prisma/config": "7.9.0",
+        "@prisma/dev": "0.24.14",
+        "@prisma/engines": "7.9.0",
+        "@prisma/studio-core": "0.33.0",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
       },
@@ -3571,19 +3889,19 @@
       }
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3591,16 +3909,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -3658,6 +3976,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -3666,6 +3993,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -3702,6 +4035,28 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4102,15 +4457,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4201,17 +4547,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typedarray": {
@@ -4258,7 +4621,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,13 +26,13 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@prisma/adapter-pg": "^7.1.0",
-    "@prisma/client": "^7.7.0",
+    "@prisma/adapter-pg": "^7.9.0",
+    "@prisma/client": "^7.9.0",
     "adm-zip": "^0.6.0",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "express-session": "^1.18.2",
     "helmet": "^8.2.0",
@@ -40,7 +40,7 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "pg": "^8.14.1",
-    "prisma": "^7.7.0",
+    "prisma": "^7.9.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {
@@ -81,9 +81,8 @@
     "exclude-after-remap": true
   },
   "overrides": {
-    "@hono/node-server": "1.19.13",
-    "fast-uri": "4.1.0",
-    "hono": "4.12.29",
+    "body-parser": "2.3.0",
+    "fast-uri": "4.1.1",
     "qs": "6.15.3"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -113,8 +113,10 @@ npm.cmd run build:native:release
 
 The command fails before native work when signing is incomplete or the configured origin is not a credential-free
 HTTPS origin. It regenerates the ignored phone Android project with a clean Expo prebuild, then builds APK and AAB
-artifacts for phone and Wear with the same signing identity. Outputs are under `mobile/android/app/build/outputs/`
-and `wear/app/build/outputs/`.
+artifacts for phone and Wear with the same signing identity. The release workflow supplies a larger Gradle heap and
+metaspace allowance for Expo release lint, removes stale final artifacts before each build, and fails immediately if
+Gradle does not recreate both outputs. Outputs are under `mobile/android/app/build/outputs/` and
+`wear/app/build/outputs/`.
 
 Record the Git commit, semantic versions, version codes, SHA-256 digests, and signing certificate fingerprint in the
 release notes. Do not rename an artifact in a way that loses those identifiers.

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -48,18 +48,19 @@ $env:EXPO_PUBLIC_CALIBRATE_SERVER_URL='https://health.example.com'
 ```
 
 Private builds that use Expo push must also have a stable Expo project ID. EAS builds embed it automatically.
-The same public identity is required for Expo OTA updates. Link the mobile project once (an Expo account is required):
+The same public identity is required for Expo OTA updates. The mobile app is linked to
+`@calibrate-health/calibrate-health-app` with project ID
+`fda8f8c5-e646-47ac-82fb-35003c9cbec7` in `mobile/app.json`. Verify that link after signing in:
 
 ```powershell
 Push-Location mobile
 npx.cmd --yes eas-cli@latest login
-npx.cmd --yes eas-cli@latest project:init
 npx.cmd --yes eas-cli@latest project:info
 Pop-Location
 ```
 
-Keep the public `extra.eas.projectId` added by `project:init`, or set the project UUID explicitly before a local
-Gradle build:
+Do not initialize a replacement project. Keep the public `owner`, `slug`, and `extra.eas.projectId` values in
+`mobile/app.json`, or set the same project UUID explicitly before a local Gradle build:
 
 ```powershell
 $env:EXPO_PUBLIC_EAS_PROJECT_ID='<expo-project-uuid>'

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -196,6 +196,30 @@ Release builds check for updates without blocking startup. After an update is do
 phone app again to run it. Keep the signed native artifact: OTA is not a substitute for an installable recovery build,
 and a native incompatibility must be corrected with a higher-version signed APK/AAB.
 
+### Publish OTA updates from GitHub Actions
+
+The `Publish Expo OTA Update` workflow is manual-only and publishes Android phone JavaScript/assets from `master`.
+Before its first use:
+
+1. Create an Expo access token and save it as the repository Actions secret `EXPO_TOKEN`.
+2. Configure the Expo `preview` environment with `EXPO_PUBLIC_CALIBRATE_SERVER_URL`,
+   `EXPO_PUBLIC_EAS_PROJECT_ID`, and `EXPO_UPDATES_CHANNEL=internal`.
+3. Configure the Expo `production` environment with the same project/server values and
+   `EXPO_UPDATES_CHANNEL=production`.
+4. Build and install the phone binary from a known `master` commit with the same channel/environment you intend to
+   update.
+
+In GitHub, open **Actions > Publish Expo OTA Update > Run workflow**, select `master`, and provide:
+
+- `native_build_ref`: the exact commit or tag used to build the installed phone app.
+- `channel`: `internal` for the dogfood APK or `production` for a production-channel build.
+- `message`: a short description shown in EAS Update history.
+
+The workflow pulls and validates the selected EAS environment, verifies that the current source descends from the
+native build reference, and compares the precise runtime fingerprint before it uploads. Any app version, native
+dependency, config plugin, icon, Wear source, or other native input change stops the publish and requires a new signed
+phone/Watch build. OTA updates never update the Wear app.
+
 ## Preserve on-device data during upgrades
 
 Expo SecureStore tokens and the SQLite offline outbox live in the Android application sandbox. Android preserves

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,9 +1,10 @@
 {
   "expo": {
     "name": "calibrate",
-    "slug": "calibrate",
+    "slug": "calibrate-health-app",
+    "owner": "calibrate-health",
     "scheme": "calibrate",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "orientation": "default",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",
@@ -17,7 +18,7 @@
     ],
     "android": {
       "package": "app.calibratehealth.mobile",
-      "versionCode": 2,
+      "versionCode": 3,
       "allowBackup": false,
       "softwareKeyboardLayoutMode": "resize",
       "adaptiveIcon": {
@@ -93,6 +94,9 @@
     "extra": {
       "router": {
         "origin": false
+      },
+      "eas": {
+        "projectId": "fda8f8c5-e646-47ac-82fb-35003c9cbec7"
       }
     }
   }

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -287,7 +287,9 @@ export default function TabsLayout() {
                             onPress={() => {
                                 if (fabKind === 'add-food') {
                                     requestAddFood({ date: logDateNavigation.selectedDate });
-                                    router.navigate('/(tabs)/today');
+                                    if (getActiveTabRoute(pathname) !== 'food-log') {
+                                        router.navigate('/(tabs)/today');
+                                    }
                                     return;
                                 }
                                 router.push({ pathname: '/(tabs)/weight', params: { date: today } });

--- a/mobile/app/(tabs)/food-log.tsx
+++ b/mobile/app/(tabs)/food-log.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { router, useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams, usePathname } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import type { FoodLogEntry } from '@calibrate/api-client';
 import type { MealPeriod } from '@calibrate/shared';
+import { AddFoodSheet } from '../../src/components/AddFoodSheet';
 import { AppButton } from '../../src/components/AppButton';
 import { AppCard } from '../../src/components/AppCard';
 import { AppText } from '../../src/components/AppText';
@@ -20,8 +21,10 @@ import { SectionHeader } from '../../src/components/SectionHeader';
 import { SkeletonBlock } from '../../src/components/SkeletonBlock';
 import { TextField } from '../../src/components/TextField';
 import { useAuth } from '../../src/auth/AuthContext';
+import { useAddFoodRequest } from '../../src/context/AddFoodRequestContext';
 import { useSharedLogDateNavigation } from '../../src/context/LogDateContext';
 import { usePrefetchPreviousFoodLog } from '../../src/hooks/usePrefetchPreviousFoodLog';
+import { getActiveTabRoute } from '../../src/navigation/contextualFab';
 import { executeOrQueueMutation, OFFLINE_MUTATION_OPERATIONS } from '../../src/offline/operations';
 import { useOfflineOutbox } from '../../src/offline/provider';
 import { MEAL_SELECT_OPTIONS } from '../../src/utils/meals';
@@ -30,11 +33,14 @@ import { SERVING_INPUT_INCREMENT } from '../../src/config/inputPrecision';
 
 export default function FoodLogScreen() {
     const routeParams = useLocalSearchParams<{ date?: string }>();
+    const pathname = usePathname();
     const { api } = useAuth();
     const { enqueue } = useOfflineOutbox();
     const queryClient = useQueryClient();
     const dateNavigation = useSharedLogDateNavigation();
+    const { request: addFoodRequest, consumeRequest: consumeAddFoodRequest } = useAddFoodRequest();
     const selectedDate = dateNavigation.selectedDate;
+    const [addFoodMeal, setAddFoodMeal] = useState<MealPeriod | null | undefined>(undefined);
     const [editEntry, setEditEntry] = useState<FoodLogEntry | null>(null);
     const [editName, setEditName] = useState('');
     const [editCalories, setEditCalories] = useState('');
@@ -51,6 +57,16 @@ export default function FoodLogScreen() {
     useEffect(() => {
         if (typeof routeParams.date === 'string') dateNavigation.setDate(routeParams.date);
     }, [dateNavigation.setDate, routeParams.date]);
+
+    useEffect(() => {
+        if (!addFoodRequest || getActiveTabRoute(pathname) !== 'food-log') return;
+
+        if (addFoodRequest.date) {
+            dateNavigation.setDate(addFoodRequest.date);
+        }
+        setAddFoodMeal(addFoodRequest.meal ?? null);
+        consumeAddFoodRequest(addFoodRequest.id);
+    }, [addFoodRequest, consumeAddFoodRequest, dateNavigation.setDate, pathname]);
 
     async function invalidateLogQueries() {
         await Promise.all([
@@ -173,6 +189,13 @@ export default function FoodLogScreen() {
 
             {foodQuery.error && <AppText style={styles.error}>{foodQuery.error.message}</AppText>}
             {deleteFood.error && <AppText style={styles.error}>{deleteFood.error.message}</AppText>}
+
+            <AddFoodSheet
+                visible={addFoodMeal !== undefined}
+                date={selectedDate}
+                initialMeal={addFoodMeal}
+                onClose={() => setAddFoodMeal(undefined)}
+            />
 
             <BottomSheetModal
                 visible={Boolean(editEntry)}

--- a/mobile/app/(tabs)/today.tsx
+++ b/mobile/app/(tabs)/today.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { StyleSheet } from 'react-native';
-import { router, useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams, usePathname } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import type { MealPeriod } from '@calibrate/shared';
 import { AddFoodSheet } from '../../src/components/AddFoodSheet';
@@ -10,36 +10,44 @@ import { DateNavigation } from '../../src/components/DateNavigation';
 import { FoodLogSummaryCard } from '../../src/components/FoodLogSummaryCard';
 import { LogContentSkeleton } from '../../src/components/LogContentSkeleton';
 import { Screen } from '../../src/components/Screen';
+import { TodayWeightCard } from '../../src/components/TodayWeightCard';
+import { WeightEntrySheet } from '../../src/components/WeightEntrySheet';
 import { useAuth } from '../../src/auth/AuthContext';
 import { useSharedLogDateNavigation } from '../../src/context/LogDateContext';
 import { useAddFoodRequest } from '../../src/context/AddFoodRequestContext';
 import { usePrefetchPreviousFoodLog } from '../../src/hooks/usePrefetchPreviousFoodLog';
+import { getActiveTabRoute } from '../../src/navigation/contextualFab';
 import { MEAL_OPTIONS } from '../../src/utils/meals';
+import { getTodayDate } from '../../src/utils/dates';
+import { getMetricDate } from '../../src/utils/metrics';
 import { useAppTheme } from '../../src/theme';
 
 export default function TodayScreen() {
     const { colors } = useAppTheme();
     const routeParams = useLocalSearchParams<{ openAddFood?: string; date?: string; meal?: string }>();
-    const { api } = useAuth();
+    const pathname = usePathname();
+    const { api, user } = useAuth();
     const dateNavigation = useSharedLogDateNavigation();
     const setLogDate = dateNavigation.setDate;
     const { request: addFoodRequest, consumeRequest: consumeAddFoodRequest } = useAddFoodRequest();
     const selectedDate = dateNavigation.selectedDate;
     const [addFoodMeal, setAddFoodMeal] = useState<MealPeriod | null | undefined>(undefined);
+    const [isWeightSheetOpen, setIsWeightSheetOpen] = useState(false);
     usePrefetchPreviousFoodLog(selectedDate, dateNavigation.minDate);
 
     const profileQuery = useQuery({ queryKey: ['mobile-profile'], queryFn: () => api.getUserProfile() });
     const foodQuery = useQuery({ queryKey: ['mobile-food', selectedDate], queryFn: () => api.getFoodLog(selectedDate) });
+    const metricsQuery = useQuery({ queryKey: ['mobile-metrics'], queryFn: () => api.getMetrics() });
 
     useEffect(() => {
-        if (!addFoodRequest) return;
+        if (!addFoodRequest || getActiveTabRoute(pathname) !== 'today') return;
 
         if (addFoodRequest.date) {
             setLogDate(addFoodRequest.date);
         }
         setAddFoodMeal(addFoodRequest.meal ?? null);
         consumeAddFoodRequest(addFoodRequest.id);
-    }, [addFoodRequest, consumeAddFoodRequest, setLogDate]);
+    }, [addFoodRequest, consumeAddFoodRequest, pathname, setLogDate]);
 
     useEffect(() => {
         if (routeParams.openAddFood !== 'true') return;
@@ -53,9 +61,11 @@ export default function TodayScreen() {
     const entries = foodQuery.data ?? [];
     const calories = entries.reduce((total, entry) => total + entry.calories, 0);
     const target = profileQuery.data?.calorieSummary.dailyCalorieTarget ?? null;
+    const selectedDateMetric = (metricsQuery.data ?? []).find((metric) => getMetricDate(metric) === selectedDate) ?? null;
+    const isToday = selectedDate === getTodayDate(user?.timezone);
     const showContentSkeleton =
-        (!profileQuery.data || !foodQuery.data) &&
-        (profileQuery.isLoading || foodQuery.isLoading);
+        (!profileQuery.data || !foodQuery.data || !metricsQuery.data) &&
+        (profileQuery.isLoading || foodQuery.isLoading || metricsQuery.isLoading);
 
     return (
         <Screen reserveBottomTabs style={styles.screenContent}>
@@ -74,16 +84,29 @@ export default function TodayScreen() {
                         entries={entries}
                         onPress={() => router.push({ pathname: '/(tabs)/food-log', params: { date: selectedDate } })}
                     />
+
+                    <TodayWeightCard
+                        metric={selectedDateMetric}
+                        weightUnit={user?.weight_unit}
+                        isToday={isToday}
+                        onPress={() => setIsWeightSheetOpen(true)}
+                    />
                 </>
             )}
 
             {foodQuery.error && <AppText style={{ color: colors.danger }}>{foodQuery.error.message}</AppText>}
             {profileQuery.error && <AppText style={{ color: colors.danger }}>{profileQuery.error.message}</AppText>}
+            {metricsQuery.error && <AppText style={{ color: colors.danger }}>{metricsQuery.error.message}</AppText>}
             <AddFoodSheet
                 visible={addFoodMeal !== undefined}
                 date={selectedDate}
                 initialMeal={addFoodMeal}
                 onClose={() => setAddFoodMeal(undefined)}
+            />
+            <WeightEntrySheet
+                visible={isWeightSheetOpen}
+                date={selectedDate}
+                onClose={() => setIsWeightSheetOpen(false)}
             />
         </Screen>
     );

--- a/mobile/modules/wear-pairing/android/build.gradle
+++ b/mobile/modules/wear-pairing/android/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 group = 'app.calibratehealth'
-version = '0.2.0'
+version = '0.2.1'
 
 android {
   namespace 'app.calibratehealth.wearpairing'
   defaultConfig {
-    versionCode 2
-    versionName '0.2.0'
+    versionCode 3
+    versionName '0.2.1'
   }
 }
 

--- a/mobile/modules/wear-pairing/package.json
+++ b/mobile/modules/wear-pairing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calibrate/wear-pairing",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "main": "index.ts",
   "peerDependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "main": "index.js",
   "engines": {

--- a/mobile/src/components/LogContentSkeleton.tsx
+++ b/mobile/src/components/LogContentSkeleton.tsx
@@ -7,7 +7,7 @@ import { radius, spacing } from '../theme';
 /**
  * Glimmer layout for the selected day's log content.
  *
- * The shape mirrors the calorie card and compact food summary so date changes do not flash the whole pane.
+ * The shape mirrors the calorie, food, and weight summaries so date changes do not flash the whole pane.
  */
 export const LogContentSkeleton: React.FC = () => (
     <>
@@ -31,6 +31,17 @@ export const LogContentSkeleton: React.FC = () => (
                     <SkeletonBlock width="78%" height={18} />
                 </View>
                 <SkeletonBlock width={72} height={24} />
+            </View>
+        </AppCard>
+
+        <AppCard>
+            <SkeletonBlock width="42%" height={32} />
+            <View style={styles.mealRow}>
+                <SkeletonBlock width={42} height={42} radius={radius.md} />
+                <View style={styles.mealText}>
+                    <SkeletonBlock width="48%" height={26} />
+                    <SkeletonBlock width="34%" height={18} />
+                </View>
             </View>
         </AppCard>
     </>

--- a/mobile/src/components/TodayWeightCard.test.tsx
+++ b/mobile/src/components/TodayWeightCard.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { MetricEntry } from '@calibrate/api-client';
+import { TodayWeightCard } from './TodayWeightCard';
+
+jest.mock('@expo/vector-icons/Ionicons', () => () => null);
+
+const TODAY_METRIC: MetricEntry = {
+    id: 1,
+    date: '2026-07-21T00:00:00.000Z',
+    weight: 168.2
+};
+
+describe('TodayWeightCard', () => {
+    it("shows today's saved weight and offers to edit it", () => {
+        const onPress = jest.fn();
+        const screen = render(
+            <TodayWeightCard metric={TODAY_METRIC} weightUnit="LB" isToday onPress={onPress} />
+        );
+
+        expect(screen.getByText("Today's weight")).toBeTruthy();
+        expect(screen.getByText('168.2 lb')).toBeTruthy();
+        expect(screen.getByText('Logged today')).toBeTruthy();
+        expect(screen.getByText('Edit')).toBeTruthy();
+
+        fireEvent.press(screen.getByRole('button'));
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a focused weigh-in action when today has no measurement', () => {
+        const screen = render(
+            <TodayWeightCard metric={null} weightUnit="KG" isToday onPress={jest.fn()} />
+        );
+
+        expect(screen.getByText('No weigh-in yet')).toBeTruthy();
+        expect(screen.getByText("Add today's measurement")).toBeTruthy();
+        expect(screen.getByText('Log')).toBeTruthy();
+        expect(screen.getByLabelText("Today's weight. No weigh-in yet. Log weight")).toBeTruthy();
+    });
+
+    it('uses day-specific copy when browsing a previous date', () => {
+        const screen = render(
+            <TodayWeightCard metric={TODAY_METRIC} weightUnit="LB" isToday={false} onPress={jest.fn()} />
+        );
+
+        expect(screen.getByText('Weight')).toBeTruthy();
+        expect(screen.getByText('Logged for this day')).toBeTruthy();
+    });
+});

--- a/mobile/src/components/TodayWeightCard.tsx
+++ b/mobile/src/components/TodayWeightCard.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Pressable, StyleSheet, View, type ViewProps } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import type { MetricEntry } from '@calibrate/api-client';
+import type { WeightUnit } from '@calibrate/shared';
+import { AppCard } from './AppCard';
+import { AppText } from './AppText';
+import { formatWeight } from '../utils/format';
+import { type AppTheme, useAppTheme } from '../theme';
+
+type TodayWeightCardProps = Omit<ViewProps, 'children'> & {
+    metric: MetricEntry | null;
+    weightUnit: WeightUnit | undefined;
+    isToday: boolean;
+    onPress: () => void;
+};
+
+/** Compact daily weigh-in summary and entry point for the Today dashboard. */
+export const TodayWeightCard: React.FC<TodayWeightCardProps> = ({
+    metric,
+    weightUnit,
+    isToday,
+    onPress,
+    style,
+    ...props
+}) => {
+    const theme = useAppTheme();
+    const styles = React.useMemo(() => createStyles(theme), [theme]);
+    const title = isToday ? "Today's weight" : 'Weight';
+    const action = metric ? 'Edit' : 'Log';
+    const metricLabel = metric ? formatWeight(metric.weight, weightUnit) : 'No weigh-in yet';
+    const supportingLabel = metric
+        ? (isToday ? 'Logged today' : 'Logged for this day')
+        : (isToday ? 'Add today\'s measurement' : 'Add a measurement for this day');
+
+    return (
+        <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`${title}. ${metricLabel}. ${action} weight`}
+            accessibilityHint={metric ? 'Opens this weigh-in for editing' : 'Opens the weight entry form'}
+            android_ripple={{ color: theme.colors.ripple }}
+            onPress={onPress}
+            style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
+        >
+            <AppCard {...props} style={[styles.card, style]}>
+                <View style={styles.headerRow}>
+                    <AppText accessibilityRole="header" aria-level={2} variant="screenTitle">{title}</AppText>
+                    <View style={styles.viewAction}>
+                        <AppText style={styles.viewActionText}>{action}</AppText>
+                        <Ionicons name="chevron-forward" size={19} color={theme.colors.primary} />
+                    </View>
+                </View>
+
+                <View style={styles.summaryRow}>
+                    <View style={styles.weightIcon}>
+                        <Ionicons name="scale-outline" size={22} color={theme.colors.primary} />
+                    </View>
+                    <View style={styles.summaryText}>
+                        <AppText variant={metric ? 'screenTitle' : 'subtitle'} numberOfLines={1}>
+                            {metricLabel}
+                        </AppText>
+                        <AppText variant="muted">{supportingLabel}</AppText>
+                    </View>
+                </View>
+            </AppCard>
+        </Pressable>
+    );
+};
+
+function createStyles(theme: AppTheme) {
+    return StyleSheet.create({
+        pressable: {
+            width: '100%',
+            borderRadius: theme.radius.lg,
+            overflow: 'hidden'
+        },
+        card: {
+            gap: theme.spacing.md
+        },
+        headerRow: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: theme.spacing.md
+        },
+        viewAction: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            flexShrink: 0,
+            gap: theme.spacing.xs
+        },
+        viewActionText: {
+            color: theme.colors.primary,
+            fontSize: theme.typography.small,
+            fontWeight: '800'
+        },
+        summaryRow: {
+            minHeight: theme.interaction.minimumTouchTarget,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: theme.spacing.md
+        },
+        weightIcon: {
+            width: 42,
+            height: 42,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: theme.radius.md,
+            backgroundColor: theme.colors.primaryContainer
+        },
+        summaryText: {
+            flex: 1,
+            minWidth: 0,
+            gap: theme.spacing.xs
+        },
+        pressed: {
+            opacity: 0.86
+        }
+    });
+}

--- a/mobile/src/navigation/contextualFab.test.ts
+++ b/mobile/src/navigation/contextualFab.test.ts
@@ -5,15 +5,18 @@ const TODAY = '2026-07-20';
 const TODAY_METRIC: MetricEntry = { id: 1, date: `${TODAY}T00:00:00.000Z`, weight: 168.2 };
 
 describe('contextual tab FAB', () => {
-    it('only identifies the primary Today and Progress routes', () => {
+    it('identifies primary tabs and the full food-log surface', () => {
         expect(getActiveTabRoute('/today')).toBe('today');
         expect(getActiveTabRoute('/progress/')).toBe('progress');
+        expect(getActiveTabRoute('/food-log?date=2026-07-20')).toBe('food-log');
         expect(getActiveTabRoute('/settings')).toBeNull();
         expect(getActiveTabRoute('/weight?date=2026-07-20')).toBeNull();
     });
 
-    it('keeps Add food on Today and removes it from secondary routes', () => {
+    it('keeps Add food on Today and the full Food log', () => {
         expect(resolveContextualFab({ pathname: '/today', today: TODAY, metrics: undefined, metricsLoaded: false }))
+            .toBe('add-food');
+        expect(resolveContextualFab({ pathname: '/food-log', today: TODAY, metrics: [], metricsLoaded: true }))
             .toBe('add-food');
         expect(resolveContextualFab({ pathname: '/settings', today: TODAY, metrics: [], metricsLoaded: true }))
             .toBeNull();

--- a/mobile/src/navigation/contextualFab.ts
+++ b/mobile/src/navigation/contextualFab.ts
@@ -3,10 +3,10 @@ import { hasMetricForDate } from '../utils/metrics';
 
 export type ContextualFabKind = 'add-food' | 'log-weight' | null;
 
-export function getActiveTabRoute(pathname: string): 'today' | 'progress' | null {
+export function getActiveTabRoute(pathname: string): 'today' | 'progress' | 'food-log' | null {
     const segments = pathname.split('?')[0].replace(/\/+$/, '').split('/').filter(Boolean);
     const route = segments[segments.length - 1];
-    if (route === 'today' || route === 'progress') return route;
+    if (route === 'today' || route === 'progress' || route === 'food-log') return route;
     return null;
 }
 
@@ -17,7 +17,7 @@ export function resolveContextualFab(input: {
     metricsLoaded: boolean;
 }): ContextualFabKind {
     const activeRoute = getActiveTabRoute(input.pathname);
-    if (activeRoute === 'today') return 'add-food';
+    if (activeRoute === 'today' || activeRoute === 'food-log') return 'add-food';
     if (activeRoute !== 'progress' || !input.metricsLoaded) return null;
     return hasMetricForDate(input.metrics ?? [], input.today) ? null : 'log-weight';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "ISC",
       "workspaces": [
         "mobile",
@@ -24,7 +24,7 @@
       }
     },
     "mobile": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@calibrate/api-client": "file:../packages/api-client",
@@ -87,7 +87,7 @@
     },
     "mobile/modules/wear-pairing": {
       "name": "@calibrate/wear-pairing",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "peerDependencies": {
         "expo": "*",
         "expo-modules-core": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "release:metadata": "node scripts/release-config.mjs metadata",
     "test:release": "node --test scripts/release-config.test.mjs scripts/release-workflow-contract.test.mjs scripts/dependency-advisory-exceptions.test.mjs",
     "test:dev-script": "node --test scripts/dev.test.mjs scripts/docker-runtime.test.mjs",
-    "test:native-release": "node --test mobile/app.config.test.cjs scripts/native-ota-contract.test.mjs scripts/native-ota-update.test.mjs scripts/native-release-build.test.mjs scripts/native-release-devices.test.mjs scripts/android-e2e.test.mjs",
+    "test:native-release": "node --test mobile/app.config.test.cjs scripts/native-ota-contract.test.mjs scripts/native-ota-update.test.mjs scripts/native-ota-ci-preflight.test.mjs scripts/native-release-build.test.mjs scripts/native-release-devices.test.mjs scripts/android-e2e.test.mjs",
     "test:mobile-build-tools": "node --test scripts/xcode-uuid-compatibility.test.mjs",
     "test:native:upgrade": "node scripts/native-upgrade-rehearsal.mjs",
     "test:native:upgrade:unit": "node --test scripts/native-upgrade-rehearsal.test.mjs",

--- a/scripts/native-ota-ci-preflight.mjs
+++ b/scripts/native-ota-ci-preflight.mjs
@@ -1,0 +1,204 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  createNativeRuntimeFingerprint,
+  EXPO_PROJECT_ID_PATTERN,
+  EXPO_UPDATE_CHANNEL_PATTERN
+} from './native-ota-contract.mjs';
+import { parseEasEnvironmentFile } from './native-ota-update.mjs';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '..');
+
+function requiredValue(argv, index, option) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${option} requires a value.`);
+  return value;
+}
+
+export function parseNativeOtaCiArgs(argv) {
+  const values = {
+    nativeBuildRef: null,
+    channel: null,
+    environment: null,
+    environmentFile: null,
+    help: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option === '--help' || option === '-h') values.help = true;
+    else if (option === '--native-build-ref') values.nativeBuildRef = requiredValue(argv, index++, option);
+    else if (option === '--channel') values.channel = requiredValue(argv, index++, option);
+    else if (option === '--environment') values.environment = requiredValue(argv, index++, option);
+    else if (option === '--environment-file') values.environmentFile = requiredValue(argv, index++, option);
+    else throw new Error(`Unknown native OTA CI option: ${option}`);
+  }
+  return values;
+}
+
+export function validateNativeOtaCompatibility(baseline, current) {
+  if (baseline.runtimeVersion !== current.runtimeVersion) {
+    throw new Error(
+      `Native runtime version changed from ${baseline.runtimeVersion} to ${current.runtimeVersion}. ` +
+      'Create and install a new signed phone build instead of publishing OTA.'
+    );
+  }
+  if (baseline.fingerprint !== current.fingerprint) {
+    throw new Error(
+      'Native runtime inputs changed after the installed build. Create and install a new signed phone/Watch build instead of publishing OTA.'
+    );
+  }
+}
+
+export function validateEasCiEnvironment(values, expected) {
+  const projectId = values.EXPO_PUBLIC_EAS_PROJECT_ID?.trim();
+  if (!projectId) {
+    throw new Error(`EAS environment ${expected.environment} does not define EXPO_PUBLIC_EAS_PROJECT_ID.`);
+  }
+  if (projectId !== expected.projectId) {
+    throw new Error(
+      `EAS environment ${expected.environment} targets project ${projectId}, but mobile/app.json targets ${expected.projectId}.`
+    );
+  }
+
+  const channel = values.EXPO_UPDATES_CHANNEL?.trim();
+  if (!channel) {
+    throw new Error(`EAS environment ${expected.environment} does not define EXPO_UPDATES_CHANNEL.`);
+  }
+  if (channel !== expected.channel) {
+    throw new Error(
+      `EAS environment ${expected.environment} targets channel ${channel}, but this dispatch targets ${expected.channel}.`
+    );
+  }
+
+  const serverUrl = values.EXPO_PUBLIC_CALIBRATE_SERVER_URL?.trim();
+  if (!serverUrl) {
+    throw new Error(`EAS environment ${expected.environment} does not define EXPO_PUBLIC_CALIBRATE_SERVER_URL.`);
+  }
+  let parsedServerUrl;
+  try {
+    parsedServerUrl = new URL(serverUrl);
+  } catch {
+    throw new Error(`EAS environment ${expected.environment} has an invalid Calibrate server URL.`);
+  }
+  if (parsedServerUrl.protocol !== 'https:') {
+    throw new Error(`EAS environment ${expected.environment} must use an HTTPS Calibrate server URL.`);
+  }
+  if (parsedServerUrl.username || parsedServerUrl.password) {
+    throw new Error(`EAS environment ${expected.environment} must not put credentials in the Calibrate server URL.`);
+  }
+  return { projectId, channel, serverUrl };
+}
+
+function runCommand(command, args, cwd, allowFailure = false) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true
+  });
+  if (result.error) throw result.error;
+  if ((result.status ?? 1) !== 0 && !allowFailure) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+    throw new Error(`${command} ${args[0] ?? ''} failed: ${detail}`);
+  }
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? ''
+  };
+}
+
+function readRuntimeContract(root) {
+  const appConfig = JSON.parse(fs.readFileSync(path.join(root, 'mobile', 'app.json'), 'utf8'));
+  return {
+    runtimeVersion: appConfig.expo?.version,
+    projectId: appConfig.expo?.extra?.eas?.projectId,
+    fingerprint: createNativeRuntimeFingerprint(root).sha256
+  };
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/native-ota-ci-preflight.mjs [options]
+
+Validate that a GitHub-hosted EAS Update is compatible with an installed Android phone build.
+
+Options:
+  --native-build-ref <ref>    Exact commit or tag used to create the installed native build
+  --channel <name>            EAS Update channel embedded in the installed build
+  --environment <name>        EAS environment selected for the update
+  --environment-file <path>   File produced by eas env:pull
+  --help                      Show this help
+`);
+}
+
+export function runNativeOtaCiPreflight(options = {}) {
+  const root = options.repositoryRoot ?? repositoryRoot;
+  const config = options.config ?? parseNativeOtaCiArgs(process.argv.slice(2));
+  if (config.help) {
+    printHelp();
+    return { help: true };
+  }
+  if (!config.nativeBuildRef || !config.channel || !config.environment || !config.environmentFile) {
+    throw new Error('Native build ref, channel, environment, and environment file are required.');
+  }
+  if (config.nativeBuildRef.startsWith('-')) throw new Error('Native build ref must not start with a dash.');
+  if (!EXPO_UPDATE_CHANNEL_PATTERN.test(config.channel)) throw new Error('Invalid EAS Update channel.');
+
+  const commit = runCommand(
+    'git',
+    ['rev-parse', '--verify', `${config.nativeBuildRef}^{commit}`],
+    root
+  ).stdout.trim();
+  const ancestry = runCommand('git', ['merge-base', '--is-ancestor', commit, 'HEAD'], root, true);
+  if (ancestry.status !== 0) {
+    throw new Error('The selected update does not descend from the installed native build ref.');
+  }
+
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'calibrate-native-ota-ci-'));
+  const checkout = path.join(temporaryDirectory, 'native-build');
+  try {
+    runCommand('git', ['worktree', 'add', '--detach', checkout, commit], root);
+    const baseline = readRuntimeContract(checkout);
+    const current = readRuntimeContract(root);
+    validateNativeOtaCompatibility(baseline, current);
+    if (!EXPO_PROJECT_ID_PATTERN.test(current.projectId ?? '')) {
+      throw new Error('mobile/app.json does not contain a valid EAS project ID.');
+    }
+
+    const environmentValues = parseEasEnvironmentFile(
+      fs.readFileSync(path.resolve(root, config.environmentFile), 'utf8')
+    );
+    const eas = validateEasCiEnvironment(environmentValues, {
+      projectId: current.projectId,
+      channel: config.channel,
+      environment: config.environment
+    });
+
+    process.stdout.write(
+      `Native build ref: ${config.nativeBuildRef} (${commit.slice(0, 12)})\n` +
+      `Runtime: ${current.runtimeVersion} | Channel: ${eas.channel} | Environment: ${config.environment}\n` +
+      `Server: ${eas.serverUrl}\n` +
+      `Native fingerprint: ${current.fingerprint}\n` +
+      'OTA compatibility preflight passed.\n'
+    );
+    return { commit, baseline, current, eas };
+  } finally {
+    runCommand('git', ['worktree', 'remove', '--force', checkout], root, true);
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    runNativeOtaCiPreflight();
+  } catch (error) {
+    console.error(`[native-ota-ci] ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/native-ota-ci-preflight.test.mjs
+++ b/scripts/native-ota-ci-preflight.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  parseNativeOtaCiArgs,
+  validateEasCiEnvironment,
+  validateNativeOtaCompatibility
+} from './native-ota-ci-preflight.mjs';
+
+test('OTA CI CLI requires explicit native-build targeting inputs', () => {
+  assert.deepEqual(parseNativeOtaCiArgs([
+    '--native-build-ref', 'v0.12.2',
+    '--channel', 'production',
+    '--environment', 'production',
+    '--environment-file', 'eas.env'
+  ]), {
+    nativeBuildRef: 'v0.12.2',
+    channel: 'production',
+    environment: 'production',
+    environmentFile: 'eas.env',
+    help: false
+  });
+  assert.throws(() => parseNativeOtaCiArgs(['--unknown']), /Unknown native OTA CI option/);
+});
+
+test('OTA CI accepts only the exact compatible native runtime', () => {
+  const installed = { runtimeVersion: '0.2.1', fingerprint: 'abc' };
+  validateNativeOtaCompatibility(installed, { ...installed });
+  assert.throws(
+    () => validateNativeOtaCompatibility(installed, { ...installed, runtimeVersion: '0.2.2' }),
+    /Native runtime version changed/
+  );
+  assert.throws(
+    () => validateNativeOtaCompatibility(installed, { ...installed, fingerprint: 'def' }),
+    /Native runtime inputs changed/
+  );
+});
+
+test('OTA CI validates the selected EAS environment contract', () => {
+  const projectId = '01234567-89ab-4def-8123-456789abcdef';
+  const expected = { projectId, channel: 'production', environment: 'production' };
+  assert.deepEqual(validateEasCiEnvironment({
+    EXPO_PUBLIC_EAS_PROJECT_ID: projectId,
+    EXPO_UPDATES_CHANNEL: 'production',
+    EXPO_PUBLIC_CALIBRATE_SERVER_URL: 'https://calibrate.example'
+  }, expected), {
+    projectId,
+    channel: 'production',
+    serverUrl: 'https://calibrate.example'
+  });
+  assert.throws(() => validateEasCiEnvironment({
+    EXPO_PUBLIC_EAS_PROJECT_ID: projectId,
+    EXPO_UPDATES_CHANNEL: 'internal',
+    EXPO_PUBLIC_CALIBRATE_SERVER_URL: 'https://calibrate.example'
+  }, expected), /targets channel internal/);
+  assert.throws(() => validateEasCiEnvironment({
+    EXPO_PUBLIC_EAS_PROJECT_ID: projectId,
+    EXPO_UPDATES_CHANNEL: 'production',
+    EXPO_PUBLIC_CALIBRATE_SERVER_URL: 'http:\/\/calibrate.example'
+  }, expected), /must use an HTTPS/);
+});

--- a/scripts/native-release-build.mjs
+++ b/scripts/native-release-build.mjs
@@ -15,6 +15,9 @@ export const REQUIRED_SIGNING_ENV = Object.freeze([
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptDirectory, '..');
 
+// Expo SDK 57 release lint can exceed the generated project's 512 MiB metaspace cap.
+export const RELEASE_GRADLE_JVM_ARGS = '-Xmx4096m -XX:MaxMetaspaceSize=1536m -Dfile.encoding=UTF-8';
+
 /** Resolve and validate the shared phone/watch release environment before Gradle can start. */
 export function resolveNativeReleaseEnvironment(environment, options = {}) {
   const missing = REQUIRED_SIGNING_ENV.filter((name) => !environment[name]?.trim());
@@ -72,7 +75,11 @@ export function resolveNativeReleaseEnvironment(environment, options = {}) {
 
 export function nativeReleaseGradleCommands(platform = process.platform) {
   const wrapper = platform === 'win32' ? 'gradlew.bat' : './gradlew';
-  const common = ['--no-daemon', '--console=plain'];
+  const common = [
+    `-Dorg.gradle.jvmargs=${RELEASE_GRADLE_JVM_ARGS}`,
+    '--no-daemon',
+    '--console=plain'
+  ];
   return [
     {
       label: 'phone',
@@ -87,6 +94,29 @@ export function nativeReleaseGradleCommands(platform = process.platform) {
       args: [':app:bundleRelease', ':app:assembleRelease', ...common]
     }
   ];
+}
+
+export function nativeReleaseArtifactPaths(build) {
+  const outputRoot = path.join(build.cwd, 'app', 'build', 'outputs');
+  return [
+    path.join(outputRoot, 'apk', 'release', 'app-release.apk'),
+    path.join(outputRoot, 'bundle', 'release', 'app-release.aab')
+  ];
+}
+
+/** Ensure a successful Gradle exit cannot reuse or conceal missing release outputs. */
+export function prepareNativeReleaseArtifacts(build, removeFile = (file) => fs.rmSync(file, { force: true })) {
+  for (const file of nativeReleaseArtifactPaths(build)) removeFile(file);
+}
+
+export function assertNativeReleaseArtifacts(build, fileExists = fs.existsSync) {
+  const missing = nativeReleaseArtifactPaths(build).filter((file) => !fileExists(file));
+  if (missing.length === 0) return;
+  throw new Error(
+    `${build.label} Gradle completed without producing the expected release artifacts:\n` +
+    `${missing.map((file) => `  - ${file}`).join('\n')}\n` +
+    `Review the earlier ${build.label} Gradle output for a masked daemon, lint, or memory failure.`
+  );
 }
 
 export function nativeReleasePrebuildCommand(root = repositoryRoot) {
@@ -137,6 +167,7 @@ function run() {
     if (!fs.existsSync(path.join(build.cwd, process.platform === 'win32' ? 'gradlew.bat' : 'gradlew'))) {
       throw new Error(`${build.label} Gradle wrapper is missing. Run a clean Android prebuild before release.`);
     }
+    prepareNativeReleaseArtifacts(build);
     const args = build.label === 'wear'
       ? [`-PcalibrateWearServerUrl=${environment.EXPO_PUBLIC_CALIBRATE_SERVER_URL}`, ...build.args]
       : build.args;
@@ -148,6 +179,7 @@ function run() {
     });
     if (result.error) throw result.error;
     if (result.status !== 0) process.exit(result.status ?? 1);
+    assertNativeReleaseArtifacts(build);
   }
 
   const commit = execFileSync('git', ['rev-parse', 'HEAD'], {

--- a/scripts/native-release-build.test.mjs
+++ b/scripts/native-release-build.test.mjs
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  assertNativeReleaseArtifacts,
+  nativeReleaseArtifactPaths,
   nativeReleaseGradleCommands,
   nativeReleaseInvocation,
   nativeReleasePrebuildCommand,
+  prepareNativeReleaseArtifacts,
+  RELEASE_GRADLE_JVM_ARGS,
   resolveNativeReleaseEnvironment
 } from './native-release-build.mjs';
 
@@ -70,8 +74,25 @@ test('native release build always produces phone and Wear APK plus AAB tasks', (
       assert.ok(command.args.includes(':app:bundleRelease'));
       assert.ok(command.args.includes(':app:assembleRelease'));
       assert.ok(command.args.includes('--no-daemon'));
+      assert.ok(command.args.includes(`-Dorg.gradle.jvmargs=${RELEASE_GRADLE_JVM_ARGS}`));
     }
   }
+});
+
+test('native release builds require freshly generated APK and AAB outputs', () => {
+  const build = { label: 'phone', cwd: 'C:/repo/mobile/android' };
+  const artifacts = nativeReleaseArtifactPaths(build);
+  assert.match(artifacts[0], /outputs[\\/]apk[\\/]release[\\/]app-release\.apk$/);
+  assert.match(artifacts[1], /outputs[\\/]bundle[\\/]release[\\/]app-release\.aab$/);
+
+  const removed = [];
+  prepareNativeReleaseArtifacts(build, (file) => removed.push(file));
+  assert.deepEqual(removed, artifacts);
+  assert.doesNotThrow(() => assertNativeReleaseArtifacts(build, () => true));
+  assert.throws(
+    () => assertNativeReleaseArtifacts(build, (file) => file.endsWith('.apk')),
+    /phone Gradle completed without producing.*app-release\.aab.*masked daemon, lint, or memory failure/s
+  );
 });
 
 test('native release build regenerates the ignored phone project before Gradle', () => {

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -43,3 +43,18 @@ test('no active workflow deploys to AWS or builds an image for every merged PR',
   assert.doesNotMatch(workflows, /aws-actions|amazon-ecs|\bECR\b|\bECS\b/i);
   assert.doesNotMatch(workflows, /pull_request_target/);
 });
+
+test('Expo OTA updates are manual, authenticated, and native-compatibility gated', () => {
+  const workflow = readWorkflow('expo-ota-update.yml');
+
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /native_build_ref:/);
+  assert.match(workflow, /refs\/heads\/master/);
+  assert.match(workflow, /secrets\.EXPO_TOKEN/);
+  assert.match(workflow, /eas env:pull/);
+  assert.match(workflow, /native-ota-ci-preflight\.mjs/);
+  assert.match(workflow, /eas update/);
+  assert.match(workflow, /--platform android/);
+  assert.match(workflow, /--non-interactive/);
+  assert.doesNotMatch(workflow, /pull_request:|push:/);
+});

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.1",
+    "version": "0.12.2",
     "api": {
       "current": "v1",
       "supported": [
@@ -13,13 +13,13 @@
   "android": {
     "application_id": "app.calibratehealth.mobile",
     "mobile": {
-      "version_name": "0.2.0",
-      "version_code": 2,
+      "version_name": "0.2.1",
+      "version_code": 3,
       "minimum_supported_version": "0.1.0"
     },
     "wear": {
-      "version_name": "0.2.0",
-      "version_code": 2,
+      "version_name": "0.2.1",
+      "version_code": 3,
       "minimum_supported_version": "0.2.0"
     },
     "channels": {

--- a/wear/app/build.gradle.kts
+++ b/wear/app/build.gradle.kts
@@ -119,8 +119,8 @@ android {
         applicationId = "app.calibratehealth.mobile"
         minSdk = 30
         targetSdk = 36
-        versionCode = 2
-        versionName = "0.2.0"
+        versionCode = 3
+        versionName = "0.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "DEFAULT_SERVER_URL", quoteBuildConfig(configuredServerOrigin))

--- a/wear/app/src/main/java/app/calibratehealth/wear/CalibrateWearApp.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/CalibrateWearApp.kt
@@ -25,24 +25,25 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.rotary.onRotaryScrollEvent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.Button
-import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Card
-import androidx.wear.compose.material3.EdgeButton
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
@@ -219,39 +220,29 @@ private fun ReadySummaryDashboard(
     val balanceLabel = when {
         caloriesRemaining == null -> "target unavailable"
         caloriesRemaining < 0 -> "kcal over"
-        else -> "kcal left"
+        else -> "kcal remaining"
     }
-    val syncLabel = when {
+    val footerLabel = when {
         homeState.actionInProgress -> "Syncing..."
         homeState.syncStatus is WearSyncStatus.Error -> "Sync needs attention"
-        else -> SummaryFormatter.sync(homeState.syncStatus, summary.lastSyncAtEpochMs)
+        summary.goalTargetWeightGrams != null -> goalProgressHeadline(summary)
+        else -> null
     }
     val progressColor = if ((caloriesRemaining ?: 0) < 0) CALIBRATE_DANGER else CALIBRATE_GREEN
     val listState = rememberTransformingLazyColumnState()
 
-    ScreenScaffold(
-        scrollState = listState,
-        edgeButton = {
-            EdgeButton(
-                onClick = onOpenActions,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = CALIBRATE_GREEN,
-                    contentColor = CALIBRATE_ON_GREEN
-                )
-            ) {
-                Text("Actions")
-            }
-        }
-    ) { contentPadding ->
+    ScreenScaffold(scrollState = listState) {
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
                 .background(CALIBRATE_BACKGROUND)
-                .padding(contentPadding),
+                // Keep the dashboard clear of the curved edge and system time without
+                // surrendering the lower third of the display to an unused edge button.
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .padding(top = 20.dp),
             contentAlignment = Alignment.Center
         ) {
-            // EdgeButton padding changes the usable height across watch sizes. Keep the ring
-            // inside the real content bounds instead of assuming a large round display.
+            // Scale from the actual circular-safe region so large watches use their display.
             val dashboardDiameter = summaryDashboardDiameter(maxWidth.value, maxHeight.value).dp
             val compactDashboard = dashboardDiameter.value < SUMMARY_COMPACT_DIAMETER_DP
             Box(
@@ -293,7 +284,7 @@ private fun ReadySummaryDashboard(
                     verticalArrangement = Arrangement.spacedBy(1.dp),
                     modifier = Modifier.padding(horizontal = 14.dp)
                 ) {
-                    CalibrateBrand()
+                    CalibrateBrand(showWordmark = !compactDashboard)
                     Text(
                         balanceValue,
                         style = if (compactDashboard) {
@@ -304,13 +295,14 @@ private fun ReadySummaryDashboard(
                     )
                     Text(balanceLabel, style = MaterialTheme.typography.labelMedium)
                     Text(SummaryFormatter.calorieProgress(summary), style = MaterialTheme.typography.labelSmall)
-                    if (!compactDashboard) {
-                        summary.goalTargetWeightGrams?.let {
-                            Text(goalProgressHeadline(summary), style = MaterialTheme.typography.labelSmall)
-                        }
-                    }
-                    if (!compactDashboard || homeState.syncStatus is WearSyncStatus.Error) {
-                        Text(syncLabel, style = MaterialTheme.typography.labelSmall, color = CALIBRATE_SECONDARY_TEXT)
+                    if (footerLabel != null && (!compactDashboard || homeState.syncStatus is WearSyncStatus.Error)) {
+                        Text(
+                            footerLabel,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = CALIBRATE_SECONDARY_TEXT,
+                            maxLines = 1,
+                            softWrap = false
+                        )
                     }
                 }
             }
@@ -319,29 +311,50 @@ private fun ReadySummaryDashboard(
 }
 
 @Composable
-private fun CalibrateBrand() {
+private fun CalibrateBrand(showWordmark: Boolean = true) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Canvas(modifier = Modifier.size(17.dp)) {
-            val markStroke = 3.dp.toPx()
+        Canvas(modifier = Modifier.size(19.dp)) {
+            val gaugeStroke = 3.5.dp.toPx()
             drawArc(
-                color = CALIBRATE_GREEN,
-                startAngle = -40f,
-                sweepAngle = 290f,
+                color = CALIBRATE_FOREGROUND,
+                startAngle = 45f,
+                sweepAngle = 270f,
                 useCenter = false,
-                style = Stroke(width = markStroke, cap = StrokeCap.Round)
+                style = Stroke(width = gaugeStroke, cap = StrokeCap.Butt)
             )
             drawLine(
                 color = CALIBRATE_FOREGROUND,
-                start = center,
-                end = center.copy(y = size.height * 0.16f),
-                strokeWidth = 2.dp.toPx(),
+                start = Offset(size.width * 0.5f, size.height * 0.03f),
+                end = Offset(size.width * 0.5f, size.height * 0.23f),
+                strokeWidth = 2.5.dp.toPx(),
                 cap = StrokeCap.Round
             )
+            val hub = Offset(size.width * 0.45f, size.height * 0.61f)
+            drawLine(
+                color = CALIBRATE_NEEDLE,
+                start = hub,
+                end = Offset(size.width * 0.79f, size.height * 0.27f),
+                strokeWidth = 3.dp.toPx(),
+                cap = StrokeCap.Round
+            )
+            drawCircle(color = CALIBRATE_HUB, radius = 3.3.dp.toPx(), center = hub)
+            drawCircle(color = CALIBRATE_FOREGROUND, radius = 1.4.dp.toPx(), center = hub)
         }
-        Text("CALIBRATE", style = MaterialTheme.typography.labelSmall, color = CALIBRATE_FOREGROUND)
+        if (showWordmark) {
+            Text(
+                "calibrate",
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = CALIBRATE_FOREGROUND,
+                maxLines = 1,
+                softWrap = false
+            )
+        }
     }
 }
 
@@ -350,12 +363,13 @@ private val CALIBRATE_FOREGROUND = Color(0xFFF3F7F1)
 private val CALIBRATE_SECONDARY_TEXT = Color(0xFFB6C5B6)
 private val CALIBRATE_RING_TRACK = Color(0xFF29382B)
 private val CALIBRATE_GREEN = Color(0xFF71D478)
-private val CALIBRATE_ON_GREEN = Color(0xFF00390A)
+private val CALIBRATE_NEEDLE = Color(0xFF8DDD2B)
+private val CALIBRATE_HUB = Color(0xFF2E7D32)
 private val CALIBRATE_DANGER = Color(0xFFFF796E)
 private const val CALORIE_RING_START_ANGLE = 140f
 private const val CALORIE_RING_SWEEP_ANGLE = 260f
 private const val SUMMARY_DASHBOARD_INSET_DP = 4f
-private const val SUMMARY_COMPACT_DIAMETER_DP = 124f
+private const val SUMMARY_COMPACT_DIAMETER_DP = 160f
 
 internal fun summaryDashboardDiameter(widthDp: Float, heightDp: Float): Float =
     (minOf(widthDp, heightDp) - SUMMARY_DASHBOARD_INSET_DP).coerceAtLeast(0f)

--- a/wear/app/src/main/java/app/calibratehealth/wear/sync/Outbox.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/sync/Outbox.kt
@@ -189,18 +189,23 @@ class WorkManagerOutboxScheduler(context: Context) : OutboxScheduler {
 
     /** Avoids duplicate cold-start/onStart refreshes while still refreshing a surviving process. */
     fun scheduleForegroundRefresh() {
-        if (foregroundRefreshGate.tryAcquire(SystemClock.elapsedRealtime())) schedule()
+        if (foregroundRefreshGate.tryAcquire(SystemClock.elapsedRealtime())) {
+            enqueue(OutboxEnqueueMode.AUTHORITATIVE_REFRESH)
+        }
     }
 
-    override fun schedule() = enqueue()
+    /** A phone invalidation must not wait behind a stale WorkManager retry chain. */
+    fun scheduleAuthoritativeRefresh() = enqueue(OutboxEnqueueMode.AUTHORITATIVE_REFRESH)
 
-    override fun scheduleContinuation() = enqueue()
+    override fun schedule() = enqueue(OutboxEnqueueMode.ORDERED)
 
-    private fun enqueue() = synchronized(enqueueLock) {
+    override fun scheduleContinuation() = enqueue(OutboxEnqueueMode.ORDERED)
+
+    private fun enqueue(mode: OutboxEnqueueMode) = synchronized(enqueueLock) {
         val request = workRequest()
         workManager.enqueueUniqueWork(
             OutboxWorkPolicy.UNIQUE_WORK_NAME,
-            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            existingWorkPolicy(mode),
             request
         )
         OutboxWorkPolicy.recordLatestWorkId(appContext, request.id)
@@ -225,6 +230,20 @@ class WorkManagerOutboxScheduler(context: Context) : OutboxScheduler {
         val enqueueLock = Any()
         val foregroundRefreshGate = ForegroundRefreshGate(minimumIntervalMs = 60_000L)
     }
+}
+
+internal enum class OutboxEnqueueMode {
+    ORDERED,
+    AUTHORITATIVE_REFRESH
+}
+
+/**
+ * Mutations and worker continuations preserve FIFO ordering. User-visible refresh events replace
+ * an old delayed chain; the new worker still drains the durable Room outbox before fetching.
+ */
+internal fun existingWorkPolicy(mode: OutboxEnqueueMode): ExistingWorkPolicy = when (mode) {
+    OutboxEnqueueMode.ORDERED -> ExistingWorkPolicy.APPEND_OR_REPLACE
+    OutboxEnqueueMode.AUTHORITATIVE_REFRESH -> ExistingWorkPolicy.REPLACE
 }
 
 internal class ForegroundRefreshGate(private val minimumIntervalMs: Long) {

--- a/wear/app/src/main/java/app/calibratehealth/wear/sync/SyncInvalidation.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/sync/SyncInvalidation.kt
@@ -23,7 +23,7 @@ internal object SyncInvalidationInbox {
         check(preferences.edit().putString(PENDING, invalidation.id).commit()) {
             "Unable to persist sync invalidation receipt."
         }
-        WorkManagerOutboxScheduler(context).schedule()
+        WorkManagerOutboxScheduler(context).scheduleAuthoritativeRefresh()
         return true
     }
 
@@ -31,7 +31,7 @@ internal object SyncInvalidationInbox {
     fun recover(context: Context): Boolean {
         val preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
         val pending = preferences.getString(PENDING, null)?.takeIf(SYNC_INVALIDATION_ID::matches) ?: return false
-        WorkManagerOutboxScheduler(context).schedule()
+        WorkManagerOutboxScheduler(context).scheduleAuthoritativeRefresh()
         return true
     }
 

--- a/wear/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/wear/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -4,7 +4,6 @@
     android:height="108dp"
     android:viewportWidth="512"
     android:viewportHeight="512">
-    <!-- Adaptive launchers may crop everything outside the centered 66dp safe zone. -->
     <group
         android:pivotX="256"
         android:pivotY="256"
@@ -13,25 +12,22 @@
         <path
             android:fillColor="@android:color/transparent"
             android:pathData="M360,151A164,164 0,1 0,363 365"
-            android:strokeColor="#1F2937"
+            android:strokeColor="#FFFFFF"
             android:strokeWidth="57" />
         <path
             android:fillColor="@android:color/transparent"
             android:pathData="M256,93L256,141"
-            android:strokeColor="#1F2937"
+            android:strokeColor="#FFFFFF"
             android:strokeLineCap="round"
             android:strokeWidth="36" />
         <path
             android:fillColor="@android:color/transparent"
             android:pathData="M239,291L351,179"
-            android:strokeColor="#8DDD2B"
+            android:strokeColor="#FFFFFF"
             android:strokeLineCap="round"
             android:strokeWidth="43" />
         <path
-            android:fillColor="#2E7D32"
+            android:fillColor="#FFFFFF"
             android:pathData="M239,247A44,44 0,1 0,239 335A44,44 0,1 0,239 247" />
-        <path
-            android:fillColor="#F6F8F4"
-            android:pathData="M239,273A18,18 0,1 0,239 309A18,18 0,1 0,239 273" />
     </group>
 </vector>

--- a/wear/app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml
+++ b/wear/app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/wear/app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml
+++ b/wear/app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/wear/app/src/test/java/app/calibratehealth/wear/sync/OutboxWorkPolicyTest.kt
+++ b/wear/app/src/test/java/app/calibratehealth/wear/sync/OutboxWorkPolicyTest.kt
@@ -1,0 +1,23 @@
+package app.calibratehealth.wear.sync
+
+import androidx.work.ExistingWorkPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OutboxWorkPolicyTest {
+    @Test
+    fun `ordered work appends to preserve FIFO mutations`() {
+        assertEquals(
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            existingWorkPolicy(OutboxEnqueueMode.ORDERED)
+        )
+    }
+
+    @Test
+    fun `authoritative refresh replaces stale retry chains`() {
+        assertEquals(
+            ExistingWorkPolicy.REPLACE,
+            existingWorkPolicy(OutboxEnqueueMode.AUTHORITATIVE_REFRESH)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- harden local signed release builds so stale or missing APK/AAB outputs cannot be mistaken for successful artifacts
- link the Expo client to `@calibrate-health/calibrate-health-app` and document the stable EAS project identity
- keep the Add food FAB available on the full Food log and add a focused weight card to Today
- resize and simplify the Wear calorie dashboard for round displays and replace the generic/cropped launcher treatment with adaptive and monochrome Calibrate artwork
- make foreground and phone-triggered Wear refreshes replace stale WorkManager retry chains while preserving the durable FIFO mutation outbox
- upgrade the audited backend graph to Prisma 7.9, Express 5.2, `body-parser` 2.3.0, and `fast-uri` 4.1.1
- add a manual, token-authenticated Expo OTA workflow with native-build fingerprint and EAS environment gates
- advance the canonical release to server `0.12.2` and phone/Wear `0.2.1` (versionCode `3`)

## Why

The native release helper could retain old artifacts after a Gradle failure, making a later install report a missing or stale phone APK. On the watch, authoritative refresh work used `APPEND_OR_REPLACE`, so opening the app or receiving a phone invalidation could remain blocked behind a failed job's exponential backoff. This left the dashboard showing a cached zero-calorie snapshot even while the watch had validated network connectivity.

The phone Today and Food log surfaces also needed a cohesive primary-entry flow: Add food should work in place on either surface, while Today's unused space is better used for today's weight measurement.

Newly published npm advisories caused the backend production audit to fail on transitive Hono, body-parser, and fast-uri versions. The dependency refresh removes Hono from Prisma's graph and resolves the remaining advisories. The OTA workflow then provides a repeatable JavaScript/assets release path without weakening native compatibility checks.

## User impact

- release builds fail clearly unless all four fresh signed artifacts exist
- the phone provides faster access to food and today's weight without redundant meal-level actions
- the watch prioritizes calories consumed/remaining and goal progress with properly scaled branding
- opening the watch or receiving a phone mutation now requests current server state immediately instead of waiting through stale backoff
- local and EAS builds share the intended Expo project and OTA identity
- operators can manually publish Android phone OTA updates from `master` after proving the selected commit is compatible with the installed native build
- backend production dependencies pass the current npm advisory audit

## Validation

- `npm.cmd audit --omit=dev --audit-level=high` in `backend` after `npm.cmd ci --omit=dev` (0 vulnerabilities)
- `npm.cmd test` in `backend` (379 passing)
- `npm.cmd run build` in `backend`
- `npm.cmd run release:check`
- `npm.cmd run test:release` (19 passing)
- `npm.cmd run test:native-release` (34 passing)
- OTA CI preflight end-to-end rehearsal against the current native build ref and production server origin
- workflow YAML parse and `git diff --check`
- `npm.cmd run typecheck` in `mobile`
- `npm.cmd test -- --runInBand` in `mobile` (76 suites, 302 tests)
- `gradlew.bat :app:testDebugUnitTest :app:assembleDebug` in `wear`
- signed phone and Wear releases built and installed on physical devices
- physical Galaxy Watch Ultra refreshed from a job delayed by roughly 1h45m to the current server snapshot: 1,585 / 1,831 kcal, 246 remaining
- Wear emulator launcher and dashboard visual inspection; no fatal launch crashes
