### PR TITLE
Standardize Android press feedback

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -345,7 +345,6 @@ const HeaderBrand: React.FC<{ colors: AppThemeColors; styles: TabStyles }> = ({ 
         accessibilityRole="button"
         accessibilityLabel="Go to Today"
         accessibilityHint="Opens the Today dashboard"
-        android_ripple={{ color: colors.surfacePressed, borderless: false }}
         focusStyle={styles.navigationFocus}
         hoverStyle={styles.navigationHover}
         onPress={() => router.push('/(tabs)/today')}
@@ -369,7 +368,6 @@ const HeaderActions: React.FC<{
             <NavigationPressable
                 accessibilityRole="button"
                 accessibilityLabel={`${offlineChangeCount} offline changes ${hasFailedOfflineChanges ? 'need attention' : 'pending'}`}
-                android_ripple={{ color: colors.surfacePressed, borderless: false }}
                 focusStyle={styles.navigationFocus}
                 hoverStyle={styles.navigationHover}
                 onPress={() => router.push('/(tabs)/settings')}
@@ -385,7 +383,6 @@ const HeaderActions: React.FC<{
         <NavigationPressable
             accessibilityRole="button"
             accessibilityLabel={unreadCount > 0 ? `Open notifications, ${unreadCount} unread` : 'Open notifications'}
-            android_ripple={{ color: colors.surfacePressed, borderless: false }}
             focusStyle={styles.navigationFocus}
             hoverStyle={styles.navigationHover}
             onPress={onOpenNotifications}
@@ -402,7 +399,6 @@ const HeaderActions: React.FC<{
             accessibilityRole="button"
             accessibilityLabel="Open account"
             accessibilityHint="Opens profile and app settings"
-            android_ripple={{ color: colors.surfacePressed, borderless: false }}
             focusStyle={styles.navigationFocus}
             hoverStyle={styles.navigationHover}
             onPress={() => router.push('/(tabs)/settings')}
@@ -434,7 +430,6 @@ const ContextualFab: React.FC<{
             accessibilityRole="button"
             accessibilityLabel={label}
             accessibilityHint={isAddFood ? 'Opens food search for the selected day' : "Opens today's weight editor"}
-            android_ripple={{ color: colors.ripple, borderless: false }}
             focusStyle={styles.fabFocus}
             hoverStyle={styles.fabHover}
             onPress={onPress}
@@ -537,7 +532,7 @@ function createStyles(colors: AppThemeColors, shadows: AppTheme['shadows']) {
         overflow: 'hidden'
     },
     pressed: {
-        backgroundColor: colors.surfaceAlt
+        backgroundColor: colors.surfacePressed
     },
     navigationHover: {
         backgroundColor: colors.surfaceAlt

--- a/mobile/src/components/AppChip.tsx
+++ b/mobile/src/components/AppChip.tsx
@@ -3,7 +3,7 @@ import { Pressable, StyleSheet, type PressableProps } from 'react-native';
 import { type AppTheme, useAppTheme } from '../theme';
 import { AppText } from './AppText';
 
-type AppChipProps = PressableProps & {
+type AppChipProps = Omit<PressableProps, 'android_ripple'> & {
     label: string;
     selected?: boolean;
 };
@@ -11,14 +11,13 @@ type AppChipProps = PressableProps & {
 /**
  * Native chip used for meal periods and compact option sets.
  */
-export const AppChip: React.FC<AppChipProps> = ({ label, selected = false, style, android_ripple, ...props }) => {
+export const AppChip: React.FC<AppChipProps> = ({ label, selected = false, style, ...props }) => {
     const theme = useAppTheme();
     const styles = React.useMemo(() => createStyles(theme), [theme]);
     return <Pressable
         {...props}
         accessibilityRole={props.accessibilityRole ?? 'button'}
         accessibilityState={{ ...props.accessibilityState, selected }}
-        android_ripple={android_ripple ?? { color: theme.colors.ripple }}
         style={({ pressed }) => [
             styles.root,
             selected && styles.selected,

--- a/mobile/src/components/AppPressableCard.test.tsx
+++ b/mobile/src/components/AppPressableCard.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import { AppCard } from './AppCard';
+import { AppPressableCard } from './AppPressableCard';
+import { AppText } from './AppText';
+import { themes } from '../theme';
+
+describe('AppPressableCard', () => {
+    it('uses a rounded surface state instead of a native Android ripple', () => {
+        const screen = render(
+            <AppPressableCard testOnly_pressed accessibilityRole="button" accessibilityLabel="Open card">
+                <AppText>Card content</AppText>
+            </AppPressableCard>
+        );
+        const button = screen.getByRole('button', { name: 'Open card' });
+
+        expect(button.props.android_ripple).toBeUndefined();
+
+        const pressableStyle = StyleSheet.flatten(button.props.style);
+        const cardStyle = StyleSheet.flatten(screen.UNSAFE_getByType(AppCard).props.style);
+        expect(pressableStyle).toEqual(expect.objectContaining({
+            borderRadius: themes.light.radius.lg,
+            transform: [{ translateY: 1 }]
+        }));
+        expect(cardStyle).toEqual(expect.objectContaining({
+            backgroundColor: themes.light.colors.surfacePressed,
+            elevation: 0
+        }));
+    });
+});

--- a/mobile/src/components/AppPressableCard.tsx
+++ b/mobile/src/components/AppPressableCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Pressable, StyleSheet, type PressableProps, type StyleProp, type ViewStyle } from 'react-native';
+import { type AppTheme, useAppTheme } from '../theme';
+import { AppCard } from './AppCard';
+
+type AppPressableCardProps = Omit<PressableProps, 'android_ripple' | 'children' | 'style'> & {
+    children: React.ReactNode;
+    style?: StyleProp<ViewStyle>;
+};
+
+/** Rounded interactive card with one consistent state layer across native and web. */
+export const AppPressableCard: React.FC<AppPressableCardProps> = ({
+    children,
+    disabled,
+    style,
+    ...props
+}) => {
+    const theme = useAppTheme();
+    const styles = React.useMemo(() => createStyles(theme), [theme]);
+
+    return (
+        <Pressable
+            {...props}
+            disabled={disabled}
+            style={({ pressed }) => [styles.pressable, pressed && !disabled && styles.pressablePressed]}
+        >
+            {({ pressed }) => (
+                <AppCard style={[style, pressed && !disabled && styles.cardPressed]}>
+                    {children}
+                </AppCard>
+            )}
+        </Pressable>
+    );
+};
+
+function createStyles(theme: AppTheme) {
+    return StyleSheet.create({
+        pressable: {
+            width: '100%',
+            borderRadius: theme.radius.lg
+        },
+        pressablePressed: {
+            transform: [{ translateY: 1 }]
+        },
+        cardPressed: {
+            backgroundColor: theme.colors.surfacePressed,
+            borderColor: theme.colors.outline,
+            shadowOpacity: 0,
+            elevation: 0
+        }
+    });
+}

--- a/mobile/src/components/DateNavigation.tsx
+++ b/mobile/src/components/DateNavigation.tsx
@@ -48,7 +48,6 @@ export const DateNavigation: React.FC<DateNavigationProps> = ({
                 <Pressable
                     accessibilityRole="button"
                     accessibilityLabel="Choose date"
-                    android_ripple={{ color: theme.colors.ripple }}
                     onPress={openPicker}
                     style={({ pressed }) => [styles.datePill, pressed && styles.pressed]}
                 >
@@ -93,7 +92,6 @@ const IconPressable: React.FC<IconPressableProps> = ({ label, icon, disabled, on
         accessibilityRole="button"
         accessibilityLabel={label}
         disabled={disabled}
-        android_ripple={{ color: theme.colors.ripple, borderless: false }}
         onPress={onPress}
         style={({ pressed }) => [styles.iconButton, disabled && styles.disabled, pressed && styles.pressed]}
     >

--- a/mobile/src/components/FoodLogSummaryCard.tsx
+++ b/mobile/src/components/FoodLogSummaryCard.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo } from 'react';
-import { Pressable, StyleSheet, View, type ViewProps } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import type { FoodLogEntry } from '@calibrate/api-client';
-import { AppCard } from './AppCard';
+import { AppPressableCard } from './AppPressableCard';
 import { AppText } from './AppText';
 import { formatCalories, formatMealPeriod } from '../utils/format';
 import { type AppTheme, useAppTheme } from '../theme';
 
-type FoodLogSummaryCardProps = Omit<ViewProps, 'children'> & {
+type FoodLogSummaryCardProps = Omit<React.ComponentProps<typeof AppPressableCard>, 'children' | 'onPress'> & {
     entries: FoodLogEntry[];
     onPress: () => void;
 };
@@ -49,63 +49,56 @@ export const FoodLogSummaryCard: React.FC<FoodLogSummaryCardProps> = ({ entries,
         : 'No food logged';
 
     return (
-        <Pressable
+        <AppPressableCard
+            {...props}
             accessibilityRole="button"
             accessibilityLabel={`Food log. ${accessibilitySummary}. View full log`}
             accessibilityHint="Opens the full food log for this day"
-            android_ripple={{ color: theme.colors.ripple }}
             onPress={onPress}
-            style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
+            style={[styles.card, style]}
         >
-            <AppCard {...props} style={[styles.card, style]}>
-                <View style={styles.headerRow}>
-                    <AppText accessibilityRole="header" aria-level={2} variant="screenTitle">Food log</AppText>
-                    <View style={styles.viewAction}>
-                        <AppText style={styles.viewActionText}>View full log</AppText>
-                        <Ionicons name="chevron-forward" size={19} color={theme.colors.primary} />
+            <View style={styles.headerRow}>
+                <AppText accessibilityRole="header" aria-level={2} variant="screenTitle">Food log</AppText>
+                <View style={styles.viewAction}>
+                    <AppText style={styles.viewActionText}>View full log</AppText>
+                    <Ionicons name="chevron-forward" size={19} color={theme.colors.primary} />
+                </View>
+            </View>
+
+            {recentMeal ? (
+                <View style={styles.summaryRow}>
+                    <View style={styles.mealIcon}>
+                        <Ionicons name="restaurant-outline" size={21} color={theme.colors.primary} />
+                    </View>
+                    <View style={styles.summaryText}>
+                        <View style={styles.mealHeading}>
+                            <AppText variant="subtitle" numberOfLines={1} style={styles.mealName}>
+                                {formatMealPeriod(recentMeal.meal)}
+                            </AppText>
+                            <AppText variant="label" numberOfLines={1}>{formatCalories(recentMeal.calories)}</AppText>
+                        </View>
+                        <AppText variant="muted" numberOfLines={1}>
+                            {formatEntryPreview(recentMeal.entries)}
+                        </AppText>
                     </View>
                 </View>
-
-                {recentMeal ? (
-                    <View style={styles.summaryRow}>
-                        <View style={styles.mealIcon}>
-                            <Ionicons name="restaurant-outline" size={21} color={theme.colors.primary} />
-                        </View>
-                        <View style={styles.summaryText}>
-                            <View style={styles.mealHeading}>
-                                <AppText variant="subtitle" numberOfLines={1} style={styles.mealName}>
-                                    {formatMealPeriod(recentMeal.meal)}
-                                </AppText>
-                                <AppText variant="label" numberOfLines={1}>{formatCalories(recentMeal.calories)}</AppText>
-                            </View>
-                            <AppText variant="muted" numberOfLines={1}>
-                                {formatEntryPreview(recentMeal.entries)}
-                            </AppText>
-                        </View>
+            ) : (
+                <View style={styles.summaryRow}>
+                    <View style={styles.mealIcon}>
+                        <Ionicons name="restaurant-outline" size={21} color={theme.colors.muted} />
                     </View>
-                ) : (
-                    <View style={styles.summaryRow}>
-                        <View style={styles.mealIcon}>
-                            <Ionicons name="restaurant-outline" size={21} color={theme.colors.muted} />
-                        </View>
-                        <View style={styles.summaryText}>
-                            <AppText variant="subtitle">Nothing logged yet</AppText>
-                            <AppText variant="muted">Use Add food to start this day.</AppText>
-                        </View>
+                    <View style={styles.summaryText}>
+                        <AppText variant="subtitle">Nothing logged yet</AppText>
+                        <AppText variant="muted">Use Add food to start this day.</AppText>
                     </View>
-                )}
-            </AppCard>
-        </Pressable>
+                </View>
+            )}
+        </AppPressableCard>
     );
 };
 
 function createStyles(theme: AppTheme) {
     return StyleSheet.create({
-        pressable: {
-            width: '100%',
-            borderRadius: theme.radius.lg,
-            overflow: 'hidden'
-        },
         card: {
             gap: theme.spacing.md
         },
@@ -153,9 +146,6 @@ function createStyles(theme: AppTheme) {
         mealName: {
             flex: 1,
             minWidth: 0
-        },
-        pressed: {
-            opacity: 0.86
         }
     });
 }

--- a/mobile/src/components/FoodLogTimelineCard.tsx
+++ b/mobile/src/components/FoodLogTimelineCard.tsx
@@ -141,7 +141,6 @@ const MealTimelineRow: React.FC<MealTimelineRowProps> = ({
                             <Pressable
                                 accessibilityRole="button"
                                 accessibilityLabel={`${isExpanded ? 'Collapse' : 'Expand'} ${formatMealPeriod(group.meal)}`}
-                                android_ripple={{ color: theme.colors.ripple }}
                                 onPress={() => onToggleMeal(group.meal)}
                                 style={({ pressed }) => [styles.expandButton, pressed && styles.pressed]}
                             >
@@ -194,7 +193,6 @@ const FoodEntryRow: React.FC<FoodEntryRowProps> = ({ entry, disabled, onEditEntr
                     accessibilityRole="button"
                     accessibilityLabel={`Edit ${entry.name}`}
                     disabled={disabled}
-                    android_ripple={{ color: theme.colors.ripple }}
                     onPress={() => onEditEntry(entry)}
                     style={({ pressed }) => [styles.entryAction, disabled && styles.disabled, pressed && styles.pressed]}
                 >
@@ -204,7 +202,6 @@ const FoodEntryRow: React.FC<FoodEntryRowProps> = ({ entry, disabled, onEditEntr
                     accessibilityRole="button"
                     accessibilityLabel={`Delete ${entry.name}`}
                     disabled={disabled}
-                    android_ripple={{ color: theme.colors.ripple }}
                     onPress={() => onDeleteEntry(entry)}
                     style={({ pressed }) => [styles.entryAction, disabled && styles.disabled, pressed && styles.pressed]}
                 >

--- a/mobile/src/components/OverlaySelect.tsx
+++ b/mobile/src/components/OverlaySelect.tsx
@@ -107,7 +107,6 @@ export function OverlaySelect<T extends string>({
                 accessibilityRole="button"
                 accessibilityLabel={accessibilityLabel}
                 accessibilityState={{ expanded: isOpen }}
-                android_ripple={{ color: theme.colors.ripple }}
                 onLayout={handleButtonLayout}
                 onPress={handleToggle}
                 style={({ pressed }) => [styles.button, pressed && styles.pressedSurface]}
@@ -145,7 +144,6 @@ export function OverlaySelect<T extends string>({
                                     key={option.value}
                                     accessibilityRole="button"
                                     accessibilityState={{ selected: isSelected }}
-                                    android_ripple={{ color: theme.colors.ripple }}
                                     onPress={() => onChange(option.value)}
                                     style={({ pressed }) => [
                                         styles.option,

--- a/mobile/src/components/TimeZonePickerField.tsx
+++ b/mobile/src/components/TimeZonePickerField.tsx
@@ -84,7 +84,6 @@ export const TimeZonePickerField: React.FC<TimeZonePickerFieldProps> = ({ value,
             <Pressable
                 accessibilityRole="button"
                 accessibilityState={{ expanded: isManualOpen }}
-                android_ripple={{ color: theme.colors.ripple }}
                 onPress={() => setIsManualOpen((current) => !current)}
                 style={({ pressed }) => [styles.advancedAction, pressed && styles.pressed]}
             >

--- a/mobile/src/components/TodayWeightCard.tsx
+++ b/mobile/src/components/TodayWeightCard.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Pressable, StyleSheet, View, type ViewProps } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import type { MetricEntry } from '@calibrate/api-client';
 import type { WeightUnit } from '@calibrate/shared';
-import { AppCard } from './AppCard';
+import { AppPressableCard } from './AppPressableCard';
 import { AppText } from './AppText';
 import { formatWeight } from '../utils/format';
 import { type AppTheme, useAppTheme } from '../theme';
 
-type TodayWeightCardProps = Omit<ViewProps, 'children'> & {
+type TodayWeightCardProps = Omit<React.ComponentProps<typeof AppPressableCard>, 'children' | 'onPress'> & {
     metric: MetricEntry | null;
     weightUnit: WeightUnit | undefined;
     isToday: boolean;
@@ -34,46 +34,39 @@ export const TodayWeightCard: React.FC<TodayWeightCardProps> = ({
         : (isToday ? 'Add today\'s measurement' : 'Add a measurement for this day');
 
     return (
-        <Pressable
+        <AppPressableCard
+            {...props}
             accessibilityRole="button"
             accessibilityLabel={`${title}. ${metricLabel}. ${action} weight`}
             accessibilityHint={metric ? 'Opens this weigh-in for editing' : 'Opens the weight entry form'}
-            android_ripple={{ color: theme.colors.ripple }}
             onPress={onPress}
-            style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
+            style={[styles.card, style]}
         >
-            <AppCard {...props} style={[styles.card, style]}>
-                <View style={styles.headerRow}>
-                    <AppText accessibilityRole="header" aria-level={2} variant="screenTitle">{title}</AppText>
-                    <View style={styles.viewAction}>
-                        <AppText style={styles.viewActionText}>{action}</AppText>
-                        <Ionicons name="chevron-forward" size={19} color={theme.colors.primary} />
-                    </View>
+            <View style={styles.headerRow}>
+                <AppText accessibilityRole="header" aria-level={2} variant="screenTitle">{title}</AppText>
+                <View style={styles.viewAction}>
+                    <AppText style={styles.viewActionText}>{action}</AppText>
+                    <Ionicons name="chevron-forward" size={19} color={theme.colors.primary} />
                 </View>
+            </View>
 
-                <View style={styles.summaryRow}>
-                    <View style={styles.weightIcon}>
-                        <Ionicons name="scale-outline" size={22} color={theme.colors.primary} />
-                    </View>
-                    <View style={styles.summaryText}>
-                        <AppText variant={metric ? 'screenTitle' : 'subtitle'} numberOfLines={1}>
-                            {metricLabel}
-                        </AppText>
-                        <AppText variant="muted">{supportingLabel}</AppText>
-                    </View>
+            <View style={styles.summaryRow}>
+                <View style={styles.weightIcon}>
+                    <Ionicons name="scale-outline" size={22} color={theme.colors.primary} />
                 </View>
-            </AppCard>
-        </Pressable>
+                <View style={styles.summaryText}>
+                    <AppText variant={metric ? 'screenTitle' : 'subtitle'} numberOfLines={1}>
+                        {metricLabel}
+                    </AppText>
+                    <AppText variant="muted">{supportingLabel}</AppText>
+                </View>
+            </View>
+        </AppPressableCard>
     );
 };
 
 function createStyles(theme: AppTheme) {
     return StyleSheet.create({
-        pressable: {
-            width: '100%',
-            borderRadius: theme.radius.lg,
-            overflow: 'hidden'
-        },
         card: {
             gap: theme.spacing.md
         },
@@ -112,9 +105,6 @@ function createStyles(theme: AppTheme) {
             flex: 1,
             minWidth: 0,
             gap: theme.spacing.xs
-        },
-        pressed: {
-            opacity: 0.86
         }
     });
 }


### PR DESCRIPTION
## Summary

- add a shared rounded pressable-card primitive for the Today food and weight cards
- replace overlapping native ripples and opacity states with one explicit surface state
- align header, FAB, date, chip, food-log, select, and timezone controls around explicit pressed feedback
- retain keyboard focus and pointer hover behavior on web

## Why

The Today cards combined React Native's Android ripple with an opacity state on a separate rounded child. On Samsung devices the native ripple painted as a rectangular layer outside the visible card shape, while nearby controls used different or no feedback.

## Impact

Food and Weight now depress as one rounded surface without fading their text. Other controls no longer stack native ripples on top of their existing pressed styles. The change is JavaScript-only and does not add native dependencies or change the Expo runtime version, so it remains eligible for OTA delivery to compatible installed builds.

## Validation

- `npm.cmd --prefix mobile test -- --runInBand` (80 suites, 315 tests)
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile run build:web`
- `git diff --check`
- Android emulator touch-down verification for Food, Weight, and date controls
