### PR TITLE
Add in-app native and OTA version management

### DIFF
--- a/.github/workflows/expo-ota-update.yml
+++ b/.github/workflows/expo-ota-update.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       native_build_ref:
-        description: Exact master commit or tag used to build the installed Android phone app
+        description: Native build tag shown in Settings > About Calibrate (or its exact source commit)
         required: true
         type: string
       channel:

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -211,7 +211,8 @@ Before its first use:
 
 In GitHub, open **Actions > Publish Expo OTA Update > Run workflow**, select `master`, and provide:
 
-- `native_build_ref`: the exact commit or tag used to build the installed phone app.
+- `native_build_ref`: the native build tag shown in **Settings > About Calibrate**, or the exact source commit used to
+  build the installed phone app.
 - `channel`: `internal` for the dogfood APK or `production` for a production-channel build.
 - `message`: a short description shown in EAS Update history.
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "calibrate-health-app",
     "owner": "calibrate-health",
     "scheme": "calibrate",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "orientation": "default",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",
@@ -18,7 +18,7 @@
     ],
     "android": {
       "package": "app.calibratehealth.mobile",
-      "versionCode": 3,
+      "versionCode": 4,
       "allowBackup": false,
       "softwareKeyboardLayoutMode": "resize",
       "adaptiveIcon": {
@@ -92,6 +92,9 @@
       "expo-status-bar"
     ],
     "extra": {
+      "calibrate": {
+        "nativeReleaseTag": "v0.12.3"
+      },
       "router": {
         "origin": false
       },

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Image, Platform, Pressable, StyleSheet, Switch, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useRouter } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ACTIVITY_LEVELS, HEIGHT_UNITS, WEIGHT_UNITS, type ActivityLevel, type HeightUnit, type Sex, type WeightUnit } from '@calibrate/shared';
 import { AppButton } from '../../src/components/AppButton';
