### PR TITLE
Fix Wear pairing recovery and stale complication updates

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.10",
+      "version": "0.12.11",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "calibrate-health-app",
     "owner": "calibrate-health",
     "scheme": "calibrate",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "orientation": "default",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",
@@ -18,7 +18,7 @@
     ],
     "android": {
       "package": "app.calibratehealth.mobile",
-      "versionCode": 5,
+      "versionCode": 6,
       "allowBackup": false,
       "softwareKeyboardLayoutMode": "resize",
       "adaptiveIcon": {
@@ -93,7 +93,7 @@
     ],
     "extra": {
       "calibrate": {
-        "nativeReleaseTag": "v0.12.4"
+        "nativeReleaseTag": "v0.12.10"
       },
       "router": {
         "origin": false

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -93,7 +93,7 @@
     ],
     "extra": {
       "calibrate": {
-        "nativeReleaseTag": "v0.12.10"
+        "nativeReleaseTag": "v0.12.11"
       },
       "router": {
         "origin": false

--- a/mobile/modules/wear-pairing/android/build.gradle
+++ b/mobile/modules/wear-pairing/android/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 group = 'app.calibratehealth'
-version = '0.2.3'
+version = '0.2.4'
 
 android {
   namespace 'app.calibratehealth.wearpairing'
   defaultConfig {
-    versionCode 5
-    versionName '0.2.3'
+    versionCode 6
+    versionName '0.2.4'
   }
 }
 

--- a/mobile/modules/wear-pairing/package.json
+++ b/mobile/modules/wear-pairing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calibrate/wear-pairing",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "main": "index.ts",
   "peerDependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "main": "index.js",
   "engines": {

--- a/mobile/src/wear/pairing.test.ts
+++ b/mobile/src/wear/pairing.test.ts
@@ -360,4 +360,43 @@ describe('Wear phone pairing coordinator', () => {
         expect(await readStoredWearPairing(ORIGIN, USER_ID + 1)).toBeNull();
         expect(transport.acknowledgeMessages).toHaveBeenLastCalledWith(['result']);
     });
+
+    it('retires a consumed request when the watch reports an exchange failure', async () => {
+        const transport = await beginPairing();
+        transport.listMessages.mockReturnValueOnce([{
+            id: 'hello', nodeId: 'node-1', path: WEAR_PAIRING_PATHS.HELLO,
+            payload: helloPayload(), receivedAt: NOW.getTime()
+        }]);
+        await processWearPairingInbox({
+            api: { issueWearPairingCredential: jest.fn().mockResolvedValue({ pairing_token: 'token' }) },
+            serverOrigin: ORIGIN, userId: USER_ID, transport, now: NOW
+        });
+        transport.listMessages.mockReturnValueOnce([{
+            id: 'failed-result',
+            nodeId: 'node-1',
+            path: WEAR_PAIRING_PATHS.RESULT,
+            payload: JSON.stringify({
+                ok: false,
+                request_id: 'request-1',
+                protocol_version: 1,
+                server_origin: ORIGIN,
+                watch_device_id: 'watch-1',
+                message: 'Pairing response was unavailable. Start pairing again.'
+            }),
+            receivedAt: NOW.getTime()
+        }]);
+
+        const result = await processWearPairingInbox({
+            api: { issueWearPairingCredential: jest.fn() },
+            serverOrigin: ORIGIN, userId: USER_ID, transport, now: NOW
+        });
+
+        expect(result).toEqual({
+            processed: 1,
+            paired: null,
+            errors: ['Pairing response was unavailable. Start pairing again.']
+        });
+        expect([...mockStorage.values()].some((value) => value.includes('"requestId":"request-1"'))).toBe(false);
+        expect(transport.acknowledgeMessages).toHaveBeenLastCalledWith(['failed-result']);
+    });
 });

--- a/mobile/src/wear/pairing.ts
+++ b/mobile/src/wear/pairing.ts
@@ -141,21 +141,35 @@ export function parsePairingHello(payload: string): PairingHello | null {
     }
 }
 
-function parsePairingResult(payload: string): (
-    Omit<StoredWearPairing, 'nodeId' | 'pairedAt'> & { requestId: string }
-) | null {
+type WearPairingResult = {
+    requestId: string;
+    serverOrigin: string;
+    watchDeviceId: string;
+} & (
+    | { ok: true; watchDeviceName: string | null }
+    | { ok: false; message: string }
+);
+
+function parsePairingResult(payload: string): WearPairingResult | null {
     try {
         const parsed = JSON.parse(payload) as Record<string, unknown>;
-        if (parsed.ok !== true || parsed.protocol_version !== WEAR_PAIRING_PROTOCOL_VERSION) return null;
+        if (
+            typeof parsed.ok !== 'boolean'
+            || parsed.protocol_version !== WEAR_PAIRING_PROTOCOL_VERSION
+        ) return null;
         const watchDeviceId = requiredText(parsed.watch_device_id, MAX_DEVICE_ID_LENGTH);
         const requestId = requiredText(parsed.request_id, MAX_REQUEST_ID_LENGTH);
         const serverOrigin = requiredText(parsed.server_origin, 2048);
+        if (!requestId || !watchDeviceId || !serverOrigin || new URL(serverOrigin).origin !== serverOrigin) return null;
+        if (!parsed.ok) {
+            const message = requiredText(parsed.message, 180);
+            return message ? { ok: false, requestId, watchDeviceId, serverOrigin, message } : null;
+        }
         const watchDeviceName = parsed.watch_device_name == null
             ? null
             : requiredText(parsed.watch_device_name, MAX_DEVICE_NAME_LENGTH);
-        if (!requestId || !watchDeviceId || !serverOrigin || new URL(serverOrigin).origin !== serverOrigin) return null;
         if (parsed.watch_device_name != null && watchDeviceName === null) return null;
-        return { requestId, watchDeviceId, watchDeviceName, serverOrigin };
+        return { ok: true, requestId, watchDeviceId, watchDeviceName, serverOrigin };
     } catch {
         return null;
     }
@@ -451,6 +465,14 @@ export async function processWearPairingInbox(options: {
                 result.serverOrigin !== origin
             ) {
                 errors.push('A watch reported a pairing result for a different Calibrate server.');
+                acknowledgedMessageIds.push(message.id);
+                continue;
+            }
+            if (!result.ok) {
+                await AsyncStorage.removeItem(pendingStorageKey(origin, options.userId));
+                pending = null;
+                processed += 1;
+                errors.push(result.message);
                 acknowledgedMessageIds.push(message.id);
                 continue;
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "mobile": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@calibrate/api-client": "file:../packages/api-client",
@@ -86,7 +86,7 @@
     },
     "mobile/modules/wear-pairing": {
       "name": "@calibrate/wear-pairing",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "peerDependencies": {
         "expo": "*",
         "expo-modules-core": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.10",
+      "version": "0.12.11",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.10",
+    "version": "0.12.11",
     "api": {
       "current": "v1",
       "supported": [
@@ -15,7 +15,7 @@
     "mobile": {
       "version_name": "0.2.4",
       "version_code": 6,
-      "native_release_tag": "v0.12.10",
+      "native_release_tag": "v0.12.11",
       "minimum_supported_version": "0.1.0"
     },
     "wear": {

--- a/shared/release.json
+++ b/shared/release.json
@@ -13,14 +13,14 @@
   "android": {
     "application_id": "app.calibratehealth.mobile",
     "mobile": {
-      "version_name": "0.2.3",
-      "version_code": 5,
-      "native_release_tag": "v0.12.4",
+      "version_name": "0.2.4",
+      "version_code": 6,
+      "native_release_tag": "v0.12.10",
       "minimum_supported_version": "0.1.0"
     },
     "wear": {
-      "version_name": "0.2.2",
-      "version_code": 4,
+      "version_name": "0.2.3",
+      "version_code": 5,
       "minimum_supported_version": "0.2.0"
     },
     "channels": {

--- a/wear/app/build.gradle.kts
+++ b/wear/app/build.gradle.kts
@@ -119,8 +119,8 @@ android {
         applicationId = "app.calibratehealth.mobile"
         minSdk = 30
         targetSdk = 36
-        versionCode = 4
-        versionName = "0.2.2"
+        versionCode = 5
+        versionName = "0.2.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "DEFAULT_SERVER_URL", quoteBuildConfig(configuredServerOrigin))

--- a/wear/app/src/main/java/app/calibratehealth/wear/pairing/PairingStateStore.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/pairing/PairingStateStore.kt
@@ -29,6 +29,13 @@ internal data class PairingSessionFacts(
 internal const val SESSION_RECOVERY_MESSAGE =
     "Watch sign-in expired. Pair again from Calibrate on your phone; queued changes will be preserved."
 
+/** A locally unexpired token is not a valid fallback after the server has rejected its session. */
+internal fun hasUsableFallbackSession(
+    isKnownInvalid: Boolean,
+    refreshExpiresAtEpochMs: Long?,
+    nowEpochMs: Long
+): Boolean = !isKnownInvalid && refreshExpiresAtEpochMs?.let { it > nowEpochMs } == true
+
 /** A compatibility-blocked watch must still probe so an in-place update or server rollback can recover. */
 internal fun PairingUiState.shouldAttemptForegroundSync(): Boolean =
     this is PairingUiState.Paired || this is PairingUiState.UpgradeRequired
@@ -129,14 +136,18 @@ internal class PairingStateStore(context: Context) {
     fun setError(message: String) {
         val bounded = message.trim().take(180).ifEmpty { "Pairing failed. Start pairing again on your phone." }
         readPending()?.let { WearPairingKeyManager().deleteOwned(it.keyAlias) }
-        val hasUsableSession = try {
+        val nowEpochMs = System.currentTimeMillis()
+        val refreshExpiresAtEpochMs = try {
             AndroidKeystoreTokenStore(appContext).read()
                 ?.refreshExpiresAtEpochMs
-                ?.let { it > System.currentTimeMillis() }
-                ?: false
         } catch (_: SecureTokenCorruptedException) {
-            false
+            null
         }
+        val hasUsableSession = hasUsableFallbackSession(
+            isKnownInvalid = preferences.getBoolean(SESSION_INVALID_KEY, false),
+            refreshExpiresAtEpochMs = refreshExpiresAtEpochMs,
+            nowEpochMs = nowEpochMs
+        )
         // A replacement attempt must not disable the still-valid session it was meant to supersede.
         val editor = preferences.edit()
             .remove(PENDING_KEY)
@@ -167,7 +178,13 @@ internal class PairingStateStore(context: Context) {
         }
         if (sessionAbsent) return
         val bounded = message.trim().take(180).ifEmpty { SESSION_RECOVERY_MESSAGE }
-        check(preferences.edit().remove(UPGRADE_REQUIRED_KEY).putString(ERROR_KEY, bounded).commit()) {
+        check(
+            preferences.edit()
+                .remove(UPGRADE_REQUIRED_KEY)
+                .putString(ERROR_KEY, bounded)
+                .putBoolean(SESSION_INVALID_KEY, true)
+                .commit()
+        ) {
             "Unable to persist Wear session recovery state."
         }
         PairingStateEvents.notifyChanged()
@@ -188,7 +205,11 @@ internal class PairingStateStore(context: Context) {
     }
 
     fun clearError() {
-        preferences.edit().remove(ERROR_KEY).remove(UPGRADE_REQUIRED_KEY).commit()
+        preferences.edit()
+            .remove(ERROR_KEY)
+            .remove(UPGRADE_REQUIRED_KEY)
+            .remove(SESSION_INVALID_KEY)
+            .commit()
         PairingStateEvents.notifyChanged()
     }
 
@@ -258,6 +279,7 @@ internal class PairingStateStore(context: Context) {
                 .remove(PENDING_RESULT_KEY)
                 .remove(ERROR_KEY)
                 .remove(UPGRADE_REQUIRED_KEY)
+                .remove(SESSION_INVALID_KEY)
                 .commit()
         ) { "Unable to clear local Wear pairing state." }
         TrustedPhoneBindingStore(appContext).clear()
@@ -270,6 +292,7 @@ internal class PairingStateStore(context: Context) {
         val upgradeRequired = preferences.getString(UPGRADE_REQUIRED_KEY, null)
         if (!upgradeRequired.isNullOrBlank()) return PairingUiState.UpgradeRequired(upgradeRequired)
         val error = preferences.getString(ERROR_KEY, null)
+            ?: SESSION_RECOVERY_MESSAGE.takeIf { preferences.getBoolean(SESSION_INVALID_KEY, false) }
         val hasPendingPairing = readPending(nowEpochMs) != null
         if (!error.isNullOrBlank() || hasPendingPairing) {
             return resolvePairingUiState(error, hasPendingPairing, null, false, nowEpochMs)
@@ -296,6 +319,7 @@ internal class PairingStateStore(context: Context) {
         private const val PENDING_RESULT_KEY = "pending_result"
         private const val ERROR_KEY = "pairing_error"
         private const val UPGRADE_REQUIRED_KEY = "client_upgrade_required"
+        private const val SESSION_INVALID_KEY = "session_invalid"
     }
 }
 

--- a/wear/app/src/main/java/app/calibratehealth/wear/pairing/PairingStateStore.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/pairing/PairingStateStore.kt
@@ -129,12 +129,25 @@ internal class PairingStateStore(context: Context) {
     fun setError(message: String) {
         val bounded = message.trim().take(180).ifEmpty { "Pairing failed. Start pairing again on your phone." }
         readPending()?.let { WearPairingKeyManager().deleteOwned(it.keyAlias) }
+        val hasUsableSession = try {
+            AndroidKeystoreTokenStore(appContext).read()
+                ?.refreshExpiresAtEpochMs
+                ?.let { it > System.currentTimeMillis() }
+                ?: false
+        } catch (_: SecureTokenCorruptedException) {
+            false
+        }
+        // A replacement attempt must not disable the still-valid session it was meant to supersede.
+        val editor = preferences.edit()
+            .remove(PENDING_KEY)
+            .remove(UPGRADE_REQUIRED_KEY)
+        if (hasUsableSession) {
+            editor.remove(ERROR_KEY)
+        } else {
+            editor.putString(ERROR_KEY, bounded)
+        }
         check(
-            preferences.edit()
-                .remove(PENDING_KEY)
-                .remove(UPGRADE_REQUIRED_KEY)
-                .putString(ERROR_KEY, bounded)
-                .commit()
+            editor.commit()
         ) {
             "Unable to persist Wear pairing error."
         }

--- a/wear/app/src/main/java/app/calibratehealth/wear/pairing/WearPairingListenerService.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/pairing/WearPairingListenerService.kt
@@ -122,8 +122,7 @@ class WearPairingListenerService : WearableListenerService() {
             if (stateStore.consumePending(pending) == null) return
 
             val keyManager = WearPairingKeyManager()
-            val resultPayload: String
-            try {
+            val resultPayload = try {
                 val exchangeId = UUID.randomUUID().toString()
                 val signature = keyManager.sign(
                     pending.keyAlias,
@@ -162,21 +161,15 @@ class WearPairingListenerService : WearableListenerService() {
                 CalibrateTileUpdate.request(context)
                 stateStore.clearError()
                 runCatching { WearSyncScheduler.scheduleAfterPairing(context) }
-                resultPayload = JSONObject()
-                    .put("ok", true)
-                    .put("request_id", pending.requestId)
-                    .put("protocol_version", WEAR_PAIRING_PROTOCOL_VERSION)
-                    .put("server_origin", pending.serverOrigin)
-                    .put("watch_device_id", pending.watchDeviceId)
-                    .put("watch_device_name", pending.watchDeviceName)
-                    .toString()
+                buildPairingResult(pending)
             } catch (error: Exception) {
+                val message = safeError(error)
                 if (error is WearUpgradeRequiredException) {
-                    stateStore.setUpgradeRequired(error.message ?: "Update Calibrate on this watch to continue.")
+                    stateStore.setUpgradeRequired(message)
                 } else {
-                    stateStore.setError(safeError(error))
+                    stateStore.setError(message)
                 }
-                return
+                buildPairingResult(pending, message)
             } finally {
                 keyManager.deleteOwned(pending.keyAlias)
             }

--- a/wear/app/src/main/java/app/calibratehealth/wear/pairing/WearPairingProtocol.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/pairing/WearPairingProtocol.kt
@@ -112,6 +112,25 @@ internal fun buildAccountDisconnectResult(command: PhoneAccountDisconnect): Stri
     )
 )
 
+/** Report both successful and failed exchanges so the phone can retire the consumed one-time request. */
+internal fun buildPairingResult(pending: PendingPairingInvite, errorMessage: String? = null): String {
+    val values = linkedMapOf(
+        "ok" to StrictJson.boolean(errorMessage == null),
+        "request_id" to StrictJson.string(pending.requestId),
+        "protocol_version" to StrictJson.number(WEAR_PAIRING_PROTOCOL_VERSION),
+        "server_origin" to StrictJson.string(pending.serverOrigin),
+        "watch_device_id" to StrictJson.string(pending.watchDeviceId)
+    )
+    if (errorMessage == null) {
+        values["watch_device_name"] = StrictJson.string(pending.watchDeviceName)
+    } else {
+        values["message"] = StrictJson.string(
+            errorMessage.trim().take(180).ifEmpty { "Pairing failed. Start pairing again on your phone." }
+        )
+    }
+    return StrictJson.stringify(StrictJson.objectOf(*values.toList().toTypedArray()))
+}
+
 internal fun parsePhonePairingInvite(
     fields: PairingFields,
     expectedServerOrigin: String,

--- a/wear/app/src/main/java/app/calibratehealth/wear/tile/CalibrateTileUpdate.kt
+++ b/wear/app/src/main/java/app/calibratehealth/wear/tile/CalibrateTileUpdate.kt
@@ -8,13 +8,18 @@ import app.calibratehealth.wear.complication.CalorieComplicationDataSourceServic
 
 /** Invalidates cache-only glance surfaces after a local cache or outbox state transition. */
 object CalibrateTileUpdate {
-    fun request(context: Context): Boolean = runCatching {
+    fun request(context: Context): Boolean {
         val appContext = context.applicationContext
-        TileService.getUpdater(appContext)
-            .requestUpdate(CalibrateTileService::class.java)
-        ComplicationDataSourceUpdateRequester.create(
-            appContext,
-            ComponentName(appContext, CalorieComplicationDataSourceService::class.java)
-        ).requestUpdateAll()
-    }.isSuccess
+        val tileRequested = runCatching {
+            TileService.getUpdater(appContext)
+                .requestUpdate(CalibrateTileService::class.java)
+        }.isSuccess
+        val complicationRequested = runCatching {
+            ComplicationDataSourceUpdateRequester.create(
+                appContext,
+                ComponentName(appContext, CalorieComplicationDataSourceService::class.java)
+            ).requestUpdateAll()
+        }.isSuccess
+        return tileRequested && complicationRequested
+    }
 }

--- a/wear/app/src/test/java/app/calibratehealth/wear/pairing/PairingUiStateTest.kt
+++ b/wear/app/src/test/java/app/calibratehealth/wear/pairing/PairingUiStateTest.kt
@@ -40,6 +40,26 @@ class PairingUiStateTest {
     }
 
     @Test
+    fun `server-rejected session is not a usable fallback for failed replacement pairing`() {
+        assertEquals(
+            false,
+            hasUsableFallbackSession(
+                isKnownInvalid = true,
+                refreshExpiresAtEpochMs = 2_000,
+                nowEpochMs = 1_000
+            )
+        )
+        assertEquals(
+            true,
+            hasUsableFallbackSession(
+                isKnownInvalid = false,
+                refreshExpiresAtEpochMs = 2_000,
+                nowEpochMs = 1_000
+            )
+        )
+    }
+
+    @Test
     fun `new pending pairing takes precedence over an expired session`() {
         assertEquals(
             PairingUiState.Pairing,

--- a/wear/app/src/test/java/app/calibratehealth/wear/pairing/WearPairingProtocolTest.kt
+++ b/wear/app/src/test/java/app/calibratehealth/wear/pairing/WearPairingProtocolTest.kt
@@ -91,6 +91,24 @@ class WearPairingProtocolTest {
     }
 
     @Test
+    fun `pairing results report both success and bounded failure to the phone`() {
+        val pending = pendingInvite()
+        assertEquals(
+            "{\"ok\":true,\"request_id\":\"b48ae280-4d9d-43d8-99cb-59c8c04ff766\"," +
+                "\"protocol_version\":1,\"server_origin\":\"https://health.example.com\"," +
+                "\"watch_device_id\":\"watch-id\",\"watch_device_name\":\"Galaxy Watch\"}",
+            buildPairingResult(pending)
+        )
+        assertEquals(
+            "{\"ok\":false,\"request_id\":\"b48ae280-4d9d-43d8-99cb-59c8c04ff766\"," +
+                "\"protocol_version\":1,\"server_origin\":\"https://health.example.com\"," +
+                "\"watch_device_id\":\"watch-id\"," +
+                "\"message\":\"Pairing response was unavailable. Start pairing again.\"}",
+            buildPairingResult(pending, " Pairing response was unavailable. Start pairing again. ")
+        )
+    }
+
+    @Test
     fun `signing payload exactly matches backend protocol bytes`() {
         val payload = buildPairingSigningPayload(
             origin,


### PR DESCRIPTION
## Summary

- send correlated failed pairing results from Wear back to the phone so consumed one-time requests are retired
- preserve a still-valid watch session when a replacement pairing attempt fails
- preserve server-rejected session state when a replacement pairing also fails
- refresh the calorie complication independently from the Tile
- bump the release candidate to server `0.12.11`, phone `0.2.4 (6)`, and Wear `0.2.3 (5)`

## Root cause

The watch consumed the one-time pairing credential before attempting the direct server exchange. When that exchange failed, it stored the error locally and returned without reporting a terminal result to the phone. The phone therefore retained an in-flight request and stale pairing metadata, while the watch pairing error masked an otherwise usable prior session and stopped current calorie state from reaching the complication.

A recovery retry also inferred fallback-session usability only from local token expiry. That allowed a server-rejected session to appear paired again after the retry failed.

Tile and complication invalidation also shared one exception boundary, so an update failure for one glance surface could suppress the other.

## Validation

- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 passed)
- `npm.cmd run test:native-release` (37 passed)
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile test -- --runInBand` (83 suites, 340 tests)
- `wear\gradlew.bat testDebugUnitTest`
- `git diff --check`

## Physical validation pending

Do not merge until the signed phone and Wear candidates have been installed in place and validated on the Galaxy phone and Galaxy Watch Ultra. Confirm fresh pairing recovery, paused calorie tracking on the complication, and preservation of existing app data.