### PR TITLE
Bump Android runtime to 0.2.3

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "calibrate-health-app",
     "owner": "calibrate-health",
     "scheme": "calibrate",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "orientation": "default",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",
@@ -18,7 +18,7 @@
     ],
     "android": {
       "package": "app.calibratehealth.mobile",
-      "versionCode": 4,
+      "versionCode": 5,
       "allowBackup": false,
       "softwareKeyboardLayoutMode": "resize",
       "adaptiveIcon": {
@@ -93,7 +93,7 @@
     ],
     "extra": {
       "calibrate": {
-        "nativeReleaseTag": "v0.12.3"
+        "nativeReleaseTag": "v0.12.4"
       },
       "router": {
         "origin": false

--- a/mobile/modules/wear-pairing/android/build.gradle
+++ b/mobile/modules/wear-pairing/android/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 group = 'app.calibratehealth'
-version = '0.2.2'
+version = '0.2.3'
 
 android {
   namespace 'app.calibratehealth.wearpairing'
   defaultConfig {
-    versionCode 4
-    versionName '0.2.2'
+    versionCode 5
+    versionName '0.2.3'
   }
 }
 

--- a/mobile/modules/wear-pairing/package.json
+++ b/mobile/modules/wear-pairing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calibrate/wear-pairing",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "main": "index.ts",
   "peerDependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "main": "index.js",
   "engines": {

--- a/mobile/src/components/FoodTrackingStatus.test.tsx
+++ b/mobile/src/components/FoodTrackingStatus.test.tsx
@@ -155,6 +155,17 @@ describe('food tracking day resolution', () => {
         expect(screen.getByText('Pause with this date')).toBeTruthy();
     });
 
+    it('removes the rectangular Android elevation from the past-day completion action', async () => {
+        mockApi.getFoodDay.mockResolvedValue(resolvedDay('OPEN'));
+        const screen = renderWithQuery(<DayStatusCard date="2026-07-23" isToday={false} />);
+
+        await waitFor(() => expect(screen.getByText('Day unresolved')).toBeTruthy());
+        expect(screen.getByRole('button', { name: 'Complete day' })).toHaveStyle({
+            elevation: 0,
+            shadowOpacity: 0
+        });
+    });
+
     it('presents inferred blank, incomplete, complete, and paused days without food prompts', async () => {
         const cases: Array<[FoodLogDay, string]> = [
             [resolvedDay('INCOMPLETE', 'INFERRED_EMPTY'), 'Tracking was not completed'],

--- a/mobile/src/components/FoodTrackingStatus.tsx
+++ b/mobile/src/components/FoodTrackingStatus.tsx
@@ -206,7 +206,7 @@ export const DayStatusCard: React.FC<{
                             style={[
                                 styles.action,
                                 useCompactOpenLayout && styles.actionCompact,
-                                useCompactOpenLayout && styles.primaryActionFlat
+                                styles.primaryActionFlat
                             ]}
                             leftIcon={<Ionicons
                                 name="checkmark-circle-outline"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "mobile": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@calibrate/api-client": "file:../packages/api-client",
@@ -86,7 +86,7 @@
     },
     "mobile/modules/wear-pairing": {
       "name": "@calibrate/wear-pairing",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "peerDependencies": {
         "expo": "*",
         "expo-modules-core": "*"

--- a/scripts/native-ota-update.mjs
+++ b/scripts/native-ota-update.mjs
@@ -49,7 +49,8 @@ export function parseNativeOtaArgs(argv) {
 
 export function createNativeOtaRunner() {
   return function runCommand(request) {
-    const result = spawnSync(request.command, request.args ?? [], {
+    const invocation = resolveNativeOtaInvocation(request);
+    const result = spawnSync(invocation.command, invocation.args, {
       cwd: request.cwd,
       env: request.env,
       encoding: request.inherit ? undefined : 'utf8',
@@ -68,6 +69,36 @@ export function createNativeOtaRunner() {
     }
     return response;
   };
+}
+
+export function resolveNativeOtaInvocation(request, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const args = request.args ?? [];
+  if (platform !== 'win32' || request.command.toLowerCase() !== 'npx.cmd') {
+    return { command: request.command, args };
+  }
+
+  const nodeExecutable = options.nodeExecutable ?? process.execPath;
+  const fileExists = options.fileExists ?? fs.existsSync;
+  const npmExecPath = request.env?.npm_execpath ?? process.env.npm_execpath;
+  const candidates = [];
+  if (npmExecPath) {
+    candidates.push(path.win32.join(path.win32.dirname(npmExecPath), 'npx-cli.js'));
+  }
+  candidates.push(path.win32.join(
+    path.win32.dirname(nodeExecutable),
+    'node_modules',
+    'npm',
+    'bin',
+    'npx-cli.js'
+  ));
+  const npxCli = candidates.find((candidate) => fileExists(candidate));
+  if (!npxCli) {
+    throw new Error(
+      'Unable to locate npm/bin/npx-cli.js for the Windows OTA command. Run this workflow through npm.cmd.'
+    );
+  }
+  return { command: nodeExecutable, args: [npxCli, ...args] };
 }
 
 function gitRequest(root, args, label, allowFailure = false) {

--- a/scripts/native-ota-update.test.mjs
+++ b/scripts/native-ota-update.test.mjs
@@ -10,6 +10,7 @@ import {
   parseEasEnvironmentFile,
   parseDirtyPaths,
   parseNativeOtaArgs,
+  resolveNativeOtaInvocation,
   runNativeOtaUpdate,
   validateEasUpdateEnvironment
 } from './native-ota-update.mjs';
@@ -72,6 +73,35 @@ test('OTA publish command targets Android and the build channel', () => {
   assert.throws(
     () => nativeOtaPublishCommand({ channel: 'production', message: 'x' }, { channel: 'internal' }),
     /pinned to the internal channel/
+  );
+});
+
+test('Windows OTA commands invoke npx through Node instead of spawning a batch file', () => {
+  const npmExecPath = 'C:\\Node\\node_modules\\npm\\bin\\npm-cli.js';
+  const invocation = resolveNativeOtaInvocation({
+    command: 'npx.cmd',
+    args: ['--yes', 'eas-cli@latest', 'env:pull'],
+    env: { npm_execpath: npmExecPath }
+  }, {
+    platform: 'win32',
+    nodeExecutable: 'C:\\Node\\node.exe',
+    fileExists: (candidate) => candidate === 'C:\\Node\\node_modules\\npm\\bin\\npx-cli.js'
+  });
+  assert.deepEqual(invocation, {
+    command: 'C:\\Node\\node.exe',
+    args: [
+      'C:\\Node\\node_modules\\npm\\bin\\npx-cli.js',
+      '--yes',
+      'eas-cli@latest',
+      'env:pull'
+    ]
+  });
+  assert.deepEqual(
+    resolveNativeOtaInvocation(
+      { command: 'npx', args: ['--version'] },
+      { platform: 'linux' }
+    ),
+    { command: 'npx', args: ['--version'] }
   );
 });
 

--- a/shared/release.json
+++ b/shared/release.json
@@ -13,9 +13,9 @@
   "android": {
     "application_id": "app.calibratehealth.mobile",
     "mobile": {
-      "version_name": "0.2.2",
-      "version_code": 4,
-      "native_release_tag": "v0.12.3",
+      "version_name": "0.2.3",
+      "version_code": 5,
+      "native_release_tag": "v0.12.4",
       "minimum_supported_version": "0.1.0"
     },
     "wear": {


### PR DESCRIPTION
## Summary
- bump the Android phone runtime from 0.2.2 (4) to 0.2.3 (5) and align canonical/mirrored mobile and pairing metadata
- advance the native release tag to v0.12.4 while leaving the Wear release identity unchanged
- make the Windows OTA runner invoke `npx` through Node's CLI instead of spawning `npx.cmd` directly
- remove the rectangular Android elevation artifact from the past-day **Complete day** action

## Why
Recent native runtime inputs changed, so the OTA preflight correctly refused to publish against runtime 0.2.2. A new signed phone binary/runtime is required before compatible OTA updates can resume.

After rebasing onto #248's host-first workflow, revalidation also exposed `spawnSync npx.cmd EINVAL` in the Windows OTA path. The button fix covers the past-day layout shown on Android, where the existing flat style was only applied to today's compact layout.

## Impact
A freshly signed internal phone APK/AAB now uses runtime 0.2.3 and Android version code 5. It preserves the established phone/Watch signing certificate and targets the `internal` channel at `https://calibratehealth.darkmachines.net`. Wear remains 0.2.2 (4).

## Validation
- `npm.cmd run setup`
- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 passed)
- `npm.cmd run test:native-release` (35 passed)
- `npm.cmd run test:dev-script` (16 passed)
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile test -- --runInBand` (83 suites, 331 tests)
- focused `FoodTrackingStatus` suite (7 passed), including the past-day Android elevation regression
- `npm.cmd run release:native:ota -- --dry-run --message "Validate Android 0.2.3 runtime"`
- exact Expo OTA CI preflight against `origin/master`
- signed phone and Wear APK/AAB build; verified phone 0.2.3 (5), Wear 0.2.2 (4), and the established shared signer
- `git diff --check`