@@ -37,6 +38,7 @@ import { ACTIVITY_OPTIONS, HEIGHT_UNIT_OPTIONS, SEX_OPTIONS, WEIGHT_UNIT_OPTIONS
 import { radius, spacing, useAppTheme } from '../../src/theme';
 import { useHealthConnect } from '../../src/healthConnect/provider';
 import { clearWearAccountData } from '../../src/wear/accountCleanup';
+import { MOBILE_CLIENT_IDENTITY } from '../../src/config/nativeClient';
 
 const MIN_PASSWORD_LENGTH = 8;
 type SettingsSheet =
@@ -63,6 +65,7 @@ function formatSessionActivity(value: string | null, fallback: string): string {
 }
 
 export default function SettingsScreen() {
+    const router = useRouter();
     const {
         api, user, clearLocalSession, logout, persistAccountDeletionCleanupNotice,
         serverUrl, setServerUrl, updateCurrentUser
@@ -457,6 +460,17 @@ export default function SettingsScreen() {
                     value={serverUrl.replace(/^https?:\/\//, '')}
                     showDivider={false}
                     onPress={() => setActiveSheet('server')}
+                />
+            </SettingsSection>
+
+            <SettingsSection title="App">
+                <SettingsRow
+                    icon="information-circle-outline"
+                    label="About Calibrate"
+                    supportingText="Version, build, and software updates"
+                    value={isWeb ? undefined : `v${MOBILE_CLIENT_IDENTITY.version}`}
+                    showDivider={false}
+                    onPress={() => router.push('/about')}
                 />
             </SettingsSection>
 

--- a/mobile/app/about.tsx
+++ b/mobile/app/about.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useRouter } from 'expo-router';
+import { AppButton } from '../src/components/AppButton';
+import { AppCard } from '../src/components/AppCard';
+import { AppText } from '../src/components/AppText';
+import { CalibrateLogo } from '../src/components/CalibrateLogo';
+import { PageHeader } from '../src/components/PageHeader';
+import { Screen } from '../src/components/Screen';
+import { radius, spacing, useAppTheme } from '../src/theme';
+import { useAppUpdateController } from '../src/updates/useAppUpdateController';
+
+function formatUpdateDate(value: Date | null): string {
+    if (!value || Number.isNaN(value.getTime())) return 'Unknown';
+    return value.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+    });
+}
+
+function getUpdateActionIcon(
+    isUpdatePending: boolean,
+    isUpdateAvailable: boolean
+): React.ComponentProps<typeof Ionicons>['name'] {
+    if (isUpdatePending) return 'refresh';
+    if (isUpdateAvailable) return 'download-outline';
+    return 'cloud-done-outline';
+}
+
+export default function AboutScreen() {
+    const router = useRouter();
+    const theme = useAppTheme();
+    const updates = useAppUpdateController();
+    const { versionInfo } = updates;
+    const nativeRelease = versionInfo.nativeBuild === 'Not applicable'
+        ? versionInfo.nativeVersion
+        : `${versionInfo.nativeVersion} (build ${versionInfo.nativeBuild})`;
+    const progressPercent = typeof updates.downloadProgress === 'number'
+        ? Math.round(updates.downloadProgress * 100)
+        : null;
+    const status = progressPercent !== null && updates.manualPhase === 'downloading'
+        ? `${updates.status} ${progressPercent}%`
+        : updates.status;
+    const actionIcon = getUpdateActionIcon(updates.isUpdatePending, updates.isUpdateAvailable);
+
+    function goBack() {
+        if (router.canGoBack()) router.back();
+        else router.replace('/settings');
+    }
+
+    return (
+        <Screen safeTop>
+            <PageHeader
+                title="About Calibrate"
+                description="Installed build and software update details."
+                onBack={goBack}
+                backLabel="Back to Settings"
+            />
+
+            <AppCard style={styles.brandCard}>
+                <View style={[styles.logoSurface, { backgroundColor: theme.colors.primaryContainer }]}>
+                    <CalibrateLogo size={52} />
+                </View>
+                <View style={styles.brandCopy}>
+                    <AppText variant="title">calibrate</AppText>
+                    <AppText variant="caption">Self-hosted food, weight, and goal tracking.</AppText>
+                </View>
+            </AppCard>
+
+            <AppCard>
+                <View style={styles.cardHeading}>
+                    <View style={[styles.headingIcon, { backgroundColor: theme.colors.primaryContainer }]}>
+                        <Ionicons name="information-circle-outline" size={22} color={theme.colors.primaryDark} />
+                    </View>
+                    <View style={styles.headingCopy}>
+                        <AppText variant="subtitle">Version details</AppText>
+                        <AppText variant="caption">Useful when checking build and OTA compatibility.</AppText>
+                    </View>
+                </View>
+                <View style={[styles.infoRows, { backgroundColor: theme.colors.surfaceContainer }]}>
+                    <InfoRow label="Native build tag" value={versionInfo.nativeReleaseTag} />
+                    <InfoRow label="Native release" value={nativeRelease} />
+                    <InfoRow label="OTA runtime" value={versionInfo.runtimeVersion} />
+                    <InfoRow label="Update channel" value={versionInfo.channel} />
+                    <InfoRow label="Current OTA" value={versionInfo.updateLabel} />
+                    <InfoRow label="Published" value={formatUpdateDate(versionInfo.updateCreatedAt)} showDivider={false} />
+                </View>
+                {versionInfo.updateId ? (
+                    <View style={styles.updateIdBlock}>
+                        <AppText variant="caption">Full update ID</AppText>
+                        <AppText selectable style={styles.updateId}>{versionInfo.updateId}</AppText>
+                    </View>
+                ) : null}
+            </AppCard>
+
+            {versionInfo.isEmergencyLaunch ? (
+                <View style={[
+                    styles.notice,
+                    { backgroundColor: theme.colors.warningContainer, borderColor: theme.colors.warning }
+                ]}>
+                    <Ionicons name="warning-outline" size={22} color={theme.colors.onWarningContainer} />
+                    <View style={styles.noticeCopy}>
+                        <AppText variant="label" style={{ color: theme.colors.onWarningContainer }}>
+                            Recovery launch
+                        </AppText>
+                        <AppText style={{ color: theme.colors.onWarningContainer }}>
+                            Calibrate returned to a safe embedded update because the latest OTA could not launch.
+                        </AppText>
+                        {versionInfo.emergencyLaunchReason ? (
+                            <AppText variant="caption" selectable>{versionInfo.emergencyLaunchReason}</AppText>
+                        ) : null}
+                    </View>
+                </View>
+            ) : null}
+
+            <AppCard>
+                <View style={styles.cardHeading}>
+                    <View style={[styles.headingIcon, { backgroundColor: theme.colors.primaryContainer }]}>
+                        <Ionicons name="cloud-download-outline" size={22} color={theme.colors.primaryDark} />
+                    </View>
+                    <View style={styles.headingCopy}>
+                        <AppText variant="subtitle">App updates</AppText>
+                        <AppText variant="caption">Check the channel built into this phone app.</AppText>
+                    </View>
+                </View>
+                <View
+                    accessibilityLiveRegion="polite"
+                    style={[styles.status, { backgroundColor: theme.colors.surfaceContainer }]}
+                >
+                    {updates.isBusy ? <ActivityIndicator color={theme.colors.primary} /> : (
+                        <Ionicons
+                            name={updates.manualPhase === 'error' ? 'alert-circle-outline' : 'checkmark-circle-outline'}
+                            size={22}
+                            color={updates.manualPhase === 'error' ? theme.colors.danger : theme.colors.primary}
+                        />
+                    )}
+                    <AppText style={styles.statusCopy}>{status}</AppText>
+                </View>
+                <AppButton
+                    title={updates.actionTitle}
+                    variant={updates.isUpdateAvailable || updates.isUpdatePending ? 'primary' : 'secondary'}
+                    disabled={!updates.isSupported || updates.isBusy}
+                    leftIcon={<Ionicons name={actionIcon} size={20} color={
+                        updates.isUpdateAvailable || updates.isUpdatePending
+                            ? theme.colors.onPrimary
+                            : theme.colors.onSurface
+                    } />}
+                    onPress={() => void updates.action()}
+                />
+                <AppText variant="caption">
+                    OTA updates can change the phone app's JavaScript and assets. Native Android or Watch changes still
+                    require a newly signed build.
+                </AppText>
+                {Platform.OS !== 'web' ? (
+                    <AppText variant="caption">
+                        Installing an update restarts Calibrate immediately. Saved account and offline data remain on the device.
+                    </AppText>
+                ) : null}
+            </AppCard>
+        </Screen>
+    );
+}
+
+const InfoRow: React.FC<{ label: string; value: string; showDivider?: boolean }> = ({
+    label,
+    value,
+    showDivider = true
+}) => {
+    const theme = useAppTheme();
+    return (
+        <View style={[
+            styles.infoRow,
+            showDivider && { borderBottomColor: theme.colors.outlineVariant, borderBottomWidth: StyleSheet.hairlineWidth }
+        ]}>
+            <AppText variant="caption">{label}</AppText>
+            <AppText style={styles.infoValue}>{value}</AppText>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    brandCard: {
+        flexDirection: 'row',
+        alignItems: 'center'
+    },
+    logoSurface: {
+        width: 72,
+        height: 72,
+        borderRadius: radius.lg,
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+    brandCopy: {
+        flex: 1,
+        minWidth: 0,
+        gap: spacing.xs
+    },
+    cardHeading: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.md
+    },
+    headingIcon: {
+        width: 42,
+        height: 42,
+        borderRadius: radius.md,
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+    headingCopy: {
+        flex: 1,
+        minWidth: 0,
+        gap: spacing.xs
+    },
+    infoRows: {
+        borderRadius: radius.md,
+        paddingHorizontal: spacing.md
+    },
+    infoRow: {
+        minHeight: 52,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: spacing.lg,
+        paddingVertical: spacing.sm
+    },
+    infoValue: {
+        flex: 1,
+        textAlign: 'right',
+        fontWeight: '700'
+    },
+    updateIdBlock: {
+        gap: spacing.xs
+    },
+    updateId: {
+        fontFamily: Platform.select({ android: 'monospace', default: undefined }),
+        fontSize: 13
+    },
+    notice: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: spacing.md,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderRadius: radius.lg,
+        padding: spacing.lg
+    },
+    noticeCopy: {
+        flex: 1,
+        gap: spacing.xs
+    },
+    status: {
+        minHeight: 64,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: spacing.md,
+        borderRadius: radius.md,
+        paddingHorizontal: spacing.md,
+        paddingVertical: spacing.sm
+    },
+    statusCopy: {
+        flex: 1
+    }
+});

--- a/mobile/modules/wear-pairing/android/build.gradle
+++ b/mobile/modules/wear-pairing/android/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 group = 'app.calibratehealth'
-version = '0.2.1'
+version = '0.2.2'
 
 android {
   namespace 'app.calibratehealth.wearpairing'
   defaultConfig {
-    versionCode 3
-    versionName '0.2.1'
+    versionCode 4
+    versionName '0.2.2'
   }
 }
 

--- a/mobile/modules/wear-pairing/package.json
+++ b/mobile/modules/wear-pairing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calibrate/wear-pairing",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "main": "index.ts",
   "peerDependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "main": "index.js",
   "engines": {

--- a/mobile/src/screens/AboutScreen.test.tsx
+++ b/mobile/src/screens/AboutScreen.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { useAppUpdateController } from '../updates/useAppUpdateController';
+import AboutScreen from '../../app/about';
+
+const mockRouter = {
+    back: jest.fn(),
+    canGoBack: jest.fn(() => true),
+    replace: jest.fn()
+};
+
+jest.mock('expo-router', () => ({
+    useRouter: () => mockRouter
+}));
+jest.mock('@expo/vector-icons/Ionicons', () => ({
+    __esModule: true,
+    default: () => null
+}));
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 })
+}));
+jest.mock('../components/CalibrateLogo', () => ({
+    CalibrateLogo: () => null
+}));
+jest.mock('../updates/useAppUpdateController', () => ({
+    useAppUpdateController: jest.fn()
+}));
+
+const mockedUseAppUpdateController = jest.mocked(useAppUpdateController);
+
+function updateController(overrides: Partial<ReturnType<typeof useAppUpdateController>> = {}) {
+    return {
+        action: jest.fn(async () => undefined),
+        actionTitle: 'Check for updates',
+        downloadProgress: undefined,
+        isBusy: false,
+        isSupported: true,
+        isUpdateAvailable: false,
+        isUpdatePending: false,
+        manualPhase: 'idle' as const,
+        status: 'Calibrate checks automatically when it opens. You can also check manually.',
+        versionInfo: {
+            nativeVersion: '0.2.2',
+            nativeBuild: '4',
+            nativeReleaseTag: 'v0.12.3',
+            runtimeVersion: '0.2.2',
+            channel: 'internal',
+            updateId: null,
+            updateLabel: 'Embedded in native build',
+            updateCreatedAt: new Date('2026-07-21T20:00:00.000Z'),
+            isEmbeddedLaunch: true,
+            isEmergencyLaunch: false,
+            emergencyLaunchReason: null
+        },
+        ...overrides
+    } as ReturnType<typeof useAppUpdateController>;
+}
+
+describe('AboutScreen', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedUseAppUpdateController.mockReturnValue(updateController());
+    });
+
+    it('shows the native tag, native version, runtime, channel, and embedded update state', () => {
+        const view = render(<AboutScreen />);
+
+        expect(view.getByRole('header')).toHaveTextContent('About Calibrate');
+        expect(view.getByText('v0.12.3')).toBeTruthy();
+        expect(view.getByText('0.2.2 (build 4)')).toBeTruthy();
+        expect(view.getAllByText('0.2.2')).toHaveLength(1);
+        expect(view.getByText('internal')).toBeTruthy();
+        expect(view.getByText('Embedded in native build')).toBeTruthy();
+        expect(view.getByLabelText('Check for updates')).toBeEnabled();
+    });
+
+    it('offers an immediate install action for an available OTA', () => {
+        const action = jest.fn(async () => undefined);
+        mockedUseAppUpdateController.mockReturnValue(updateController({
+            action,
+            actionTitle: 'Install and restart',
+            isUpdateAvailable: true,
+            manualPhase: 'available',
+            status: 'A compatible OTA update is available and ready to download.'
+        }));
+
+        const view = render(<AboutScreen />);
+        fireEvent.press(view.getByLabelText('Install and restart'));
+
+        expect(action).toHaveBeenCalledTimes(1);
+        expect(view.getByText(/compatible OTA update is available/)).toBeTruthy();
+    });
+});

