### PR TITLE
Fix barcode food logging

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/app/barcode.tsx
+++ b/mobile/app/barcode.tsx
@@ -6,7 +6,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { MEAL_PERIODS, type MealPeriod } from '@calibrate/shared';
-import type { FoodLogCreatePayload, FoodSearchResult } from '@calibrate/api-client';
+import type { FoodLogCreatePayload } from '@calibrate/api-client';
 import { AppButton } from '../src/components/AppButton';
 import { AppCard } from '../src/components/AppCard';
 import { AppText } from '../src/components/AppText';
@@ -27,30 +27,14 @@ import {
     getBarcodeLookupErrorMessage,
     getBarcodeLookupStatus,
     getCameraPermissionState,
-    getProviderAttribution
+    getProviderAttribution,
+    resolveBarcodeFoodMatch
 } from '../src/barcode/workflow';
 
 function parseMeal(value: unknown): MealPeriod {
     return typeof value === 'string' && MEAL_OPTIONS.includes(value as MealPeriod)
         ? value as MealPeriod
         : MEAL_PERIODS.BREAKFAST;
-}
-
-function buildBarcodeFoodPayload(result: FoodSearchResult, code: string, date: string, meal: MealPeriod): FoodLogCreatePayload {
-    const calories = typeof result.calories === 'number' ? Math.round(result.calories) : 0;
-
-    return {
-        date,
-        meal_period: meal,
-        name: result.name,
-        calories,
-        servings_consumed: 1,
-        calories_per_serving_snapshot: calories,
-        external_source: result.source ?? null,
-        external_id: result.id,
-        brand: result.brand ?? null,
-        barcode: result.barcode ?? code
-    };
 }
 
 export default function BarcodeScreen() {
@@ -73,14 +57,13 @@ export default function BarcodeScreen() {
         mutationFn: (code: string) => api.searchFood('', code)
     });
     const logFood = useMutation({
-        mutationFn: (result: FoodSearchResult) => {
+        mutationFn: (payload: FoodLogCreatePayload) => {
             if (foodDayQuery.data?.status !== 'OPEN') {
                 throw new Error('Backfill this day before adding food.');
             }
             if (!barcode) {
                 throw new Error('Scan a barcode before logging food.');
             }
-            const payload = buildBarcodeFoodPayload(result, barcode, selectedDate, meal);
             return executeOrQueueMutation({
                 operation: OFFLINE_MUTATION_OPERATIONS.CREATE_FOOD_LOG,
                 payload,
@@ -252,12 +235,20 @@ export default function BarcodeScreen() {
         lookup.mutate(decision.barcode);
     }
 
-    const first = lookup.data?.items[0];
+    const firstProviderItem = lookup.data?.items[0];
+    const match = barcode
+        ? resolveBarcodeFoodMatch({
+              value: firstProviderItem,
+              barcode,
+              date: selectedDate,
+              meal
+          })
+        : null;
     const lookupStatus = getBarcodeLookupStatus({
         hasBarcode: barcode !== null,
         isPending: lookup.isPending,
         isSuccess: lookup.isSuccess,
-        hasResult: Boolean(first),
+        hasResult: Boolean(match),
         hasError: Boolean(lookup.error)
     });
     const providerAttribution = getProviderAttribution(lookup.data?.provider, lookup.data?.attribution);
@@ -283,7 +274,17 @@ export default function BarcodeScreen() {
     else if (lookupStatus === 'searching') statusMessage = 'Searching food providers...';
     else if (lookupStatus === 'no-result') statusMessage = 'No matching food was found. Try again or scan a different barcode.';
     else if (lookupStatus === 'error' && lookupErrorMessage) statusMessage = lookupErrorMessage;
-    else if (lookupStatus === 'result' && first) statusMessage = `Found ${first.name}.`;
+    else if (lookupStatus === 'result' && match) statusMessage = `Found ${match.item.name}.`;
+
+    const resultDetails = match
+        ? [match.item.brand, match.measure?.label].filter(Boolean).join(' | ')
+        : '';
+    let logButtonTitle = `Log to ${selectedDate}`;
+    if (logFood.isPending) {
+        logButtonTitle = 'Logging...';
+    } else if (match?.calories !== null && match?.calories !== undefined) {
+        logButtonTitle = `Log ${formatCalories(match.calories)} to ${selectedDate}`;
+    }
 
     return (
         <Screen scroll={false} style={styles.root}>
@@ -316,15 +317,22 @@ export default function BarcodeScreen() {
                     >
                         {statusMessage}
                     </AppText>
-                    {first && (
+                    {match && (
                         <View
                             accessible
-                            accessibilityLabel={`${first.name}, ${first.brand ?? 'provider result'}, ${formatCalories(first.calories)}`}
+                            accessibilityLabel={`${match.item.name}, ${resultDetails || 'provider result'}, ${formatCalories(match.calories)}`}
                             style={styles.result}
                         >
-                            <AppText variant="body">{first.name}</AppText>
-                            <AppText variant="caption">{first.brand ?? 'Food provider result'}</AppText>
-                            <AppText variant="label">{formatCalories(first.calories)}</AppText>
+                            <AppText variant="body">{match.item.name}</AppText>
+                            <AppText variant="caption">{resultDetails || 'Food provider result'}</AppText>
+                            {match.calories !== null && (
+                                <AppText variant="label">{formatCalories(match.calories)}</AppText>
+                            )}
+                            {match.error && (
+                                <AppText accessibilityRole="alert" style={styles.error}>
+                                    {match.error}
+                                </AppText>
+                            )}
                         </View>
                     )}
                     {providerAttribution && (
@@ -360,11 +368,11 @@ export default function BarcodeScreen() {
                     <AppButton
                         accessibilityRole="button"
                         accessibilityHint="Adds the matched food to the selected day and meal."
-                        title={logFood.isPending ? 'Logging...' : `Log to ${selectedDate}`}
-                        disabled={!first || lookupStatus !== 'result' || logFood.isPending}
+                        title={logButtonTitle}
+                        disabled={!match?.payload || lookupStatus !== 'result' || logFood.isPending}
                         leftIcon={<Ionicons name="add" size={18} color={theme.colors.onPrimary} />}
                         onPress={() => {
-                            if (first) logFood.mutate(first);
+                            if (match?.payload) logFood.mutate(match.payload);
                         }}
                     />
                     {(lookupStatus === 'no-result' || lookupStatus === 'error') && barcode && (

--- a/mobile/src/barcode/workflow.test.ts
+++ b/mobile/src/barcode/workflow.test.ts
@@ -1,10 +1,12 @@
+import { MEAL_PERIODS } from '@calibrate/shared';
 import {
     BarcodeScanGate,
     getBarcodeLookupErrorMessage,
     getBarcodeLookupStatus,
     getCameraPermissionState,
     getProviderAttribution,
-    normalizeBarcode
+    normalizeBarcode,
+    resolveBarcodeFoodMatch
 } from './workflow';
 
 describe('barcode workflow', () => {
@@ -67,5 +69,73 @@ describe('barcode workflow', () => {
         });
         expect(getProviderAttribution('openFoodFacts')).toEqual({ text: 'Data from Open Food Facts' });
         expect(getProviderAttribution(undefined, 'Provider attribution')).toEqual({ text: 'Provider attribution' });
+    });
+
+    it('converts provider barcode metadata into a complete one-serving food log', () => {
+        const match = resolveBarcodeFoodMatch({
+            value: {
+                id: 'provider-food-1',
+                source: 'openFoodFacts',
+                description: 'Greek yogurt',
+                brand: 'Example Dairy',
+                availableMeasures: [
+                    { label: 'per 100g', gramWeight: 100, quantity: 100, unit: 'g' },
+                    { label: '1 container', gramWeight: 170, quantity: 1, unit: 'container' }
+                ],
+                nutrientsPer100g: { calories: 59 }
+            },
+            barcode: '012345678905',
+            date: '2026-07-24',
+            meal: MEAL_PERIODS.BREAKFAST
+        });
+
+        expect(match).toMatchObject({
+            item: {
+                name: 'Greek yogurt',
+                brand: 'Example Dairy',
+                barcode: '012345678905'
+            },
+            measure: { label: '1 container', gramWeight: 170 },
+            calories: 100,
+            error: null,
+            payload: {
+                date: '2026-07-24',
+                meal_period: MEAL_PERIODS.BREAKFAST,
+                name: 'Greek yogurt',
+                calories: 100,
+                external_source: 'openFoodFacts',
+                external_id: 'provider-food-1',
+                brand: 'Example Dairy',
+                barcode: '012345678905',
+                measure_label: '1 container',
+                grams_per_measure_snapshot: 170,
+                grams_total_snapshot: 170
+            }
+        });
+    });
+
+    it('keeps partial provider matches readable but blocks logging without serving metadata', () => {
+        const match = resolveBarcodeFoodMatch({
+            value: {
+                id: 'partial-food',
+                source: 'openFoodFacts',
+                description: 'Mystery snack',
+                brand: 'Corner Market',
+                availableMeasures: []
+            },
+            barcode: '012345678905',
+            date: '2026-07-24',
+            meal: MEAL_PERIODS.LUNCH
+        });
+
+        expect(match).toMatchObject({
+            item: {
+                name: 'Mystery snack',
+                brand: 'Corner Market'
+            },
+            calories: null,
+            payload: null,
+            error: 'This food does not include a usable serving measure.'
+        });
     });
 });

--- a/mobile/src/barcode/workflow.ts
+++ b/mobile/src/barcode/workflow.ts
@@ -1,3 +1,13 @@
+import type { FoodLogCreatePayload } from '@calibrate/api-client';
+import type { MealPeriod } from '@calibrate/shared';
+import {
+    buildSearchedFoodLogPayload,
+    getPreferredFoodMeasureIndex,
+    normalizeSearchedFoodItem,
+    type ProviderFoodMeasure,
+    type SearchedFoodItem
+} from '../food/serving';
+
 const BARCODE_DUPLICATE_WINDOW_MS = 1_200;
 const SUPPORTED_BARCODE_LENGTHS = new Set([6, 7, 8, 12, 13]);
 const FATSECRET_URL = 'https://www.fatsecret.com';
@@ -15,6 +25,60 @@ export type ProviderAttribution = {
     text: string;
     url?: string;
 };
+
+export type BarcodeFoodMatch = {
+    item: SearchedFoodItem;
+    measure: ProviderFoodMeasure | null;
+    calories: number | null;
+    payload: FoodLogCreatePayload | null;
+    error: string | null;
+};
+
+/**
+ * Convert the provider wire shape into the same complete serving snapshot used by text search.
+ * Barcode providers return `description`, nested nutrients, and measures rather than flattened
+ * `name` and `calories` fields.
+ */
+export function resolveBarcodeFoodMatch(options: {
+    value: unknown;
+    barcode: string;
+    date: string;
+    meal: MealPeriod;
+}): BarcodeFoodMatch | null {
+    const normalizedItem = normalizeSearchedFoodItem(options.value);
+    if (!normalizedItem) return null;
+
+    const item = normalizedItem.barcode
+        ? normalizedItem
+        : { ...normalizedItem, barcode: options.barcode };
+    const preferredMeasureIndex = getPreferredFoodMeasureIndex(item);
+    const measure = preferredMeasureIndex === null ? null : item.measures[preferredMeasureIndex];
+    const result = buildSearchedFoodLogPayload({
+        item,
+        measure,
+        quantity: 1,
+        date: options.date,
+        meal: options.meal
+    });
+
+    if (!result.ok) {
+        return {
+            item,
+            measure,
+            calories: null,
+            payload: null,
+            error: result.message
+        };
+    }
+
+    return {
+        item,
+        measure,
+        calories: result.calculation.calories,
+        payload: result.payload,
+        error: null
+    };
+}
 
 /** Decide whether the current platform can prompt again or must hand control to settings. */
 export function getCameraPermissionState(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -594,20 +594,40 @@ export type FoodLogUpdatePayload = Partial<{
     servings_consumed: number | null;
 }>;
 
+export type FoodSearchNutrients = {
+    calories: number;
+    protein?: number;
+    fat?: number;
+    carbs?: number;
+};
+
+export type FoodSearchMeasure = {
+    label: string;
+    gramWeight?: number;
+    quantity?: number;
+    unit?: string;
+};
+
 export type FoodSearchResult = {
     id: string;
-    name: string;
-    brand?: string | null;
-    calories?: number | null;
-    source?: string;
-    barcode?: string | null;
-    servingSize?: string | null;
-    measures?: unknown[];
+    source: string;
+    description: string;
+    brand?: string;
+    barcode?: string;
+    locale?: string;
+    availableMeasures: FoodSearchMeasure[];
+    nutrientsPer100g?: FoodSearchNutrients;
+    nutrientsForRequest?: {
+        grams: number;
+        nutrients: FoodSearchNutrients;
+        note?: string;
+    };
 };
 
 export type FoodSearchResponse = {
     items: FoodSearchResult[];
     provider?: string;
+    supportsBarcodeLookup?: boolean;
     attribution?: string;
 };
 

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.7",
+    "version": "0.12.8",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- normalize barcode lookup results through the same provider-serving path used by text search
- choose a practical one-serving measure, calculate calories, and preserve the complete provider, barcode, measure, and gram snapshot
- render partial provider records with an actionable missing-data message instead of undefined metadata or a malformed log request
- correct the API-client food-search wire types and bump the canonical patch release to `0.12.8`

## Root cause

The barcode screen still expected a legacy flattened result containing `name` and `calories`. The current provider contract returns `description`, `availableMeasures`, and nested `nutrientsPer100g`. Fields such as provider and brand could therefore appear while the food name, calories, and log payload remained undefined.

## User impact

A scanned UPC/EAN with complete provider data now resolves into a loggable one-serving food entry with accurate calorie and serving snapshots. Genuinely incomplete provider records remain visible by name and brand, but logging is disabled with a specific explanation instead of submitting invalid data.

## Rebase

- rebased onto `master` after #255
- retains #253's `brace-expansion` audit remediation; the production audit reports zero vulnerabilities locally
- advances the canonical release from `0.12.7` to `0.12.8`

## Validation

- `npm.cmd audit --omit=dev --audit-level=high` - 0 vulnerabilities
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile test -- --runInBand` - 83 suites / 340 tests
- `npm.cmd --prefix mobile run build:web` - 31 static routes, including `/barcode`
- `npm.cmd --prefix packages/api-client test` - 43 tests
- `npm.cmd run api:contract:check`
- `npm.cmd run release:check`
- `npm.cmd run test:release` - 20 tests
- `git diff --check`

Physical camera scanning was not repeated in this worktree. The repository's standing physical Galaxy phone/Watch evidence item remains reported by `release:check` and should be completed during device review.
