### PR TITLE
Fix automatic release image publishing

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,8 +1,14 @@
 name: Build Release Image
 
 on:
-  # Releases are dispatched by cut-release.yml after the immutable tag exists.
-  # Keeping this manual-only avoids a duplicate build when the tag is pushed.
+  # Validated master releases call this workflow after creating the immutable tag.
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Existing vMAJOR.MINOR.PATCH tag created by the validated manifest release
+        required: true
+        type: string
+  # Retain an explicit recovery path for rebuilding an existing immutable release.
   workflow_dispatch:
     inputs:
       release_tag:
@@ -15,7 +21,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: release-image-${{ inputs.release_tag || github.ref_name }}
+  group: release-image-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 env:
@@ -31,7 +37,7 @@ jobs:
       - name: Checkout immutable release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -43,7 +49,7 @@ jobs:
         id: release
         shell: bash
         env:
-          REQUESTED_TAG: ${{ inputs.release_tag || github.ref_name }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           if [[ ! "${REQUESTED_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  actions: write
+  packages: write
 
 concurrency:
   group: publish-manifest-release
@@ -15,9 +15,12 @@ concurrency:
 
 jobs:
   publish:
-    name: Tag and Dispatch New Manifest Version
+    name: Tag Validated Manifest Version
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      should_release: ${{ steps.version.outputs.should_release }}
+      release_tag: ${{ steps.version.outputs.new_tag }}
 
     steps:
       - name: Require master
@@ -79,22 +82,14 @@ jobs:
           git tag -a "${NEW_TAG}" -m "Release ${NEW_TAG}" "${GITHUB_SHA}"
           git push origin "${NEW_TAG}"
 
-      - name: Dispatch current release image workflow
-        if: steps.version.outputs.should_release == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'container.yml',
-              // Always load the current workflow; the immutable release tag is an explicit build input.
-              ref: 'master',
-              inputs: {
-                release_tag: '${{ steps.version.outputs.new_tag }}',
-              },
-            });
-
       - name: Report no-op release check
         if: steps.version.outputs.should_release != 'true'
         run: echo "No release published because ${{ steps.version.outputs.new_tag }} is already the latest manifest release."
+
+  build_release_image:
+    name: Build Validated Release Image
+    needs: publish
+    if: needs.publish.outputs.should_release == 'true'
+    uses: ./.github/workflows/container.yml
+    with:
+      release_tag: ${{ needs.publish.outputs.release_tag }}

--- a/docs/architecture/0002-canonical-release-manifest.md
+++ b/docs/architecture/0002-canonical-release-manifest.md
@@ -13,10 +13,11 @@ manifest. That could publish a tag whose version disagreed with the server and c
 
 Treat `shared/release.json` as the canonical release identity and compatibility policy. Native and package metadata
 remain mirrors because their build tools need values before app code runs. `npm run release:check` validates those
-mirrors. On every merge to `master`, the release workflow reads the stable server version from the manifest. It is a
-no-op when that version already has the latest stable tag, creates the tag when the version advances, and refuses a
-regression or prerelease version. It then dispatches the current GHCR-only image workflow with the immutable release
-tag as an explicit input, so an older tag cannot reintroduce its historical deployment steps.
+mirrors and the structural risk-evidence contract. On every merge to `master`, the release workflow reads the stable
+server version from the manifest. It is a no-op when that version already has the latest stable tag, creates the tag
+when the version advances, and refuses a regression or prerelease version. It then calls the current reusable
+GHCR-only image workflow as a dependent job with the immutable release tag as an explicit input, so an older tag
+cannot reintroduce its historical deployment steps.
 
 Semantic-version comparison follows prerelease precedence. Build metadata does not affect ordering. Raising a
 minimum supported client version remains an explicit compatibility decision documented in release notes.

--- a/docs/release-compatibility.md
+++ b/docs/release-compatibility.md
@@ -63,18 +63,20 @@ npm.cmd run release:check
 npm.cmd run test:release
 ```
 
-These checks parse configuration only. They do not invoke Gradle, Expo, Docker, or the full CI suite.
+These checks parse release configuration, dependency policy, workflow contracts, and retained risk-evidence
+references. They do not invoke Gradle, Expo, Docker, or the full CI suite.
 
 The `Publish Manifest Release` workflow does not calculate or mutate versions. Every merge to `master` validates the
 exact stable `server.version` declared in `shared/release.json`. If that version is newer than the latest stable tag,
-the workflow runs the container release gates, creates the tag, and dispatches the current GHCR-only image workflow.
+the workflow runs the container release gates, creates the tag, and directly calls the current GHCR-only image
+workflow as a dependent job.
 If the version is already published, it exits without building an image. Regressions and prerelease versions fail
 closed. A manual dispatch on `master` is retained only as a recovery mechanism; ordinary releases require no step
 beyond merging the reviewed version bump.
 
-The image workflow receives the immutable tag as an explicit input while its workflow definition is loaded from
-`master`. This prevents rebuilding an older tag from executing historical AWS/ECS deployment jobs. It publishes only
-the version and source-SHA tags to GHCR; deployment to a self-host remains an operator-controlled Docker Compose
+The reusable image workflow receives the immutable tag as an explicit input while its workflow definition is loaded
+from `master`. This prevents rebuilding an older tag from executing historical AWS/ECS deployment jobs. It publishes
+only the version and source-SHA tags to GHCR; deployment to a self-host remains an operator-controlled Docker Compose
 operation.
 
 Container publication runs `release:check:container`, including the encrypted backup/restore drill, strict dependency

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release:native:ota": "node scripts/native-ota-update.mjs",
     "api:generate": "node backend/node_modules/openapi-typescript/bin/cli.js docs/openapi/v1.yaml -o packages/api-client/src/generated/v1.ts",
     "api:contract:check": "npm run api:generate && git diff --exit-code -- packages/api-client/src/generated/v1.ts",
-    "release:check": "node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs",
+    "release:check": "node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs && node scripts/verify-risk-evidence.mjs",
     "release:check:container": "node scripts/postgres-backup-restore-smoke.mjs && node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs --strict && node scripts/verify-risk-evidence.mjs",
     "release:check:production": "node scripts/postgres-backup-restore-smoke.mjs && node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs --strict && node scripts/verify-risk-evidence.mjs --release",
     "release:metadata": "node scripts/release-config.mjs metadata",

--- a/quality/risk-evidence.json
+++ b/quality/risk-evidence.json
@@ -142,7 +142,7 @@
         {
           "id": "fresh-migration",
           "npmScript": "db:migrate",
-          "scriptCommand": "npm --prefix backend run db:migrate",
+          "scriptCommand": "node scripts/dev-stack.mjs db:migrate",
           "paths": [
             ".github/workflows/tests.yml",
             "backend/prisma/schema.prisma"

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -15,17 +15,23 @@ test('master merges publish only when the reviewed manifest version advances', (
   assert.match(workflow, /node scripts\/release-config\.mjs plan/);
   assert.match(workflow, /npm run release:check:container/);
   assert.doesNotMatch(workflow, /npm run release:check:production/);
-  assert.match(workflow, /workflow_id: 'container\.yml'/);
-  assert.match(workflow, /ref: 'master'/);
-  assert.match(workflow, /release_tag: '\$\{\{ steps\.version\.outputs\.new_tag \}\}'/);
+  assert.match(workflow, /packages: write/);
+  assert.match(workflow, /build_release_image:/);
+  assert.match(workflow, /needs: publish/);
+  assert.match(workflow, /uses: \.\/\.github\/workflows\/container\.yml/);
+  assert.match(workflow, /release_tag: \$\{\{ needs\.publish\.outputs\.release_tag \}\}/);
+  assert.doesNotMatch(workflow, /createWorkflowDispatch|workflow_id:/);
 });
 
 test('release images use the current GHCR-only workflow with an explicit immutable tag', () => {
   const workflow = readWorkflow('container.yml');
 
   assert.doesNotMatch(workflow, /push:\s*\n\s+tags:/, 'image builds must be explicitly dispatched');
+  assert.match(workflow, /workflow_call:/);
+  assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /release_tag:/);
-  assert.match(workflow, /ref: \$\{\{ inputs\.release_tag \|\| github\.ref \}\}/);
+  assert.match(workflow, /ref: \$\{\{ inputs\.release_tag \}\}/);
+  assert.match(workflow, /REQUESTED_TAG: \$\{\{ inputs\.release_tag \}\}/);
   assert.match(workflow, /node scripts\/release-config\.mjs tag/);
   assert.match(workflow, /ghcr\.io/);
   assert.match(workflow, /platforms: linux\/amd64/);


### PR DESCRIPTION
## Summary

- update the retained fresh-migration evidence to match the host-run `db:migrate` command
- include structural risk-evidence validation in the normal PR/local release check
- make `Build Release Image` reusable and invoke it directly after a validated manifest tag is created on `master`
- retain manual image dispatch as a recovery path and update workflow contracts/documentation

## Root cause

The Compose workflow migration changed the root `db:migrate` script from a direct backend command to `node scripts/dev-stack.mjs db:migrate`, but `quality/risk-evidence.json` still pinned the previous command. PR CI did not run the structural risk-evidence validator, so the mismatch reached `master`. Both `Publish Manifest Release` runs then failed in `release:check:container` before creating `v0.12.5` or dispatching the image build.

The image workflow also depended on a separate REST workflow dispatch after tagging. This change makes that dependency explicit as a reusable workflow job in the validated `master` release chain.

## Impact

Once merged, the pending `0.12.5` manifest release should pass the container gates, create the immutable tag, and automatically build/push the corresponding GHCR image. Future risk-evidence command drift will fail in PR CI before merge.

## Validation

- clean-checkout `npm.cmd run release:check:container`
- `npm.cmd run test:release` (20 tests)
- `npm.cmd run test:expo-web:release` (14 tests)
- `npm.cmd run test:deploy` (7 tests)
- `actionlint` for `cut-release.yml` and `container.yml`
- `git diff --check`