--- a/mobile/src/updates/appUpdate.test.ts
+++ b/mobile/src/updates/appUpdate.test.ts
@@ -1,0 +1,123 @@
+jest.mock('expo-application', () => ({
+    nativeApplicationVersion: '0.2.1',
+    nativeBuildVersion: '3'
+}));
+jest.mock('expo-updates', () => ({
+    checkForUpdateAsync: jest.fn(),
+    fetchUpdateAsync: jest.fn(),
+    reloadAsync: jest.fn()
+}));
+
+import {
+    canManageOtaUpdates,
+    checkForAppUpdate,
+    createAppVersionInfo,
+    downloadAppUpdate,
+    shortenUpdateId
+} from './appUpdate';
+
+describe('app update presentation and actions', () => {
+    it('reports the native release and an embedded update separately', () => {
+        expect(createAppVersionInfo({
+            platform: 'android',
+            isDevelopment: false,
+            nativeApplicationVersion: '0.2.1',
+            nativeBuildVersion: '3',
+            fallbackNativeVersion: '0.1.0',
+            fallbackNativeBuild: '1',
+            nativeReleaseTag: 'v0.12.2',
+            runningUpdate: {
+                updateId: '01234567-89ab-4def-8123-456789abcdef',
+                channel: 'internal',
+                createdAt: new Date('2026-07-21T20:00:00.000Z'),
+                isEmbeddedLaunch: true,
+                isEmergencyLaunch: false,
+                emergencyLaunchReason: null,
+                runtimeVersion: '0.2.1'
+            }
+        })).toMatchObject({
+            nativeVersion: '0.2.1',
+            nativeBuild: '3',
+            nativeReleaseTag: 'v0.12.2',
+            runtimeVersion: '0.2.1',
+            channel: 'internal',
+            updateLabel: 'Embedded in native build',
+            updateId: '01234567-89ab-4def-8123-456789abcdef'
+        });
+    });
+
+    it('identifies the currently running OTA by a stable short ID', () => {
+        const info = createAppVersionInfo({
+            platform: 'android',
+            isDevelopment: false,
+            nativeApplicationVersion: null,
+            nativeBuildVersion: null,
+            fallbackNativeVersion: '0.2.1',
+            fallbackNativeBuild: '3',
+            nativeReleaseTag: 'v0.12.2',
+            runningUpdate: {
+                updateId: 'abcdef01-89ab-4def-8123-456789abcdef',
+                channel: 'production',
+                isEmbeddedLaunch: false,
+                isEmergencyLaunch: false,
+                emergencyLaunchReason: null
+            }
+        });
+        expect(shortenUpdateId(info.updateId!)).toBe('abcdef01');
+        expect(info.updateLabel).toBe('OTA abcdef01');
+        expect(info.nativeVersion).toBe('0.2.1');
+        expect(info.nativeBuild).toBe('3');
+    });
+
+    it('does not mislabel a development bundle as an OTA', () => {
+        expect(createAppVersionInfo({
+            platform: 'android',
+            isDevelopment: true,
+            nativeApplicationVersion: '0.2.1',
+            nativeBuildVersion: '3',
+            fallbackNativeVersion: '0.2.1',
+            fallbackNativeBuild: '3',
+            nativeReleaseTag: 'v0.12.2',
+            runningUpdate: {
+                isEmbeddedLaunch: false,
+                isEmergencyLaunch: false,
+                emergencyLaunchReason: null,
+                runtimeVersion: '0.2.1'
+            }
+        })).toMatchObject({
+            channel: 'Development',
+            updateLabel: 'Development bundle'
+        });
+    });
+
+    it('keeps manual OTA controls out of web and development runtimes', () => {
+        expect(canManageOtaUpdates('web', false, true)).toBe(false);
+        expect(canManageOtaUpdates('android', true, true)).toBe(false);
+        expect(canManageOtaUpdates('android', false, false)).toBe(false);
+        expect(canManageOtaUpdates('android', false, true)).toBe(true);
+    });
+
+    it('distinguishes current, available, and rollback checks', async () => {
+        await expect(checkForAppUpdate({
+            checkForUpdateAsync: async () => ({ isAvailable: false, isRollBackToEmbedded: false })
+        })).resolves.toBe('current');
+        await expect(checkForAppUpdate({
+            checkForUpdateAsync: async () => ({ isAvailable: true, isRollBackToEmbedded: false })
+        })).resolves.toBe('available');
+        await expect(checkForAppUpdate({
+            checkForUpdateAsync: async () => ({ isAvailable: false, isRollBackToEmbedded: true })
+        })).resolves.toBe('rollback');
+    });
+
+    it('downloads only a new update or rollback directive', async () => {
+        await expect(downloadAppUpdate({
+            fetchUpdateAsync: async () => ({ isNew: true, isRollBackToEmbedded: false })
+        })).resolves.toBe(true);
+        await expect(downloadAppUpdate({
+            fetchUpdateAsync: async () => ({ isNew: false, isRollBackToEmbedded: true })
+        })).resolves.toBe(true);
+        await expect(downloadAppUpdate({
+            fetchUpdateAsync: async () => ({ isNew: false, isRollBackToEmbedded: false })
+        })).resolves.toBe(false);
+    });
+});

