### PR TITLE
Use full-screen calorie and goal pages on Wear

### DIFF
--- a/shared/release.json
+++ b/shared/release.json
@@ -19,8 +19,8 @@
       "minimum_supported_version": "0.1.0"
     },
     "wear": {
-      "version_name": "0.2.1",
-      "version_code": 3,
+      "version_name": "0.2.2",
+      "version_code": 4,
       "minimum_supported_version": "0.2.0"
     },
     "channels": {

--- a/wear/app/build.gradle.kts
+++ b/wear/app/build.gradle.kts
@@ -119,8 +119,8 @@ android {
         applicationId = "app.calibratehealth.mobile"
         minSdk = 30
         targetSdk = 36
-        versionCode = 3
-        versionName = "0.2.1"
+        versionCode = 4
+        versionName = "0.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "DEFAULT_SERVER_URL", quoteBuildConfig(configuredServerOrigin))

--- a/wear/app/src/main/java/app/calibratehealth/wear/CalibrateWearApp.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/CalibrateWearApp.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Arrangement
@@ -15,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -47,6 +51,7 @@ import androidx.wear.compose.material3.Card
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
@@ -96,8 +101,16 @@ fun CalibrateWearApp(
     val currentOnOpenAccountDeletionOnPhone = rememberUpdatedState(onOpenAccountDeletionOnPhone)
     val currentOnDisconnect = rememberUpdatedState(onDisconnect)
     MaterialTheme {
-        AppScaffold(modifier = modifier) {
-            val navController = rememberSwipeDismissableNavController()
+        val navController = rememberSwipeDismissableNavController()
+        val currentBackStackEntry by navController.currentBackStackEntryFlow.collectAsState(
+            initial = navController.currentBackStackEntry
+        )
+        val fullBleedSummary = appState is WearAppState.Ready &&
+            currentBackStackEntry?.destination?.route == SUMMARY_ROUTE
+        AppScaffold(
+            modifier = modifier,
+            timeText = { if (!fullBleedSummary) TimeText() }
+        ) {
             val reminderNavigationReady = appState is WearAppState.Ready
             LaunchedEffect(reminderDeepLinkRequest, reminderDeepLink, reminderNavigationReady) {
                 if (reminderDeepLink == null || !reminderNavigationReady) return@LaunchedEffect
@@ -214,6 +227,39 @@ private fun ReadySummaryDashboard(
     homeState: WearHomeUiState,
     onOpenActions: () -> Unit
 ) {
+    val pagerState = rememberPagerState(pageCount = { SUMMARY_PAGE_COUNT })
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(CALIBRATE_BACKGROUND)
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { page ->
+            when (page) {
+                CALORIE_SUMMARY_PAGE -> CalorieSummaryPage(
+                    summary = summary,
+                    onOpenActions = onOpenActions
+                )
+                else -> GoalProgressPage(summary = summary)
+            }
+        }
+        SummaryPageIndicator(
+            selectedPage = pagerState.currentPage,
+            status = summaryStatus(homeState),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 10.dp)
+        )
+    }
+}
+
+@Composable
+private fun CalorieSummaryPage(
+    summary: WearSummary,
+    onOpenActions: () -> Unit
+) {
     val progress = calorieProgressFraction(summary.caloriesConsumed, summary.calorieTarget)
     val caloriesRemaining = summary.caloriesRemaining
     val balanceValue = caloriesRemaining?.let { SummaryFormatter.calorieCount(abs(it)) } ?: "--"
@@ -222,92 +268,198 @@ private fun ReadySummaryDashboard(
         caloriesRemaining < 0 -> "kcal over"
         else -> "kcal remaining"
     }
-    val footerLabel = when {
-        homeState.actionInProgress -> "Syncing..."
-        homeState.syncStatus is WearSyncStatus.Error -> "Sync needs attention"
-        summary.goalTargetWeightGrams != null -> goalProgressHeadline(summary)
-        else -> null
-    }
     val progressColor = if ((caloriesRemaining ?: 0) < 0) CALIBRATE_DANGER else CALIBRATE_GREEN
-    val listState = rememberTransformingLazyColumnState()
-
-    ScreenScaffold(scrollState = listState) {
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(CALIBRATE_BACKGROUND)
-                // Keep the dashboard clear of the curved edge and system time without
-                // surrendering the lower third of the display to an unused edge button.
-                .padding(horizontal = 12.dp, vertical = 8.dp)
-                .padding(top = 20.dp),
-            contentAlignment = Alignment.Center
+    FullBleedSummaryGauge(
+        progress = progress,
+        progressColor = progressColor,
+        accessibilityDescription = calorieAccessibilityDescription(summary),
+        onClick = onOpenActions
+    ) { compactDashboard ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(1.dp),
+            modifier = Modifier.padding(horizontal = 18.dp)
         ) {
-            // Scale from the actual circular-safe region so large watches use their display.
-            val dashboardDiameter = summaryDashboardDiameter(maxWidth.value, maxHeight.value).dp
-            val compactDashboard = dashboardDiameter.value < SUMMARY_COMPACT_DIAMETER_DP
-            Box(
-                modifier = Modifier
-                    .size(dashboardDiameter)
-                    .clickable(onClick = onOpenActions)
-                    .semantics(mergeDescendants = true) {
-                        contentDescription = calorieAccessibilityDescription(summary)
-                    },
-                contentAlignment = Alignment.Center
-            ) {
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .semantics {
-                            progress?.let { progressBarRangeInfo = ProgressBarRangeInfo(it, 0f..1f) }
-                        }
-                ) {
-                    val strokeWidth = 9.dp.toPx()
-                    drawArc(
-                        color = CALIBRATE_RING_TRACK,
-                        startAngle = CALORIE_RING_START_ANGLE,
-                        sweepAngle = CALORIE_RING_SWEEP_ANGLE,
-                        useCenter = false,
-                        style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
-                    )
-                    progress?.let {
-                        drawArc(
-                            color = progressColor,
-                            startAngle = CALORIE_RING_START_ANGLE,
-                            sweepAngle = CALORIE_RING_SWEEP_ANGLE * it,
-                            useCenter = false,
-                            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
-                        )
-                    }
+            CalibrateBrand(showWordmark = !compactDashboard)
+            Text(
+                balanceValue,
+                style = if (compactDashboard) {
+                    MaterialTheme.typography.titleLarge
+                } else {
+                    MaterialTheme.typography.displaySmall
                 }
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(1.dp),
-                    modifier = Modifier.padding(horizontal = 14.dp)
-                ) {
-                    CalibrateBrand(showWordmark = !compactDashboard)
-                    Text(
-                        balanceValue,
-                        style = if (compactDashboard) {
-                            MaterialTheme.typography.titleLarge
-                        } else {
-                            MaterialTheme.typography.displaySmall
-                        }
-                    )
-                    Text(balanceLabel, style = MaterialTheme.typography.labelMedium)
-                    Text(SummaryFormatter.calorieProgress(summary), style = MaterialTheme.typography.labelSmall)
-                    if (footerLabel != null && (!compactDashboard || homeState.syncStatus is WearSyncStatus.Error)) {
-                        Text(
-                            footerLabel,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = CALIBRATE_SECONDARY_TEXT,
-                            maxLines = 1,
-                            softWrap = false
-                        )
-                    }
+            )
+            Text(balanceLabel, style = MaterialTheme.typography.labelMedium)
+            Text(SummaryFormatter.calorieProgress(summary), style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}
+
+@Composable
+private fun GoalProgressPage(summary: WearSummary) {
+    val progress = goalProgressFraction(summary)
+    val currentWeight = summary.goalCurrentWeightGrams?.let {
+        SummaryFormatter.weight(it, summary.weightUnit)
+    }
+    val targetWeight = summary.goalTargetWeightGrams?.let {
+        SummaryFormatter.weight(it, summary.weightUnit)
+    }
+    val value = when {
+        summary.goalTargetWeightGrams == null -> "--"
+        summary.goalDailyDeficit == 0 -> "Maintain"
+        summary.goalIsComplete == true -> "Reached"
+        summary.goalProgressPercent != null -> "${summary.goalProgressPercent.roundToInt()}%"
+        else -> "--"
+    }
+    val label = when {
+        summary.goalTargetWeightGrams == null -> "goal unavailable"
+        summary.goalDailyDeficit == 0 -> "maintenance goal"
+        summary.goalIsComplete == true -> "goal complete"
+        else -> "to goal"
+    }
+
+    FullBleedSummaryGauge(
+        progress = progress,
+        progressColor = CALIBRATE_GOAL,
+        accessibilityDescription = goalAccessibilityDescription(summary)
+    ) { compactDashboard ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(1.dp),
+            modifier = Modifier.padding(horizontal = 18.dp)
+        ) {
+            CalibrateBrand(showWordmark = !compactDashboard)
+            Text(
+                value,
+                style = if (value.length > 5 || compactDashboard) {
+                    MaterialTheme.typography.titleLarge
+                } else {
+                    MaterialTheme.typography.displaySmall
                 }
+            )
+            Text(label, style = MaterialTheme.typography.labelMedium)
+            if (currentWeight != null) {
+                Text("Current $currentWeight", style = MaterialTheme.typography.labelSmall)
+            }
+            if (targetWeight != null) {
+                Text(
+                    "Goal $targetWeight",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = CALIBRATE_SECONDARY_TEXT
+                )
             }
         }
     }
+}
+
+@Composable
+private fun FullBleedSummaryGauge(
+    progress: Float?,
+    progressColor: Color,
+    accessibilityDescription: String,
+    onClick: (() -> Unit)? = null,
+    content: @Composable (compactDashboard: Boolean) -> Unit
+) {
+    var pageModifier = Modifier
+        .fillMaxSize()
+        .background(CALIBRATE_BACKGROUND)
+        .semantics(mergeDescendants = true) {
+            contentDescription = accessibilityDescription
+        }
+    if (onClick != null) pageModifier = pageModifier.clickable(onClick = onClick)
+
+    BoxWithConstraints(
+        modifier = pageModifier,
+        contentAlignment = Alignment.Center
+    ) {
+        val dashboardDiameter = summaryDashboardDiameter(maxWidth.value, maxHeight.value).dp
+        val compactDashboard = dashboardDiameter.value < SUMMARY_COMPACT_DIAMETER_DP
+        Box(
+            modifier = Modifier.size(dashboardDiameter),
+            contentAlignment = Alignment.Center
+        ) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .semantics {
+                        progress?.let { progressBarRangeInfo = ProgressBarRangeInfo(it, 0f..1f) }
+                    }
+            ) {
+                val strokeWidth = 10.dp.toPx()
+                val strokeInset = strokeWidth / 2f
+                val arcSize = Size(
+                    width = (size.width - strokeWidth).coerceAtLeast(0f),
+                    height = (size.height - strokeWidth).coerceAtLeast(0f)
+                )
+                val arcOrigin = Offset(strokeInset, strokeInset)
+                drawArc(
+                    color = CALIBRATE_RING_TRACK,
+                    startAngle = CALORIE_RING_START_ANGLE,
+                    sweepAngle = CALORIE_RING_SWEEP_ANGLE,
+                    useCenter = false,
+                    topLeft = arcOrigin,
+                    size = arcSize,
+                    style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                )
+                progress?.let {
+                    drawArc(
+                        color = progressColor,
+                        startAngle = CALORIE_RING_START_ANGLE,
+                        sweepAngle = CALORIE_RING_SWEEP_ANGLE * it,
+                        useCenter = false,
+                        topLeft = arcOrigin,
+                        size = arcSize,
+                        style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                    )
+                }
+            }
+            content(compactDashboard)
+        }
+    }
+}
+
+@Composable
+private fun SummaryPageIndicator(
+    selectedPage: Int,
+    status: SummaryDashboardStatus?,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.semantics {
+            contentDescription = "Page ${selectedPage + 1} of $SUMMARY_PAGE_COUNT"
+        },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        if (status != null) {
+            Text(
+                status.label,
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                color = status.color,
+                maxLines = 1
+            )
+        }
+        Canvas(modifier = Modifier.size(width = 24.dp, height = 6.dp)) {
+            repeat(SUMMARY_PAGE_COUNT) { page ->
+                drawCircle(
+                    color = if (page == selectedPage) CALIBRATE_FOREGROUND else CALIBRATE_RING_TRACK,
+                    radius = if (page == selectedPage) 3.dp.toPx() else 2.dp.toPx(),
+                    center = Offset(
+                        x = if (page == CALORIE_SUMMARY_PAGE) 6.dp.toPx() else 18.dp.toPx(),
+                        y = size.height / 2f
+                    )
+                )
+            }
+        }
+    }
+}
+
+private data class SummaryDashboardStatus(val label: String, val color: Color)
+
+private fun summaryStatus(homeState: WearHomeUiState): SummaryDashboardStatus? = when {
+    homeState.actionInProgress -> SummaryDashboardStatus("Syncing...", CALIBRATE_SECONDARY_TEXT)
+    homeState.syncStatus is WearSyncStatus.Error -> SummaryDashboardStatus("Sync needs attention", CALIBRATE_DANGER)
+    else -> null
 }
 
 @Composable
@@ -363,20 +515,30 @@ private val CALIBRATE_FOREGROUND = Color(0xFFF3F7F1)
 private val CALIBRATE_SECONDARY_TEXT = Color(0xFFB6C5B6)
 private val CALIBRATE_RING_TRACK = Color(0xFF29382B)
 private val CALIBRATE_GREEN = Color(0xFF71D478)
+private val CALIBRATE_GOAL = Color(0xFF8DDD2B)
 private val CALIBRATE_NEEDLE = Color(0xFF8DDD2B)
 private val CALIBRATE_HUB = Color(0xFF2E7D32)
 private val CALIBRATE_DANGER = Color(0xFFFF796E)
 private const val CALORIE_RING_START_ANGLE = 140f
 private const val CALORIE_RING_SWEEP_ANGLE = 260f
-private const val SUMMARY_DASHBOARD_INSET_DP = 4f
 private const val SUMMARY_COMPACT_DIAMETER_DP = 160f
+private const val SUMMARY_PAGE_COUNT = 2
+private const val CALORIE_SUMMARY_PAGE = 0
 
 internal fun summaryDashboardDiameter(widthDp: Float, heightDp: Float): Float =
-    (minOf(widthDp, heightDp) - SUMMARY_DASHBOARD_INSET_DP).coerceAtLeast(0f)
+    minOf(widthDp, heightDp).coerceAtLeast(0f)
 
 internal fun calorieProgressFraction(consumed: Int?, target: Int?): Float? = when {
     consumed == null || target == null || target <= 0 -> null
     else -> (consumed.toFloat() / target).coerceIn(0f, 1f)
+}
+
+internal fun goalProgressFraction(summary: WearSummary): Float? = when {
+    summary.goalTargetWeightGrams == null -> null
+    summary.goalDailyDeficit == 0 -> null
+    summary.goalIsComplete == true -> 1f
+    summary.goalProgressPercent == null -> null
+    else -> (summary.goalProgressPercent.toFloat() / 100f).coerceIn(0f, 1f)
 }
 
 internal fun calorieAccessibilityDescription(summary: WearSummary): String {

--- a/wear/app/src/test/java/app/calibratehealth/wear/CalorieProgressTest.kt
+++ b/wear/app/src/test/java/app/calibratehealth/wear/CalorieProgressTest.kt
@@ -5,10 +5,10 @@ import org.junit.Test
 
 class CalorieProgressTest {
     @Test
-    fun `dashboard diameter fits the smaller post-inset screen dimension`() {
-        assertEquals(116f, summaryDashboardDiameter(widthDp = 192f, heightDp = 120f))
-        assertEquals(188f, summaryDashboardDiameter(widthDp = 192f, heightDp = 220f))
-        assertEquals(0f, summaryDashboardDiameter(widthDp = 3f, heightDp = 3f))
+    fun `dashboard diameter uses the full smaller screen dimension`() {
+        assertEquals(120f, summaryDashboardDiameter(widthDp = 192f, heightDp = 120f))
+        assertEquals(192f, summaryDashboardDiameter(widthDp = 192f, heightDp = 220f))
+        assertEquals(3f, summaryDashboardDiameter(widthDp = 3f, heightDp = 3f))
     }
 
     @Test
@@ -45,9 +45,12 @@ class CalorieProgressTest {
         )
 
         assertEquals("42% to goal", goalProgressHeadline(goal))
+        assertEquals(0.42f, goalProgressFraction(goal))
         assertEquals("Current 85.8 kg | Goal 80.0 kg", goalProgressDetail(goal))
         assertEquals("Goal reached", goalProgressHeadline(goal.copy(goalIsComplete = true)))
+        assertEquals(1f, goalProgressFraction(goal.copy(goalIsComplete = true)))
         assertEquals("Maintenance goal", goalProgressHeadline(goal.copy(goalDailyDeficit = 0, goalIsComplete = true)))
+        assertEquals(null, goalProgressFraction(goal.copy(goalDailyDeficit = 0, goalIsComplete = true)))
         assertEquals(
             "Maintenance goal. Current 85.8 kg. Goal 80.0 kg. 5.8 kg from target.",
             goalAccessibilityDescription(goal.copy(goalDailyDeficit = 0, goalIsComplete = true))


### PR DESCRIPTION
## Summary

- use the full round Wear display for the calorie balance gauge and hide the system time on that dashboard
- separate calorie-budget progress from weight-goal progress into two horizontally swipeable pages
- give each page its own aligned progress arc, focused copy, accessibility description, and shared page indicator
- advance the Wear client to `0.2.2` (`versionCode` 4) without changing the server or phone-native release

## Why

The previous dashboard reserved space for the clock, which pushed the gauge off-center relative to the physical display. It also showed weight-goal progress beneath a calorie-consumption arc, visually associating two unrelated measures.

The revised dashboard centers one full-bleed gauge for today's calorie balance and moves weight-goal progress to a dedicated second page reached by swiping horizontally.

## Validation

- `npm.cmd run release:check`
- `npm.cmd run test:release`
- `wear/gradlew.bat testDebugUnitTest assembleDebug --console=plain`
- installed and exercised the debug APK on the 454 x 454 Wear emulator
- visually verified both pages, horizontal paging, centered full-display arcs, and absence of the clock on the summary route
- launched the final APK on the Wear emulator with no crash-buffer entries
- `git diff --check`

This is a native Wear change and requires a new Watch APK; it is not deliverable through Expo OTA.
