### PR TITLE
Keep mobile input content above system keyboards

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.6",
+      "version": "0.12.7",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/app/_layout.web.tsx
+++ b/mobile/app/_layout.web.tsx
@@ -119,7 +119,13 @@ export default function RootLayout() {
                                 <Head>
                                     <title>calibrate</title>
                                 </Head>
-                                <View style={[styles.viewport, { height: visualViewportHeight }]}>
+                                <View
+                                    style={[
+                                        styles.viewport,
+                                        visualViewportHeight !== undefined && styles.visualViewport,
+                                        { height: visualViewportHeight }
+                                    ]}
+                                >
                                     <Slot />
                                 </View>
                             </BrowserRuntime>
@@ -135,5 +141,9 @@ const styles = StyleSheet.create({
     viewport: {
         flex: 1,
         minHeight: 0
+    },
+    visualViewport: {
+        flex: 0,
+        width: '100%'
     }
 });

--- a/mobile/app/_layout.web.tsx
+++ b/mobile/app/_layout.web.tsx
@@ -2,6 +2,7 @@ import 'react-native-gesture-handler';
 import React from 'react';
 import { Slot } from 'expo-router';
 import Head from 'expo-router/head';
+import { StyleSheet, View } from 'react-native';
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
@@ -14,6 +15,7 @@ import { AppErrorBoundary } from '../src/components/AppErrorBoundary';
 import { HealthConnectProvider } from '../src/healthConnect/provider';
 import { PwaStatusBanner } from '../src/pwa/PwaStatusBanner.web';
 import { useBrowserNotificationStream } from '../src/notifications/useBrowserNotificationStream.web';
+import { useVisualViewportHeight } from '../src/hooks/useVisualViewportHeight';
 
 const queryClient = new QueryClient();
 
@@ -80,6 +82,7 @@ const AuthenticatedPwaStatus: React.FC = () => {
 
 export default function RootLayout() {
     const theme = useAppTheme();
+    const visualViewportHeight = useVisualViewportHeight();
 
     React.useEffect(() => {
         const previousRootBackground = document.documentElement.style.backgroundColor;
@@ -116,7 +119,9 @@ export default function RootLayout() {
                                 <Head>
                                     <title>calibrate</title>
                                 </Head>
-                                <Slot />
+                                <View style={[styles.viewport, { height: visualViewportHeight }]}>
+                                    <Slot />
+                                </View>
                             </BrowserRuntime>
                         </NativePushRegistrationProvider>
                     </AuthProvider>
@@ -125,3 +130,10 @@ export default function RootLayout() {
         </AppErrorBoundary>
     );
 }
+
+const styles = StyleSheet.create({
+    viewport: {
+        flex: 1,
+        minHeight: 0
+    }
+});

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Redirect, router } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -19,6 +19,7 @@ import { CalibrateLogo } from '../src/components/CalibrateLogo';
 import { DatePickerField } from '../src/components/DatePickerField';
 import { HealthConnectOnboardingStep } from '../src/components/HealthConnectOnboardingStep';
 import { LoadingState } from '../src/components/LoadingState';
+import { KeyboardAwareScrollView } from '../src/components/KeyboardAwareScrollView';
 import { NumberStepperField } from '../src/components/NumberStepperField';
 import { GoalDailyChangeSelect } from '../src/components/GoalDailyChangeSelect';
 import { Screen } from '../src/components/Screen';
@@ -558,18 +559,15 @@ export default function OnboardingScreen() {
                 behavior={getKeyboardAvoidingBehavior(Platform.OS)}
                 style={styles.wizardRegion}
             >
-                <ScrollView
-                    automaticallyAdjustKeyboardInsets={Platform.OS === 'ios'}
+                <KeyboardAwareScrollView
                     contentContainerStyle={styles.wizardContent}
-                    keyboardDismissMode="on-drag"
-                    keyboardShouldPersistTaps="handled"
                     showsVerticalScrollIndicator={false}
                 >
                     <AppCard>
                         <SectionHeader title={activeStep.title} description={activeStep.description} />
                         {renderStepContent()}
                     </AppCard>
-                </ScrollView>
+                </KeyboardAwareScrollView>
 
                 <View style={[styles.actionBar, { borderTopColor: themeColors.outlineVariant, backgroundColor: themeColors.background }]}>
                     {(validationError || setupMutation.error) && (

--- a/mobile/src/components/BottomSheetModal.tsx
+++ b/mobile/src/components/BottomSheetModal.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Animated, Easing, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, StyleSheet, View, type ViewStyle } from 'react-native';
+import { Animated, Easing, KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type AppTheme, useAppTheme } from '../theme';
 import { useReducedMotionPreference } from '../hooks/useReducedMotionPreference';
+import { useVisualViewportHeight } from '../hooks/useVisualViewportHeight';
 import { getKeyboardAvoidingBehavior } from '../utils/keyboard';
+import { KeyboardAwareScrollView } from './KeyboardAwareScrollView';
 
 type BottomSheetModalProps = {
     visible: boolean;
@@ -27,6 +29,7 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
     const theme = useAppTheme();
     const styles = React.useMemo(() => createStyles(theme), [theme]);
     const reduceMotion = useReducedMotionPreference();
+    const visualViewportHeight = useVisualViewportHeight();
     const [shouldRender, setShouldRender] = useState(visible);
     const backdropOpacity = useRef(new Animated.Value(0)).current;
     const sheetProgress = useRef(new Animated.Value(1)).current;
@@ -86,7 +89,11 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
         <Modal visible transparent animationType="none" presentationStyle="overFullScreen" onRequestClose={onRequestClose}>
             <KeyboardAvoidingView
                 behavior={getKeyboardAvoidingBehavior(Platform.OS)}
-                style={styles.root}
+                style={[
+                    styles.root,
+                    visualViewportHeight !== undefined && styles.webViewportRoot,
+                    visualViewportHeight !== undefined && { height: visualViewportHeight }
+                ]}
             >
                 <Pressable accessibilityRole="button" accessibilityLabel="Close dialog" style={StyleSheet.absoluteFill} onPress={onRequestClose}>
                     <Animated.View style={[styles.backdrop, { opacity: backdropOpacity }]} />
@@ -101,16 +108,12 @@ export const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
                         }
                     ]}
                 >
-                    <ScrollView
-                        automaticallyAdjustKeyboardInsets={Platform.OS === 'ios'}
+                    <KeyboardAwareScrollView
                         contentContainerStyle={[styles.content, { paddingBottom: Math.max(theme.spacing.lg, insets.bottom + theme.spacing.sm) }]}
-                        keyboardDismissMode="on-drag"
-                        keyboardShouldPersistTaps="handled"
-                        showsVerticalScrollIndicator={false}
                     >
                         <View style={styles.handle} />
                         {children}
-                    </ScrollView>
+                    </KeyboardAwareScrollView>
                 </Animated.View>
             </KeyboardAvoidingView>
         </Modal>
@@ -122,6 +125,10 @@ function createStyles(theme: AppTheme) {
     root: {
         flex: 1,
         justifyContent: 'flex-end'
+    },
+    webViewportRoot: {
+        flex: 0,
+        width: '100%'
     },
     backdrop: {
         flex: 1,

--- a/mobile/src/components/KeyboardAwareScrollView.test.tsx
+++ b/mobile/src/components/KeyboardAwareScrollView.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Keyboard, ScrollView, StyleSheet } from 'react-native';
+import { act, render } from '@testing-library/react-native';
+import { AppText } from './AppText';
+import { KeyboardAwareScrollView } from './KeyboardAwareScrollView';
+
+describe('KeyboardAwareScrollView', () => {
+    const keyboardListeners: Partial<Record<string, () => void>> = {};
+
+    beforeEach(() => {
+        jest.spyOn(Keyboard, 'isVisible').mockReturnValue(false);
+        jest.spyOn(Keyboard, 'addListener').mockImplementation((event, listener) => {
+            keyboardListeners[event] = listener as () => void;
+            return { remove: jest.fn() } as unknown as ReturnType<typeof Keyboard.addListener>;
+        });
+    });
+
+    afterEach(() => {
+        Object.keys(keyboardListeners).forEach((event) => delete keyboardListeners[event]);
+        jest.restoreAllMocks();
+    });
+
+    it('uses form-friendly keyboard interaction defaults', () => {
+        const view = render(
+            <KeyboardAwareScrollView testID="keyboard-scroller">
+                <AppText>Form content</AppText>
+            </KeyboardAwareScrollView>
+        );
+
+        const scroller = view.UNSAFE_getByType(ScrollView);
+        expect(scroller.props.keyboardDismissMode).toBe('on-drag');
+        expect(scroller.props.keyboardShouldPersistTaps).toBe('handled');
+        expect(scroller.props.showsVerticalScrollIndicator).toBe(false);
+    });
+
+    it('reserves room for related content while the software keyboard is visible', () => {
+        const view = render(
+            <KeyboardAwareScrollView
+                testID="keyboard-scroller"
+                keyboardContextHeight={220}
+                contentContainerStyle={{ paddingBottom: 24 }}
+            >
+                <AppText>Form content</AppText>
+            </KeyboardAwareScrollView>
+        );
+
+        act(() => {
+            const showKeyboard = keyboardListeners.keyboardDidShow ?? keyboardListeners.keyboardWillShow;
+            showKeyboard?.();
+        });
+
+        const contentStyle = StyleSheet.flatten(
+            view.UNSAFE_getByType(ScrollView).props.contentContainerStyle
+        );
+        expect(contentStyle.paddingBottom).toBe(220);
+    });
+
+    it('preserves larger configured bottom padding when the keyboard opens', () => {
+        const view = render(
+            <KeyboardAwareScrollView
+                keyboardContextHeight={120}
+                contentContainerStyle={{ paddingBottom: 160 }}
+            >
+                <AppText>Form content</AppText>
+            </KeyboardAwareScrollView>
+        );
+
+        act(() => {
+            const showKeyboard = keyboardListeners.keyboardDidShow ?? keyboardListeners.keyboardWillShow;
+            showKeyboard?.();
+        });
+
+        const contentStyle = StyleSheet.flatten(
+            view.UNSAFE_getByType(ScrollView).props.contentContainerStyle
+        );
+        expect(contentStyle.paddingBottom).toBe(160);
+    });
+});

--- a/mobile/src/components/KeyboardAwareScrollView.tsx
+++ b/mobile/src/components/KeyboardAwareScrollView.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    Keyboard,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    TextInput,
+    type ScrollViewProps
+} from 'react-native';
+import { useVisualViewportHeight } from '../hooks/useVisualViewportHeight';
+
+type KeyboardAwareScrollViewProps = ScrollViewProps & {
+    keyboardContextHeight?: number;
+};
+
+const DEFAULT_KEYBOARD_CONTEXT_HEIGHT = 192; // Keeps validation, actions, or the first search result visible below the active field.
+const WEB_KEYBOARD_OVERLAY_THRESHOLD = 80; // Ignores small visual-viewport changes caused by mobile browser chrome.
+
+/**
+ * Shared form scroller that reveals focused inputs plus the content that
+ * explains or acts on their current value.
+ */
+export const KeyboardAwareScrollView: React.FC<KeyboardAwareScrollViewProps> = ({
+    automaticallyAdjustKeyboardInsets,
+    contentContainerStyle,
+    keyboardContextHeight = DEFAULT_KEYBOARD_CONTEXT_HEIGHT,
+    keyboardDismissMode = 'on-drag',
+    keyboardShouldPersistTaps = 'handled',
+    onContentSizeChange,
+    onFocus,
+    showsVerticalScrollIndicator = false,
+    ...props
+}) => {
+    const scrollViewRef = useRef<ScrollView>(null);
+    const focusedInputRef = useRef<unknown>(null);
+    const [isKeyboardVisible, setIsKeyboardVisible] = useState(() => Platform.OS !== 'web' && Keyboard.isVisible());
+    const visualViewportHeight = useVisualViewportHeight();
+    const isWebKeyboardOverlayVisible = Platform.OS === 'web'
+        && visualViewportHeight !== undefined
+        && typeof window !== 'undefined'
+        && visualViewportHeight < window.innerHeight - WEB_KEYBOARD_OVERLAY_THRESHOLD;
+    const shouldRevealKeyboardContext = isKeyboardVisible || isWebKeyboardOverlayVisible;
+
+    const revealFocusedInput = useCallback((input: unknown = focusedInputRef.current) => {
+        if (!input) return;
+
+        requestAnimationFrame(() => {
+            if (
+                Platform.OS === 'web'
+                && typeof (input as { scrollIntoView?: unknown }).scrollIntoView === 'function'
+            ) {
+                (input as Element).scrollIntoView({ block: 'center', inline: 'nearest' });
+                return;
+            }
+
+            scrollViewRef.current?.scrollResponderScrollNativeHandleToKeyboard(
+                input,
+                keyboardContextHeight,
+                true
+            );
+        });
+    }, [keyboardContextHeight]);
+
+    useEffect(() => {
+        if (Platform.OS === 'web') return;
+
+        const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+        const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+        const showSubscription = Keyboard.addListener(showEvent, () => {
+            setIsKeyboardVisible(true);
+            const focusedInput = TextInput.State.currentlyFocusedInput();
+            focusedInputRef.current = focusedInput;
+            revealFocusedInput(focusedInput);
+        });
+        const hideSubscription = Keyboard.addListener(hideEvent, () => setIsKeyboardVisible(false));
+
+        return () => {
+            showSubscription.remove();
+            hideSubscription.remove();
+        };
+    }, [revealFocusedInput]);
+
+    const flattenedContentStyle = StyleSheet.flatten(contentContainerStyle);
+    const configuredBottomPadding = typeof flattenedContentStyle?.paddingBottom === 'number'
+        ? flattenedContentStyle.paddingBottom
+        : 0;
+    const keyboardContentStyle = shouldRevealKeyboardContext
+        ? { paddingBottom: Math.max(configuredBottomPadding, keyboardContextHeight) }
+        : undefined;
+
+    useEffect(() => {
+        if (isWebKeyboardOverlayVisible) revealFocusedInput();
+    }, [isWebKeyboardOverlayVisible, revealFocusedInput]);
+
+    return (
+        <ScrollView
+            {...props}
+            ref={scrollViewRef}
+            automaticallyAdjustKeyboardInsets={
+                automaticallyAdjustKeyboardInsets ?? Platform.OS === 'ios'
+            }
+            contentContainerStyle={[contentContainerStyle, keyboardContentStyle]}
+            keyboardDismissMode={keyboardDismissMode}
+            keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+            onContentSizeChange={(width, height) => {
+                onContentSizeChange?.(width, height);
+                if (shouldRevealKeyboardContext) revealFocusedInput();
+            }}
+            onFocus={(event) => {
+                onFocus?.(event);
+                focusedInputRef.current = event.target;
+                revealFocusedInput(event.target);
+            }}
+            showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+        />
+    );
+};

--- a/mobile/src/components/Screen.test.tsx
+++ b/mobile/src/components/Screen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { AppText } from './AppText';
 import { Screen } from './Screen';
@@ -39,5 +39,17 @@ describe('Screen', () => {
         const contentStyle = StyleSheet.flatten(view.getByTestId('responsive-screen').props.contentContainerStyle);
 
         expect(contentStyle.paddingBottom).toBe(88);
+    });
+
+    it('uses the shared keyboard-aware scroller for form content', () => {
+        const view = render(
+            <Screen testID="responsive-screen">
+                <AppText>Account form</AppText>
+            </Screen>
+        );
+
+        const scroller = view.UNSAFE_getByType(ScrollView);
+        expect(scroller.props.keyboardDismissMode).toBe('on-drag');
+        expect(scroller.props.keyboardShouldPersistTaps).toBe('handled');
     });
 });

--- a/mobile/src/components/Screen.tsx
+++ b/mobile/src/components/Screen.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Platform, ScrollView, StyleSheet, View, type ViewProps, useWindowDimensions } from 'react-native';
+import { Platform, StyleSheet, View, type ViewProps, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type AppTheme, useAppTheme } from '../theme';
+import { KeyboardAwareScrollView } from './KeyboardAwareScrollView';
 
 type ScreenProps = ViewProps & {
     scroll?: boolean;
@@ -66,19 +67,17 @@ export const Screen: React.FC<ScreenProps> = ({
     }
 
     return (
-        <ScrollView
+        <KeyboardAwareScrollView
             {...viewProps}
             accessibilityRole={accessibilityRole}
             role={resolvedRole}
             focusable={Platform.OS === 'web'}
             tabIndex={Platform.OS === 'web' ? -1 : undefined}
             contentContainerStyle={contentStyle}
-            keyboardDismissMode="on-drag"
-            keyboardShouldPersistTaps="handled"
             style={styles.scroller}
         >
             {children}
-        </ScrollView>
+        </KeyboardAwareScrollView>
     );
 };
 

--- a/mobile/src/hooks/useVisualViewportHeight.ts
+++ b/mobile/src/hooks/useVisualViewportHeight.ts
@@ -1,0 +1,4 @@
+/** Native layouts receive keyboard dimensions from React Native. */
+export function useVisualViewportHeight(): number | undefined {
+    return undefined;
+}

--- a/mobile/src/hooks/useVisualViewportHeight.web.ts
+++ b/mobile/src/hooks/useVisualViewportHeight.web.ts
@@ -1,0 +1,25 @@
+import { useSyncExternalStore } from 'react';
+
+function subscribe(onStoreChange: () => void): () => void {
+    const viewport = window.visualViewport;
+    if (!viewport) {
+        window.addEventListener('resize', onStoreChange);
+        return () => window.removeEventListener('resize', onStoreChange);
+    }
+
+    viewport.addEventListener('resize', onStoreChange);
+    viewport.addEventListener('scroll', onStoreChange);
+    return () => {
+        viewport.removeEventListener('resize', onStoreChange);
+        viewport.removeEventListener('scroll', onStoreChange);
+    };
+}
+
+function getSnapshot(): number {
+    return Math.round(window.visualViewport?.height ?? window.innerHeight);
+}
+
+/** Uses the browser's unobscured viewport rather than the layout viewport behind a software keyboard. */
+export function useVisualViewportHeight(): number | undefined {
+    return useSyncExternalStore(subscribe, getSnapshot, () => undefined);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4522,6 +4522,27 @@
         "node": ">= 5.10.0"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -8948,27 +8969,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minipass": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.6",
+      "version": "0.12.7",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.6",
+    "version": "0.12.7",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## What changed

- add a shared keyboard-aware scroll container for screens, bottom sheets, and onboarding
- keep focused fields plus nearby validation, actions, or initial search results visible when native keyboard dimensions change
- re-scroll focused input when asynchronous content such as food-search results changes the layout
- size mobile web/PWA layouts and modal sheets from the browser visual viewport so the system keyboard cannot obscure them
- add regression coverage for keyboard interaction defaults and context padding
- bump the canonical server release and package mirrors to `0.12.7`; native phone and Wear versions remain unchanged because this is a JavaScript/web-only patch

## Why

Food search results and other information immediately below focused inputs could render behind the system keyboard. Existing Android resize configuration and iOS inset adjustment kept some inputs reachable, but the shared scroll containers did not reserve visible context below the focused control or react when results arrived asynchronously. Mobile browsers also size fixed modals from the layout viewport, which can extend behind the visual keyboard.

## Validation

- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile test -- --runInBand` (83 suites, 336 tests)
- `npm.cmd --prefix mobile run build:web`
- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 tests)
- `git diff --check`

Android emulator QA was attempted, but no ADB target was connected in the workspace.