--- a/mobile/src/updates/appUpdate.ts
+++ b/mobile/src/updates/appUpdate.ts
@@ -1,0 +1,132 @@
+import * as Application from 'expo-application';
+import * as Updates from 'expo-updates';
+import { Platform } from 'react-native';
+import appConfig from '../../app.json';
+import release from '../../../shared/release.json';
+
+export type RunningUpdateInfo = {
+    updateId?: string;
+    channel?: string;
+    createdAt?: Date;
+    isEmbeddedLaunch: boolean;
+    isEmergencyLaunch: boolean;
+    emergencyLaunchReason: string | null;
+    runtimeVersion?: string;
+};
+
+export type AppVersionInfo = {
+    nativeVersion: string;
+    nativeBuild: string;
+    nativeReleaseTag: string;
+    runtimeVersion: string;
+    channel: string;
+    updateId: string | null;
+    updateLabel: string;
+    updateCreatedAt: Date | null;
+    isEmbeddedLaunch: boolean;
+    isEmergencyLaunch: boolean;
+    emergencyLaunchReason: string | null;
+};
+
+type AppVersionInfoInput = {
+    platform: string;
+    isDevelopment: boolean;
+    nativeApplicationVersion: string | null;
+    nativeBuildVersion: string | null;
+    fallbackNativeVersion: string;
+    fallbackNativeBuild: string;
+    nativeReleaseTag: string;
+    runningUpdate: RunningUpdateInfo;
+};
+
+export type AppUpdateCheckOutcome = 'available' | 'rollback' | 'current';
+
+export type AppUpdateRuntime = {
+    checkForUpdateAsync: () => Promise<{
+        isAvailable: boolean;
+        isRollBackToEmbedded: boolean;
+    }>;
+    fetchUpdateAsync: () => Promise<{
+        isNew: boolean;
+        isRollBackToEmbedded: boolean;
+    }>;
+    reloadAsync: () => Promise<void>;
+};
+
+export const appUpdateRuntime: AppUpdateRuntime = {
+    checkForUpdateAsync: Updates.checkForUpdateAsync,
+    fetchUpdateAsync: Updates.fetchUpdateAsync,
+    reloadAsync: Updates.reloadAsync
+};
+
+export function shortenUpdateId(updateId: string): string {
+    return updateId.slice(0, 8);
+}
+
+export function createAppVersionInfo(input: AppVersionInfoInput): AppVersionInfo {
+    const isWeb = input.platform === 'web';
+    const updateId = input.runningUpdate.updateId?.trim() || null;
+    const configuredChannel = input.runningUpdate.channel?.trim();
+    let channel = 'Not configured';
+    if (isWeb) channel = 'Browser';
+    else if (input.isDevelopment) channel = 'Development';
+    if (configuredChannel) channel = configuredChannel;
+
+    let updateLabel = 'Embedded in native build';
+    if (isWeb) updateLabel = 'Managed by browser';
+    else if (input.isDevelopment) updateLabel = 'Development bundle';
+    else if (!input.runningUpdate.isEmbeddedLaunch) {
+        updateLabel = updateId ? `OTA ${shortenUpdateId(updateId)}` : 'Downloaded OTA';
+    }
+
+    return {
+        nativeVersion: isWeb
+            ? 'Not applicable'
+            : input.nativeApplicationVersion?.trim() || input.fallbackNativeVersion,
+        nativeBuild: isWeb
+            ? 'Not applicable'
+            : input.nativeBuildVersion?.trim() || input.fallbackNativeBuild,
+        nativeReleaseTag: isWeb ? 'Not applicable' : input.nativeReleaseTag,
+        runtimeVersion: input.runningUpdate.runtimeVersion?.trim() || input.fallbackNativeVersion,
+        channel,
+        updateId,
+        updateLabel,
+        updateCreatedAt: input.runningUpdate.createdAt ?? null,
+        isEmbeddedLaunch: input.runningUpdate.isEmbeddedLaunch,
+        isEmergencyLaunch: input.runningUpdate.isEmergencyLaunch,
+        emergencyLaunchReason: input.runningUpdate.emergencyLaunchReason
+    };
+}
+
+export function getAppVersionInfo(runningUpdate: RunningUpdateInfo): AppVersionInfo {
+    return createAppVersionInfo({
+        platform: Platform.OS,
+        isDevelopment: typeof __DEV__ !== 'undefined' && __DEV__,
+        nativeApplicationVersion: Application.nativeApplicationVersion,
+        nativeBuildVersion: Application.nativeBuildVersion,
+        fallbackNativeVersion: release.android.mobile.version_name,
+        fallbackNativeBuild: String(release.android.mobile.version_code),
+        nativeReleaseTag: appConfig.expo.extra.calibrate.nativeReleaseTag,
+        runningUpdate
+    });
+}
+
+export function canManageOtaUpdates(platform: string, isDevelopment: boolean, isEnabled: boolean): boolean {
+    return platform !== 'web' && !isDevelopment && isEnabled;
+}
+
+export async function checkForAppUpdate(
+    runtime: Pick<AppUpdateRuntime, 'checkForUpdateAsync'> = appUpdateRuntime
+): Promise<AppUpdateCheckOutcome> {
+    const result = await runtime.checkForUpdateAsync();
+    if (result.isAvailable) return 'available';
+    if (result.isRollBackToEmbedded) return 'rollback';
+    return 'current';
+}
+
+export async function downloadAppUpdate(
+    runtime: Pick<AppUpdateRuntime, 'fetchUpdateAsync'> = appUpdateRuntime
+): Promise<boolean> {
+    const result = await runtime.fetchUpdateAsync();
+    return result.isNew || result.isRollBackToEmbedded;
+}

