### PR TITLE
Normalize Expo OTA native fingerprint

### DIFF
--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -221,6 +221,9 @@ message. No native build tag is supplied. Expo selects clients by project, Andro
 receive the update. The workflow derives the previous `master` commit from the push event and stops before publishing
 if the native fingerprint changed without an app-version change. Increment the mobile app version and create a new
 signed native build whenever native dependencies, config plugins, icons, permissions, or other native inputs change.
+The fingerprint is normalized to those native inputs: Expo/EAS config, native assets, config plugins, local native
+modules, Wear sources, and resolved packages that contribute Android code. Server release policy, application
+JavaScript, root package metadata, and JS-only or tooling-only dependency changes remain OTA-compatible.
 OTA updates never update the Wear app.
 
 After testing the automatic internal deployment, open its workflow run in GitHub Actions and approve the waiting

--- a/scripts/expo-ota-ci-preflight.mjs
+++ b/scripts/expo-ota-ci-preflight.mjs
@@ -111,12 +111,12 @@ function runCommand(command, args, cwd, allowFailure = false) {
   };
 }
 
-function readExpoProject(root) {
+function readExpoProject(root, packageMetadataRoot = root) {
   const appConfig = JSON.parse(fs.readFileSync(path.join(root, 'mobile', 'app.json'), 'utf8'));
   return {
     appVersion: appConfig.expo?.version,
     projectId: appConfig.expo?.extra?.eas?.projectId,
-    nativeFingerprint: createNativeRuntimeFingerprint(root).sha256
+    nativeFingerprint: createNativeRuntimeFingerprint(root, { packageMetadataRoot }).sha256
   };
 }
 
@@ -134,7 +134,7 @@ function readPreviousExpoProject(root, previousRef) {
   const checkout = path.join(temporaryDirectory, 'previous-master');
   try {
     runCommand('git', ['worktree', 'add', '--detach', checkout, commit], root);
-    return { commit, project: readExpoProject(checkout) };
+    return { commit, project: readExpoProject(checkout, root) };
   } finally {
     runCommand('git', ['worktree', 'remove', '--force', checkout], root, true);
     fs.rmSync(temporaryDirectory, { recursive: true, force: true });

--- a/scripts/native-ota-contract.mjs
+++ b/scripts/native-ota-contract.mjs
@@ -17,11 +17,9 @@ const NATIVE_INPUT_FILES = Object.freeze([
   'mobile/app.json',
   'mobile/app.config.js',
   'mobile/eas.json',
-  'mobile/package.json',
   'mobile/assets/adaptive-icon.png',
   'mobile/assets/icon.png',
-  'mobile/assets/notification-icon.png',
-  'shared/release.json'
+  'mobile/assets/notification-icon.png'
 ]);
 
 const NATIVE_INPUT_DIRECTORIES = Object.freeze([
@@ -31,6 +29,17 @@ const NATIVE_INPUT_DIRECTORIES = Object.freeze([
 ]);
 
 const GENERATED_DIRECTORY_NAMES = new Set(['.gradle', '.kotlin', '.cxx', 'build', 'node_modules']);
+
+const NATIVE_BUILD_TOOL_PACKAGES = new Set([
+  '@expo/config',
+  '@expo/config-plugins',
+  '@expo/image-utils',
+  '@expo/prebuild-config',
+  '@expo/sdk-runtime-versions',
+  'expo',
+  'hermes-engine',
+  'react-native'
+]);
 
 function normalizedRelativePath(root, file) {
   return path.relative(root, file).split(path.sep).join('/');
@@ -67,8 +76,15 @@ function dependencyPackageKey(packages, currentKey, dependencyName) {
   return packages[rootKey] ? rootKey : null;
 }
 
-/** Select only the production dependency graph reachable from the mobile workspace. */
-export function createMobileLockSnapshot(lock) {
+function packageNameFromLockEntry(key, entry) {
+  if (entry.name) return entry.name;
+  const marker = key.lastIndexOf('node_modules/');
+  if (marker < 0) return null;
+  const segments = key.slice(marker + 'node_modules/'.length).split('/');
+  return segments[0]?.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+}
+
+function productionPackageEntries(lock) {
   const packages = lock?.packages;
   if (!packages?.mobile) throw new Error('package-lock.json is missing the mobile workspace.');
   const selected = new Map();
@@ -90,13 +106,56 @@ export function createMobileLockSnapshot(lock) {
       if (dependencyKey) pending.push(dependencyKey);
     }
   }
-  return [...selected.entries()]
+  return selected;
+}
+
+function expoModuleSupportsAndroid(packageDirectory) {
+  const configPath = path.join(packageDirectory, 'expo-module.config.json');
+  if (!fs.existsSync(configPath)) return false;
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  return config.platforms?.includes('android') || config.android !== undefined;
+}
+
+function packageContributesAndroidNativeCode(packageDirectory, packageName) {
+  if (NATIVE_BUILD_TOOL_PACKAGES.has(packageName)) return true;
+  if (!fs.existsSync(packageDirectory)) return false;
+  return fs.existsSync(path.join(packageDirectory, 'android')) ||
+    expoModuleSupportsAndroid(packageDirectory) ||
+    fs.existsSync(path.join(packageDirectory, 'app.plugin.js')) ||
+    fs.existsSync(path.join(packageDirectory, 'react-native.config.js'));
+}
+
+/** Discover installed production packages that contribute Android code or native configuration. */
+export function discoverAndroidNativePackageNames(root, lock) {
+  const packageNames = new Set();
+  for (const [key, entry] of productionPackageEntries(lock)) {
+    const packageName = packageNameFromLockEntry(key, entry);
+    if (!packageName) continue;
+    const packageDirectory = path.join(root, key);
+    if (packageContributesAndroidNativeCode(packageDirectory, packageName)) packageNames.add(packageName);
+  }
+  return packageNames;
+}
+
+/** Snapshot resolved native package identities without hashing unrelated JS and tooling dependencies. */
+export function createAndroidNativeLockSnapshot(lock, nativePackageNames) {
+  return [...productionPackageEntries(lock).entries()]
+    .map(([key, value]) => [key, packageNameFromLockEntry(key, value), value])
+    .filter(([, packageName]) => packageName && nativePackageNames.has(packageName))
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => [key, value]);
+    .map(([key, packageName, value]) => [
+      key,
+      {
+        name: packageName,
+        version: value.version ?? null,
+        resolved: value.resolved ?? null,
+        integrity: value.integrity ?? null
+      }
+    ]);
 }
 
 /** Hash every tracked input that can change the Android or Wear native runtime. */
-export function createNativeRuntimeFingerprint(root) {
+export function createNativeRuntimeFingerprint(root, options = {}) {
   const files = [
     ...NATIVE_INPUT_FILES.map((file) => path.join(root, file)),
     ...NATIVE_INPUT_DIRECTORIES.flatMap((directory) => filesUnder(root, directory))
@@ -115,14 +174,20 @@ export function createNativeRuntimeFingerprint(root) {
     digest.update('\0');
   }
   const lock = JSON.parse(fs.readFileSync(path.join(root, 'package-lock.json'), 'utf8'));
-  digest.update('mobile-package-lock\0');
-  digest.update(JSON.stringify(createMobileLockSnapshot(lock)));
+  const packageMetadataRoot = options.packageMetadataRoot ?? root;
+  const metadataLock = packageMetadataRoot === root
+    ? lock
+    : JSON.parse(fs.readFileSync(path.join(packageMetadataRoot, 'package-lock.json'), 'utf8'));
+  const nativePackageNames = options.nativePackageNames ??
+    discoverAndroidNativePackageNames(packageMetadataRoot, metadataLock);
+  digest.update('android-native-package-lock\0');
+  digest.update(JSON.stringify(createAndroidNativeLockSnapshot(lock, nativePackageNames)));
   digest.update('\0');
   return {
     sha256: digest.digest('hex'),
     files: [
       ...files.map((file) => normalizedRelativePath(root, file)),
-      'package-lock.json#mobile-production-graph'
+      'package-lock.json#android-native-packages'
     ]
   };
 }

--- a/scripts/native-ota-contract.test.mjs
+++ b/scripts/native-ota-contract.test.mjs
@@ -5,8 +5,9 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
-  createMobileLockSnapshot,
+  createAndroidNativeLockSnapshot,
   createNativeRuntimeFingerprint,
+  discoverAndroidNativePackageNames,
   resolveExpoUpdateBuildConfig,
   writeNativeOtaBaseline
 } from './native-ota-contract.mjs';
@@ -14,6 +15,7 @@ import {
 function createFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'calibrate-ota-contract-'));
   for (const file of [
+    'package.json',
     'mobile/app.json',
     'mobile/app.config.js',
     'mobile/eas.json',
@@ -28,22 +30,89 @@ function createFixture() {
   ]) {
     const absolute = path.join(root, file);
     fs.mkdirSync(path.dirname(absolute), { recursive: true });
-    const contents = file === 'mobile/app.json' ? '{"expo":{"version":"0.1.0"}}' : file;
+    let contents = file;
+    if (file === 'mobile/app.json') {
+      contents = JSON.stringify({
+        expo: {
+          version: '0.1.0',
+          android: {
+            permissions: ['CAMERA']
+          }
+        }
+      });
+    } else if (file === 'shared/release.json') {
+      contents = JSON.stringify({
+        server: { version: '1.0.0' },
+        android: {
+          mobile: {
+            version_name: '0.1.0',
+            version_code: 1,
+            minimum_supported_version: '0.1.0'
+          }
+        }
+      });
+    } else if (file === 'package.json') {
+      contents = JSON.stringify({ name: 'cal-io', version: '1.0.0' });
+    } else if (file === 'mobile/package.json') {
+      contents = JSON.stringify({
+        dependencies: {
+          expo: '~57.0.7',
+          '@expo/dom-webview': '57.0.1',
+          'expo-camera': '~57.0.3',
+          'react-native': '0.86.0',
+          'js-library': '1.0.0'
+        }
+      });
+    }
     fs.writeFileSync(absolute, contents);
   }
   fs.writeFileSync(path.join(root, 'package-lock.json'), JSON.stringify({
     packages: {
-      mobile: { dependencies: { expo: '~57.0.7' } },
-      'node_modules/expo': { version: '57.0.7', dependencies: { '@expo/config': '1.0.0' } },
+      '': { name: 'cal-io', version: '1.0.0' },
+      mobile: {
+        name: 'mobile',
+        version: '0.1.0',
+        dependencies: {
+          expo: '~57.0.7',
+          'expo-camera': '~57.0.3',
+          'react-native': '0.86.0',
+          'js-library': '1.0.0'
+        }
+      },
+      'node_modules/expo': {
+        version: '57.0.7',
+        dependencies: {
+          '@expo/config': '1.0.0',
+          '@expo/dom-webview': '57.0.1'
+        }
+      },
       'node_modules/@expo/config': { version: '1.0.0' },
+      'node_modules/@expo/dom-webview': { version: '57.0.1' },
+      'node_modules/expo-camera': { version: '57.0.3' },
+      'node_modules/react-native': { version: '0.86.0' },
+      'node_modules/js-library': { version: '1.0.0', dependencies: { 'brace-expansion': '5.0.7' } },
+      'node_modules/brace-expansion': { version: '5.0.7' },
       backend: { dependencies: { express: '5.0.0' } },
       'node_modules/express': { version: '5.0.0' }
     }
   }));
+  for (const file of [
+    'node_modules/expo/android/build.gradle',
+    'node_modules/@expo/dom-webview/expo-module.config.json',
+    'node_modules/expo-camera/expo-module.config.json',
+    'node_modules/react-native/android/build.gradle'
+  ]) {
+    const absolute = path.join(root, file);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    const contents = file.endsWith('expo-module.config.json')
+      ? JSON.stringify({ platforms: ['android'], android: { modules: ['ExampleModule'] } })
+      : file;
+    fs.writeFileSync(absolute, contents);
+  }
   return root;
 }
 
-test('native runtime fingerprint changes for native inputs but ignores OTA-safe source', () => {
+test('native runtime fingerprint ignores server, JS source, and JS-only dependency changes', () => {
   const root = createFixture();
   try {
     const initial = createNativeRuntimeFingerprint(root);
@@ -51,29 +120,163 @@ test('native runtime fingerprint changes for native inputs but ignores OTA-safe 
     fs.writeFileSync(path.join(root, 'mobile', 'src', 'screen.tsx'), 'safe JS change');
     assert.equal(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
 
+    const releasePath = path.join(root, 'shared', 'release.json');
+    const release = JSON.parse(fs.readFileSync(releasePath, 'utf8'));
+    release.server.version = '1.0.1';
+    release.android.mobile.minimum_supported_version = '0.1.1';
+    fs.writeFileSync(releasePath, JSON.stringify(release));
+    assert.equal(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    const rootPackagePath = path.join(root, 'package.json');
+    fs.writeFileSync(rootPackagePath, JSON.stringify({ name: 'cal-io', version: '1.0.1' }));
+    assert.equal(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    const mobilePackagePath = path.join(root, 'mobile', 'package.json');
+    const mobilePackage = JSON.parse(fs.readFileSync(mobilePackagePath, 'utf8'));
+    mobilePackage.dependencies['js-library'] = '1.1.0';
+    fs.writeFileSync(mobilePackagePath, JSON.stringify(mobilePackage));
+    assert.equal(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    const lockPath = path.join(root, 'package-lock.json');
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    lock.packages[''].version = '1.0.1';
+    lock.packages['node_modules/js-library'].version = '1.1.0';
+    lock.packages['node_modules/brace-expansion'].version = '5.0.8';
+    fs.writeFileSync(lockPath, JSON.stringify(lock));
+    assert.equal(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('native runtime fingerprint changes for native packages, config, plugins, and assets', () => {
+  const root = createFixture();
+  try {
+    const initial = createNativeRuntimeFingerprint(root);
+    const lockPath = path.join(root, 'package-lock.json');
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    lock.packages['node_modules/expo-camera'].version = '57.0.4';
+    fs.writeFileSync(lockPath, JSON.stringify(lock));
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    lock.packages['node_modules/expo-camera'].version = '57.0.3';
+    lock.packages['node_modules/@expo/dom-webview'].version = '57.0.2';
+    fs.writeFileSync(lockPath, JSON.stringify(lock));
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    lock.packages['node_modules/@expo/dom-webview'].version = '57.0.1';
+    fs.writeFileSync(lockPath, JSON.stringify({
+      ...lock,
+      packages: {
+        ...lock.packages,
+        'node_modules/expo-camera': { version: '57.0.3' },
+        'node_modules/react-native': { version: '0.87.0' }
+      }
+    }));
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    fs.writeFileSync(lockPath, JSON.stringify({
+      ...lock,
+      packages: {
+        ...lock.packages,
+        'node_modules/expo-camera': { version: '57.0.3' },
+        'node_modules/react-native': { version: '0.86.0' }
+      }
+    }));
+    const appConfigPath = path.join(root, 'mobile', 'app.json');
+    const appConfig = JSON.parse(fs.readFileSync(appConfigPath, 'utf8'));
+    appConfig.expo.android.permissions.push('POST_NOTIFICATIONS');
+    fs.writeFileSync(appConfigPath, JSON.stringify(appConfig));
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    fs.writeFileSync(appConfigPath, JSON.stringify({
+      expo: {
+        version: '0.1.0',
+        android: {
+          permissions: ['CAMERA']
+        }
+      }
+    }));
     fs.writeFileSync(path.join(root, 'mobile', 'plugins', 'example.js'), 'native config change');
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    fs.writeFileSync(path.join(root, 'mobile', 'plugins', 'example.js'), 'mobile/plugins/example.js');
+    fs.writeFileSync(path.join(root, 'mobile', 'assets', 'icon.png'), 'changed native icon');
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    fs.writeFileSync(path.join(root, 'mobile', 'assets', 'icon.png'), 'mobile/assets/icon.png');
+    fs.writeFileSync(
+      path.join(root, 'mobile', 'modules', 'example', 'android', 'build.gradle'),
+      'changed local native module'
+    );
+    assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
+
+    fs.writeFileSync(
+      path.join(root, 'mobile', 'modules', 'example', 'android', 'build.gradle'),
+      'mobile/modules/example/android/build.gradle'
+    );
+    fs.writeFileSync(path.join(root, 'wear', 'app', 'build.gradle.kts'), 'changed Wear build');
     assert.notEqual(createNativeRuntimeFingerprint(root).sha256, initial.sha256);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('mobile lock snapshot ignores unrelated backend packages', () => {
+test('Android native lock snapshot excludes backend and JS-only packages', () => {
   const base = {
     packages: {
-      mobile: { dependencies: { expo: '57.0.7' } },
+      mobile: {
+        dependencies: {
+          expo: '57.0.7',
+          '@expo/dom-webview': '57.0.1',
+          'expo-camera': '57.0.3',
+          'js-library': '1.0.0'
+        }
+      },
       'node_modules/expo': { version: '57.0.7' },
+      'node_modules/@expo/dom-webview': { version: '57.0.1' },
+      'node_modules/expo-camera': { version: '57.0.3' },
+      'node_modules/js-library': { version: '1.0.0', dependencies: { 'brace-expansion': '5.0.7' } },
+      'node_modules/brace-expansion': { version: '5.0.7' },
       backend: { dependencies: { express: '5.0.0' } },
       'node_modules/express': { version: '5.0.0' }
     }
   };
+  const nativePackageNames = new Set(['@expo/dom-webview', 'expo', 'expo-camera']);
   const changedBackend = structuredClone(base);
   changedBackend.packages['node_modules/express'].version = '5.1.0';
-  assert.deepEqual(createMobileLockSnapshot(base), createMobileLockSnapshot(changedBackend));
+  const changedJs = structuredClone(base);
+  changedJs.packages['node_modules/brace-expansion'].version = '5.0.8';
+  assert.deepEqual(
+    createAndroidNativeLockSnapshot(base, nativePackageNames),
+    createAndroidNativeLockSnapshot(changedBackend, nativePackageNames)
+  );
+  assert.deepEqual(
+    createAndroidNativeLockSnapshot(base, nativePackageNames),
+    createAndroidNativeLockSnapshot(changedJs, nativePackageNames)
+  );
 
-  const changedMobile = structuredClone(base);
-  changedMobile.packages['node_modules/expo'].version = '57.0.8';
-  assert.notDeepEqual(createMobileLockSnapshot(base), createMobileLockSnapshot(changedMobile));
+  const changedNative = structuredClone(base);
+  changedNative.packages['node_modules/expo-camera'].version = '57.0.4';
+  assert.notDeepEqual(
+    createAndroidNativeLockSnapshot(base, nativePackageNames),
+    createAndroidNativeLockSnapshot(changedNative, nativePackageNames)
+  );
+});
+
+test('Android native package discovery uses installed module metadata', () => {
+  const root = createFixture();
+  try {
+    const lock = JSON.parse(fs.readFileSync(path.join(root, 'package-lock.json'), 'utf8'));
+    const nativePackageNames = discoverAndroidNativePackageNames(root, lock);
+    assert.equal(nativePackageNames.has('@expo/dom-webview'), true);
+    assert.equal(nativePackageNames.has('expo-camera'), true);
+    assert.equal(nativePackageNames.has('react-native'), true);
+    assert.equal(nativePackageNames.has('js-library'), false);
+    assert.equal(nativePackageNames.has('brace-expansion'), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('OTA build config validates project UUID and update channel', () => {


### PR DESCRIPTION
## Summary

- fingerprint the normalized Android native runtime contract instead of raw release and package manifests
- discover Android modules and config plugins from installed package metadata instead of package-name prefixes
- ignore server/minimum-client metadata, root/mobile package metadata, JS source, and pure-JS/tooling dependency churn
- retain native sensitivity for Expo/React Native packages, permissions, native assets, local native modules, and Wear inputs
- document the OTA compatibility boundary and add regression coverage

## Root cause

The preflight hashed raw `shared/release.json` and a broad mobile production dependency graph. A server-only version bump therefore changed the native fingerprint and incorrectly required a new app version/native build.

## Impact

The current signed Android 0.2.3 build remains compatible with the pending JS update. Routine server and pure-JS dependency changes no longer block OTA publishing, while genuine native changes still require an app-version bump and signed build.

## Validation

- `npm.cmd run test:native-release` (37 passing)
- `npm.cmd run test:release` (20 passing)
- `npm.cmd run release:check`
- exact previously failing preflight from `f052767` on channel `internal`, environment `preview` (passes; native inputs unchanged; runtime 0.2.3)
- signed 0.2.3 baseline preflight from `39a99cb` (passes)
- `npm.cmd audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `git diff --check`
