### PR TITLE
Publish a latest release image tag

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,6 +8,11 @@ on:
         description: Existing vMAJOR.MINOR.PATCH tag created by the validated manifest release
         required: true
         type: string
+      publish_latest:
+        description: Also publish the moving latest tag after validating the current stable release
+        required: false
+        default: false
+        type: boolean
   # Retain an explicit recovery path for rebuilding an existing immutable release.
   workflow_dispatch:
     inputs:
@@ -15,6 +20,11 @@ on:
         description: Existing vMAJOR.MINOR.PATCH tag to build with the current GHCR-only workflow
         required: true
         type: string
+      publish_latest:
+        description: Also update latest when rebuilding the current stable release
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -50,6 +60,7 @@ jobs:
         shell: bash
         env:
           REQUESTED_TAG: ${{ inputs.release_tag }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
           set -euo pipefail
           if [[ ! "${REQUESTED_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -67,6 +78,14 @@ jobs:
           if [[ "${SOURCE_SHA}" != "$(git rev-parse HEAD)" ]]; then
             echo "Checkout does not match ${REQUESTED_TAG}." >&2
             exit 1
+          fi
+
+          if [[ "${PUBLISH_LATEST}" == "true" ]]; then
+            LATEST_RELEASE_TAG="$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+            if [[ "${REQUESTED_TAG}" != "${LATEST_RELEASE_TAG}" ]]; then
+              echo "Refusing to move latest to ${REQUESTED_TAG}; current stable release is ${LATEST_RELEASE_TAG}." >&2
+              exit 1
+            fi
           fi
 
           {
@@ -90,6 +109,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
           set -euo pipefail
           GHCR_IMAGE="${GHCR_IMAGE,,}"
@@ -98,6 +118,9 @@ jobs:
             echo "tags<<EOF"
             echo "${GHCR_IMAGE}:${RELEASE_TAG}"
             echo "${GHCR_IMAGE}:sha-${SOURCE_SHA}"
+            if [[ "${PUBLISH_LATEST}" == "true" ]]; then
+              echo "${GHCR_IMAGE}:latest"
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -93,3 +93,4 @@ jobs:
     uses: ./.github/workflows/container.yml
     with:
       release_tag: ${{ needs.publish.outputs.release_tag }}
+      publish_latest: true

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,5 +1,5 @@
 # Application image and public hostname.
-APP_IMAGE=ghcr.io/mchartier/calibratehealth:master
+APP_IMAGE=ghcr.io/mchartier/calibratehealth:latest
 APP_HOST=calibratehealth.example.com
 SESSION_SECRET=replace-with-at-least-32-random-bytes
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,8 @@ its own `pg_isready` health check, and the app waits for it before running migra
 ## Initial configuration
 
 1. Copy `.env.example` to `.env` and replace every placeholder used by your selected files.
-2. Use a pinned immutable `APP_IMAGE` tag or digest for reproducible upgrades.
+2. `APP_IMAGE` defaults to the moving `latest` release tag. Replace it with an immutable `vMAJOR.MINOR.PATCH` tag or
+   digest when you need reproducible upgrades and rollbacks.
 3. Generate `SESSION_SECRET` from at least 32 random bytes and keep it stable across restarts.
 4. Point `APP_HOST` DNS at the proxy host. Caddy obtains certificates itself; Traefik uses the configured resolver and
    external Docker network.
@@ -83,9 +84,10 @@ exist.
   readiness probe.
 - `restart: unless-stopped`, init handling, and stop grace periods cover normal host reboots and orderly Postgres
   shutdown. Do not scale the Compose app beyond one replica without separately designing migration and job ownership.
-- Before an upgrade, confirm a recent encrypted backup exists. Pull the new immutable image, run `docker compose up -d`,
-  and watch `docker compose logs -f app` until migrations and readiness succeed. Database migrations are forward-only;
-  rollback means restoring a pre-upgrade backup into a clean database and running the matching prior image.
+- Before an upgrade, confirm a recent encrypted backup exists. If you use `latest`, pull it explicitly before running
+  `docker compose up -d`; Compose does not automatically refresh a moving tag. Watch `docker compose logs -f app` until
+  migrations and readiness succeed. Database migrations are forward-only; rollback means restoring a pre-upgrade
+  backup into a clean database and running the matching prior image.
 
 ## Encrypted automated backups
 

--- a/docs/release-compatibility.md
+++ b/docs/release-compatibility.md
@@ -75,9 +75,10 @@ closed. A manual dispatch on `master` is retained only as a recovery mechanism; 
 beyond merging the reviewed version bump.
 
 The reusable image workflow receives the immutable tag as an explicit input while its workflow definition is loaded
-from `master`. This prevents rebuilding an older tag from executing historical AWS/ECS deployment jobs. It publishes
-only the version and source-SHA tags to GHCR; deployment to a self-host remains an operator-controlled Docker Compose
-operation.
+from `master`. This prevents rebuilding an older tag from executing historical AWS/ECS deployment jobs. Validated
+manifest releases publish version, source-SHA, and moving `latest` tags to GHCR. Manual recovery builds leave `latest`
+unchanged by default and reject attempts to move it to anything other than the highest stable release. Deployment to
+a self-host remains an operator-controlled Docker Compose operation.
 
 Container publication runs `release:check:container`, including the encrypted backup/restore drill, strict dependency
 policy, canonical version checks, and risk-contract validation. It intentionally does not claim physical Android/Wear

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -20,23 +20,31 @@ test('master merges publish only when the reviewed manifest version advances', (
   assert.match(workflow, /needs: publish/);
   assert.match(workflow, /uses: \.\/\.github\/workflows\/container\.yml/);
   assert.match(workflow, /release_tag: \$\{\{ needs\.publish\.outputs\.release_tag \}\}/);
+  assert.match(workflow, /publish_latest: true/);
   assert.doesNotMatch(workflow, /createWorkflowDispatch|workflow_id:/);
 });
 
-test('release images use the current GHCR-only workflow with an explicit immutable tag', () => {
+test('release images publish immutable identity and guard the moving latest tag', () => {
   const workflow = readWorkflow('container.yml');
+  const deployEnvironment = readFileSync(path.join(repositoryRoot, 'deploy', '.env.example'), 'utf8');
 
   assert.doesNotMatch(workflow, /push:\s*\n\s+tags:/, 'image builds must be explicitly dispatched');
   assert.match(workflow, /workflow_call:/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /release_tag:/);
+  assert.match(workflow, /publish_latest:/);
+  assert.match(workflow, /default: false/);
   assert.match(workflow, /ref: \$\{\{ inputs\.release_tag \}\}/);
   assert.match(workflow, /REQUESTED_TAG: \$\{\{ inputs\.release_tag \}\}/);
   assert.match(workflow, /node scripts\/release-config\.mjs tag/);
   assert.match(workflow, /ghcr\.io/);
+  assert.match(workflow, /echo "\$\{GHCR_IMAGE\}:latest"/);
+  assert.match(workflow, /Refusing to move latest/);
   assert.match(workflow, /platforms: linux\/amd64/);
   assert.doesNotMatch(workflow, /linux\/arm64|setup-qemu-action/);
   assert.doesNotMatch(workflow, /aws-actions|amazon-ecs|\bECR\b|\bECS\b|Deploy Staging|Deploy Prod/i);
+  assert.match(deployEnvironment, /^APP_IMAGE=ghcr\.io\/mchartier\/calibratehealth:latest$/m);
+  assert.doesNotMatch(deployEnvironment, /calibratehealth:master/);
 });
 
 test('no active workflow deploys to AWS or builds an image for every merged PR', () => {

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.5",
+    "version": "0.12.6",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## What changed

- publish `ghcr.io/mchartier/calibratehealth:latest` alongside the immutable version and source-SHA tags for validated manifest releases
- keep manual recovery builds from moving `latest` by default, and reject an opt-in move to anything other than the highest stable release
- change the deployment example from the obsolete `master` tag to `latest` and document explicit pulls plus immutable pinning
- bump the server release from `0.12.5` to `0.12.6` so merging this change creates a new validated release and initializes `latest`
- add workflow contract coverage for the moving-tag behavior and deployment default

## Why

The old master-merge image workflow was removed, but `deploy/.env.example` still selected `:master`. Current manifest releases publish only version and source-SHA tags, so a deployment using that example can keep running a stale server image even after a successful release. That explains how the released client can reach endpoints that the deployed server image does not contain.

## Validation

- `npm.cmd run release:check:container` (including encrypted Postgres backup/restore smoke test)
- `npm.cmd run test:release` (20 passing)
- `npm.cmd run test:expo-web:release` (14 passing)
- `npm.cmd run test:deploy` (7 passing)
- `docker run --rm -v "C:\Users\MChar\Code\calibrate-health:/repo" -w /repo rhysd/actionlint:latest .github/workflows/container.yml .github/workflows/cut-release.yml`
- `git diff --check`