--- a/mobile/src/updates/useAppUpdateController.test.tsx
+++ b/mobile/src/updates/useAppUpdateController.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+const mockCheckForUpdateAsync = jest.fn();
+const mockFetchUpdateAsync = jest.fn();
+const mockReloadAsync = jest.fn();
+const mockUpdatesState = {
+    currentlyRunning: {
+        channel: 'internal',
+        createdAt: new Date('2026-07-21T20:00:00.000Z'),
+        emergencyLaunchReason: null,
+        isEmbeddedLaunch: true,
+        isEmergencyLaunch: false,
+        runtimeVersion: '0.2.1',
+        updateId: '01234567-89ab-4def-8123-456789abcdef'
+    },
+    downloadProgress: undefined,
+    isChecking: false,
+    isDownloading: false,
+    isRestarting: false,
+    isUpdateAvailable: false,
+    isUpdatePending: false
+};
+
+jest.mock('expo-application', () => ({
+    nativeApplicationVersion: '0.2.1',
+    nativeBuildVersion: '3'
+}));
+jest.mock('expo-updates', () => ({
+    checkForUpdateAsync: (...args: unknown[]) => mockCheckForUpdateAsync(...args),
+    fetchUpdateAsync: (...args: unknown[]) => mockFetchUpdateAsync(...args),
+    isEnabled: true,
+    reloadAsync: (...args: unknown[]) => mockReloadAsync(...args),
+    useUpdates: () => mockUpdatesState
+}));
+jest.mock('./appUpdate', () => {
+    const actual = jest.requireActual('./appUpdate');
+    return {
+        ...actual,
+        canManageOtaUpdates: () => true
+    };
+});
+
+import { useAppUpdateController } from './useAppUpdateController';
+
+describe('useAppUpdateController', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUpdatesState.isUpdateAvailable = false;
+        mockUpdatesState.isUpdatePending = false;
+    });
+
+    it('checks, downloads, and restarts into an available update', async () => {
+        mockCheckForUpdateAsync.mockResolvedValue({
+            isAvailable: true,
+            isRollBackToEmbedded: false
+        });
+        mockFetchUpdateAsync.mockResolvedValue({
+            isNew: true,
+            isRollBackToEmbedded: false
+        });
+        mockReloadAsync.mockResolvedValue(undefined);
+        const { result } = renderHook(() => useAppUpdateController());
+
+        await act(async () => result.current.action());
+        expect(result.current.actionTitle).toBe('Install and restart');
+
+        await act(async () => result.current.action());
+        expect(mockFetchUpdateAsync).toHaveBeenCalledTimes(1);
+        expect(mockReloadAsync).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(result.current.actionTitle).toBe('Restarting...'));
+    });
+
+    it('restarts immediately when an update is already downloaded', async () => {
+        mockUpdatesState.isUpdatePending = true;
+        mockReloadAsync.mockResolvedValue(undefined);
+        const { result } = renderHook(() => useAppUpdateController());
+
+        expect(result.current.actionTitle).toBe('Restart to update');
+        await act(async () => result.current.action());
+
+        expect(mockReloadAsync).toHaveBeenCalledTimes(1);
+        expect(mockFetchUpdateAsync).not.toHaveBeenCalled();
+    });
+});

--- a/mobile/src/updates/useAppUpdateController.ts
+++ b/mobile/src/updates/useAppUpdateController.ts
@@ -1,0 +1,130 @@
+import { useCallback, useMemo, useState } from 'react';
+import * as Updates from 'expo-updates';
+import { Platform } from 'react-native';
+import {
+    appUpdateRuntime,
+    canManageOtaUpdates,
+    checkForAppUpdate,
+    downloadAppUpdate,
+    getAppVersionInfo
+} from './appUpdate';
+
+type ManualUpdatePhase = 'idle' | 'checking' | 'available' | 'current' | 'downloading' | 'restarting' | 'error';
+
+function updateFailureMessage(action: 'check' | 'install'): string {
+    return action === 'check'
+        ? "Couldn't check for updates. Check your connection and try again."
+        : "Couldn't install the update. Check your connection and try again.";
+}
+
+export function useAppUpdateController() {
+    const updates = Updates.useUpdates();
+    const isDevelopment = typeof __DEV__ !== 'undefined' && __DEV__;
+    const isSupported = canManageOtaUpdates(Platform.OS, isDevelopment, Updates.isEnabled);
+    const [manualPhase, setManualPhase] = useState<ManualUpdatePhase>('idle');
+    const [manualStatus, setManualStatus] = useState<string | null>(null);
+    const manuallyAvailable = manualPhase === 'available';
+    const isUpdateAvailable = manuallyAvailable || updates.isUpdateAvailable;
+    const isBusy = manualPhase === 'checking'
+        || manualPhase === 'downloading'
+        || manualPhase === 'restarting'
+        || updates.isChecking
+        || updates.isDownloading
+        || updates.isRestarting;
+    const versionInfo = useMemo(
+        () => getAppVersionInfo(updates.currentlyRunning),
+        [updates.currentlyRunning]
+    );
+
+    const check = useCallback(async () => {
+        if (!isSupported || isBusy) return;
+        setManualPhase('checking');
+        setManualStatus('Checking the selected update channel...');
+        try {
+            const result = await checkForAppUpdate();
+            if (result === 'current') {
+                setManualPhase('current');
+                setManualStatus("You're using the newest compatible update.");
+                return;
+            }
+            setManualPhase('available');
+            setManualStatus(result === 'rollback'
+                ? 'A recovery update is available. Install it to return to the embedded version.'
+                : 'A compatible OTA update is available and ready to download.');
+        } catch {
+            setManualPhase('error');
+            setManualStatus(updateFailureMessage('check'));
+        }
+    }, [isBusy, isSupported]);
+
+    const restart = useCallback(async () => {
+        if (!isSupported || isBusy) return;
+        setManualPhase('restarting');
+        setManualStatus('Restarting Calibrate with the downloaded update...');
+        try {
+            await appUpdateRuntime.reloadAsync();
+        } catch {
+            setManualPhase('error');
+            setManualStatus(updateFailureMessage('install'));
+        }
+    }, [isBusy, isSupported]);
+
+    const install = useCallback(async () => {
+        if (!isSupported || isBusy) return;
+        setManualPhase('downloading');
+        setManualStatus('Downloading and verifying the update...');
+        try {
+            const downloaded = await downloadAppUpdate();
+            if (!downloaded) {
+                setManualPhase('current');
+                setManualStatus('That update is no longer available. Check again for the latest version.');
+                return;
+            }
+            setManualPhase('restarting');
+            setManualStatus('Update verified. Restarting Calibrate...');
+            await appUpdateRuntime.reloadAsync();
+        } catch {
+            setManualPhase('error');
+            setManualStatus(updateFailureMessage('install'));
+        }
+    }, [isBusy, isSupported]);
+
+    let status = manualStatus;
+    if (!status && Platform.OS === 'web') {
+        status = 'Browser updates are installed through the Calibrate PWA lifecycle.';
+    } else if (!status && !isSupported) {
+        status = 'Manual OTA checks are available in signed release builds.';
+    } else if (!status && updates.isUpdatePending) {
+        status = 'An update is downloaded and ready. Restart to use it now.';
+    } else if (!status && updates.isUpdateAvailable) {
+        status = 'A compatible OTA update is available and ready to download.';
+    } else if (!status) {
+        status = 'Calibrate checks automatically when it opens. You can also check manually.';
+    }
+
+    let actionTitle = 'Check for updates';
+    let action = check;
+    if (!isSupported) actionTitle = Platform.OS === 'web' ? 'Browser-managed updates' : 'Release builds only';
+    else if (updates.isUpdatePending) {
+        actionTitle = 'Restart to update';
+        action = restart;
+    } else if (isUpdateAvailable) {
+        actionTitle = 'Install and restart';
+        action = install;
+    } else if (manualPhase === 'checking' || updates.isChecking) actionTitle = 'Checking...';
+    else if (manualPhase === 'downloading' || updates.isDownloading) actionTitle = 'Downloading...';
+    else if (manualPhase === 'restarting' || updates.isRestarting) actionTitle = 'Restarting...';
+
+    return {
+        action,
+        actionTitle,
+        downloadProgress: updates.downloadProgress,
+        isBusy,
+        isSupported,
+        isUpdateAvailable,
+        isUpdatePending: updates.isUpdatePending,
+        manualPhase,
+        status,
+        versionInfo
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "ISC",
       "workspaces": [
         "mobile",
@@ -24,7 +24,7 @@
       }
     },
     "mobile": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@calibrate/api-client": "file:../packages/api-client",
@@ -87,7 +87,7 @@
     },
     "mobile/modules/wear-pairing": {
       "name": "@calibrate/wear-pairing",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "peerDependencies": {
         "expo": "*",
         "expo-modules-core": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/scripts/release-config.mjs
+++ b/scripts/release-config.mjs
@@ -131,6 +131,11 @@ export function validateManifest(manifest) {
     }
   }
 
+  const nativeReleaseTag = manifest?.android?.mobile?.native_release_tag;
+  if (typeof nativeReleaseTag !== 'string' || !/^v\d+\.\d+\.\d+$/.test(nativeReleaseTag)) {
+    errors.push('android.mobile.native_release_tag must be a stable vMAJOR.MINOR.PATCH tag.');
+  }
+
   const applicationId = manifest?.android?.application_id;
   if (typeof applicationId !== 'string' || !/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)+$/.test(applicationId)) {
     errors.push('android.application_id must be a valid lowercase Android application ID.');
@@ -183,6 +188,12 @@ export async function checkRepository(root = REPOSITORY_ROOT) {
   assertMatch(errors, 'mobile/app.json expo.version', expoConfig.expo?.version, manifest.android.mobile.version_name);
   assertMatch(errors, 'mobile/app.json expo.android.versionCode', expoConfig.expo?.android?.versionCode, manifest.android.mobile.version_code);
   assertMatch(errors, 'mobile/app.json expo.android.package', expoConfig.expo?.android?.package, manifest.android.application_id);
+  assertMatch(
+    errors,
+    'mobile/app.json expo.extra.calibrate.nativeReleaseTag',
+    expoConfig.expo?.extra?.calibrate?.nativeReleaseTag,
+    manifest.android.mobile.native_release_tag
+  );
 
   // Expo generates this ignored directory. Validate it when present without making a clean checkout depend on prebuild.
   if (mobileGradle !== null) {

--- a/scripts/release-config.test.mjs
+++ b/scripts/release-config.test.mjs
@@ -8,7 +8,12 @@ const validManifest = {
   server: { version: '1.2.3', api: { current: 'v1', supported: ['v1'] } },
   android: {
     application_id: 'app.calibratehealth.mobile',
-    mobile: { version_name: '2.0.0', version_code: 20, minimum_supported_version: '1.5.0' },
+    mobile: {
+      version_name: '2.0.0',
+      version_code: 20,
+      native_release_tag: 'v1.2.3',
+      minimum_supported_version: '1.5.0'
+    },
     wear: { version_name: '2.0.0', version_code: 10, minimum_supported_version: '1.0.0' },
     channels: { debug: {}, internal: {}, production: {} }
   }
@@ -32,6 +37,12 @@ test('manifest rejects a minimum client version newer than the release', () => {
   const manifest = structuredClone(validManifest);
   manifest.android.wear.minimum_supported_version = '2.1.0';
   assert.match(validateManifest(manifest).join('\n'), /minimum_supported_version cannot exceed/);
+});
+
+test('manifest requires a stable native build tag', () => {
+  const manifest = structuredClone(validManifest);
+  manifest.android.mobile.native_release_tag = 'master';
+  assert.match(validateManifest(manifest).join('\n'), /native_release_tag must be a stable/);
 });
 
 test('release metadata is deterministic when source date epoch is supplied', async () => {

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.2",
+    "version": "0.12.3",
     "api": {
       "current": "v1",
       "supported": [
@@ -13,8 +13,9 @@
   "android": {
     "application_id": "app.calibratehealth.mobile",
     "mobile": {
-      "version_name": "0.2.1",
-      "version_code": 3,
+      "version_name": "0.2.2",
+      "version_code": 4,
+      "native_release_tag": "v0.12.3",
       "minimum_supported_version": "0.1.0"
     },
     "wear": {


### PR DESCRIPTION
## What changed

- add an authenticated About page linked from Settings
- display the installed native build tag, Android version/build, OTA runtime and channel, exact running update ID, publish time, and recovery-launch state
- add manual Expo update controls to check for, download, verify, and immediately restart into a compatible OTA
- distinguish browser, development, embedded, and OTA runtime states so debug builds are not mislabeled
- make the native build tag part of the canonical release configuration and point the OTA workflow at the in-app value

## Why

Operators need to identify the exact installed native client before publishing an OTA against it. The app previously had no discoverable version surface and no way to explicitly check for or apply an available OTA.

## Impact

After one new signed native install, Settings > About Calibrate provides the compatibility values needed by the OTA workflow. Compatible JavaScript and asset updates can then be installed directly from the app; Android or Wear native changes still require a signed native build.

## Validation

- `npm.cmd --prefix mobile test -- --runInBand` (79 suites, 312 tests)
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd run test:native-release` (34 tests)
- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 tests)
- `npm.cmd run build:expo-web`
- regenerated Android project and installed `app:installDebug` on the Pixel 10 emulator
- navigated to Settings > About, verified version/update states via UI hierarchy and screenshot, and found no app crash in logcat
