### PR TITLE
Fix tab screen bottom spacing

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.9",
+      "version": "0.12.10",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/app/(tabs)/food-log.tsx
+++ b/mobile/app/(tabs)/food-log.tsx
@@ -17,7 +17,7 @@ import { useFoodDayStatus } from '../../src/components/FoodTrackingStatus';
 import { NumberStepperField } from '../../src/components/NumberStepperField';
 import { OverlaySelect } from '../../src/components/OverlaySelect';
 import { PageHeader } from '../../src/components/PageHeader';
-import { Screen } from '../../src/components/Screen';
+import { TabScreen } from '../../src/components/TabScreen';
 import { SectionHeader } from '../../src/components/SectionHeader';
 import { SkeletonBlock } from '../../src/components/SkeletonBlock';
 import { TextField } from '../../src/components/TextField';
@@ -171,7 +171,7 @@ export default function FoodLogScreen() {
     }
 
     return (
-        <Screen safeTop reserveBottomTabs>
+        <TabScreen safeTop reserveFab={canEditFood}>
             <PageHeader
                 title="Food log"
                 description="Review and edit every meal entry."
@@ -256,7 +256,7 @@ export default function FoodLogScreen() {
                     />
                 </View>
             </BottomSheetModal>
-        </Screen>
+        </TabScreen>
     );
 }
 

--- a/mobile/app/(tabs)/progress.tsx
+++ b/mobile/app/(tabs)/progress.tsx
@@ -9,7 +9,7 @@ import { BottomSheetModal } from '../../src/components/BottomSheetModal';
 import { GoalProgressCard } from '../../src/components/GoalProgressCard';
 import { GoalDailyChangeSelect } from '../../src/components/GoalDailyChangeSelect';
 import { NumberStepperField } from '../../src/components/NumberStepperField';
-import { Screen } from '../../src/components/Screen';
+import { TabScreen } from '../../src/components/TabScreen';
 import { SectionHeader } from '../../src/components/SectionHeader';
 import { SegmentedControl } from '../../src/components/SegmentedControl';
 import { WeightTrendPreviewCard } from '../../src/components/progress/WeightTrendPreviewCard';
@@ -129,9 +129,7 @@ export default function ProgressScreen() {
 
     return (
         <>
-            <Screen
-                style={{ backgroundColor: themeColors.background }}
-            >
+            <TabScreen>
                 <GoalProgressCard
                     latestMetric={metricsQuery.data?.[0]}
                     goal={goalQuery.data}
@@ -142,7 +140,7 @@ export default function ProgressScreen() {
                 <WeightTrendPreviewCard
                     onPress={() => router.push('/weight-trend')}
                 />
-            </Screen>
+            </TabScreen>
 
             <BottomSheetModal visible={isGoalEditorOpen} onRequestClose={() => setIsGoalEditorOpen(false)}>
                 <SectionHeader

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -13,7 +13,7 @@ import { WearPairingCard } from '../../src/components/WearPairingCard';
 import { BottomSheetModal } from '../../src/components/BottomSheetModal';
 import { DatePickerField } from '../../src/components/DatePickerField';
 import { NumberStepperField } from '../../src/components/NumberStepperField';
-import { Screen } from '../../src/components/Screen';
+import { TabScreen } from '../../src/components/TabScreen';
 import { SectionHeader } from '../../src/components/SectionHeader';
 import { SegmentedControl } from '../../src/components/SegmentedControl';
 import { TextField } from '../../src/components/TextField';
@@ -344,7 +344,7 @@ export default function SettingsScreen() {
     }
 
     return (
-        <Screen reserveBottomTabs style={{ backgroundColor: themeColors.background }}>
+        <TabScreen>
             <AppCard style={{ backgroundColor: themeColors.surface, borderColor: themeColors.outlineVariant }}>
                 <View style={styles.accountSummary}>
                     <View style={[styles.summaryAvatar, { backgroundColor: themeColors.primaryContainer }]}>
@@ -933,7 +933,7 @@ export default function SettingsScreen() {
                     />
                 </View>
             </BottomSheetModal>
-        </Screen>
+        </TabScreen>
     );
 }
 

--- a/mobile/app/(tabs)/today.tsx
+++ b/mobile/app/(tabs)/today.tsx
@@ -10,7 +10,7 @@ import { DateNavigation } from '../../src/components/DateNavigation';
 import { FoodLogSummaryCard } from '../../src/components/FoodLogSummaryCard';
 import { DayStatusCard, useFoodDayStatus } from '../../src/components/FoodTrackingStatus';
 import { LogContentSkeleton } from '../../src/components/LogContentSkeleton';
-import { Screen } from '../../src/components/Screen';
+import { TabScreen } from '../../src/components/TabScreen';
 import { TodayWeightCard } from '../../src/components/TodayWeightCard';
 import { WeightEntrySheet } from '../../src/components/WeightEntrySheet';
 import { useAuth } from '../../src/auth/AuthContext';
@@ -94,7 +94,7 @@ export default function TodayScreen() {
         (profileQuery.isLoading || foodQuery.isLoading || metricsQuery.isLoading || foodDayQuery.isLoading);
 
     return (
-        <Screen style={styles.screenContent}>
+        <TabScreen style={styles.screenContent}>
             <DateNavigation navigation={dateNavigation} />
             {isPaused && (
                 <DayStatusCard
@@ -160,7 +160,7 @@ export default function TodayScreen() {
                 date={selectedDate}
                 onClose={() => setIsWeightSheetOpen(false)}
             />
-        </Screen>
+        </TabScreen>
     );
 }
 

--- a/mobile/app/(tabs)/weight.tsx
+++ b/mobile/app/(tabs)/weight.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
 import { DateNavigation } from '../../src/components/DateNavigation';
-import { Screen } from '../../src/components/Screen';
+import { TabScreen } from '../../src/components/TabScreen';
 import { WeightEntrySheet } from '../../src/components/WeightEntrySheet';
 import { useLogDateNavigation } from '../../src/hooks/useLogDateNavigation';
 
@@ -16,7 +16,7 @@ export default function WeightScreen() {
     }
 
     return (
-        <Screen reserveBottomTabs>
+        <TabScreen>
             <DateNavigation navigation={dateNavigation} />
 
             <WeightEntrySheet
@@ -24,6 +24,6 @@ export default function WeightScreen() {
                 date={dateNavigation.selectedDate}
                 onClose={closeSheet}
             />
-        </Screen>
+        </TabScreen>
     );
 }

--- a/mobile/src/components/Screen.test.tsx
+++ b/mobile/src/components/Screen.test.tsx
@@ -35,17 +35,6 @@ describe('Screen', () => {
         }));
     });
 
-    it('uses FAB clearance instead of stacking it on normal bottom padding', () => {
-        const view = render(
-            <Screen testID="responsive-screen" reserveBottomTabs>
-                <AppText>Dashboard</AppText>
-            </Screen>
-        );
-        const contentStyle = StyleSheet.flatten(view.getByTestId('responsive-screen').props.contentContainerStyle);
-
-        expect(contentStyle.paddingBottom).toBe(88);
-    });
-
     it('uses the shared keyboard-aware scroller for form content', () => {
         const view = render(
             <Screen testID="responsive-screen">

--- a/mobile/src/components/Screen.tsx
+++ b/mobile/src/components/Screen.tsx
@@ -7,10 +7,8 @@ import { KeyboardAwareScrollView } from './KeyboardAwareScrollView';
 type ScreenProps = ViewProps & {
     scroll?: boolean;
     safeTop?: boolean;
-    reserveBottomTabs?: boolean;
 };
 
-const BOTTOM_TAB_RESERVED_SPACE = 88; // Expanded FAB height plus two layout gaps above the tab bar.
 const DESKTOP_CONTENT_MAX_WIDTH = 1040; // Keeps forms and metrics readable on wide browser windows.
 const WIDE_LAYOUT_BREAKPOINT = 840;
 
@@ -18,7 +16,6 @@ export const Screen: React.FC<ScreenProps> = ({
     children,
     scroll = true,
     safeTop = false,
-    reserveBottomTabs = false,
     style,
     accessibilityRole,
     role,
@@ -32,7 +29,7 @@ export const Screen: React.FC<ScreenProps> = ({
     const horizontalPadding = Platform.OS === 'web' && width >= WIDE_LAYOUT_BREAKPOINT
         ? theme.spacing.xl
         : theme.spacing.lg;
-    const bottomPadding = insets.bottom + (reserveBottomTabs ? BOTTOM_TAB_RESERVED_SPACE : theme.spacing.xl);
+    const bottomPadding = insets.bottom + theme.spacing.xl;
     const topPadding = safeTop ? insets.top + theme.spacing.lg : theme.spacing.lg;
     const contentStyle = [
         styles.content,

--- a/mobile/src/components/TabScreen.test.tsx
+++ b/mobile/src/components/TabScreen.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { AppText } from './AppText';
+import { TabScreen } from './TabScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 32, left: 0 })
+}));
+
+describe('TabScreen', () => {
+    it('does not duplicate the bottom inset already owned by the tab bar', () => {
+        const view = render(
+            <TabScreen testID="tab-screen">
+                <AppText>Progress</AppText>
+            </TabScreen>
+        );
+        const contentStyle = StyleSheet.flatten(view.getByTestId('tab-screen').props.contentContainerStyle);
+
+        expect(contentStyle.paddingBottom).toBe(16);
+    });
+
+    it('reserves clearance only when the route has a FAB', () => {
+        const view = render(
+            <TabScreen testID="tab-screen" reserveFab>
+                <AppText>Food log</AppText>
+            </TabScreen>
+        );
+        const contentStyle = StyleSheet.flatten(view.getByTestId('tab-screen').props.contentContainerStyle);
+
+        expect(contentStyle.paddingBottom).toBe(88);
+    });
+});

--- a/mobile/src/components/TabScreen.tsx
+++ b/mobile/src/components/TabScreen.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { spacing } from '../theme';
+import { Screen } from './Screen';
+
+type TabScreenProps = React.ComponentProps<typeof Screen> & {
+    reserveFab?: boolean;
+};
+
+const TAB_FAB_CLEARANCE = 88; // Expanded FAB height plus two gaps above the tab bar.
+
+/**
+ * Screen layout for routes whose tab bar already owns the device bottom inset.
+ */
+export const TabScreen: React.FC<TabScreenProps> = ({
+    reserveFab = false,
+    style,
+    ...screenProps
+}) => (
+    <Screen
+        {...screenProps}
+        style={[
+            reserveFab ? styles.contentWithFab : styles.content,
+            style
+        ]}
+    />
+);
+
+const styles = StyleSheet.create({
+    content: {
+        paddingBottom: spacing.lg
+    },
+    contentWithFab: {
+        paddingBottom: TAB_FAB_CLEARANCE
+    }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.9",
+      "version": "0.12.10",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.9",
+    "version": "0.12.10",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- add a shared `TabScreen` wrapper that avoids duplicating the bottom safe-area inset already owned by the tab navigator
- migrate Today, Progress, Account, Weight, and Food Log to the shared layout
- reserve expanded FAB clearance only while Food Log actually renders its contextual action
- bump the canonical server patch release and package mirrors from `0.12.9` to `0.12.10`

## Root cause

The general-purpose `Screen` component applied the device bottom inset even inside the tab navigator, where the tab bar already includes that inset. It also exposed `reserveBottomTabs`, which conflated tab layout with FAB overlay clearance and remained enabled on routes that no longer rendered a FAB.

## Impact

Short tab screens no longer gain a small unnecessary vertical scroll, Account and the hidden Weight route no longer retain obsolete FAB space, and closed Food Log days no longer end with unused overlay clearance. Full-screen routes retain their existing safe-area behavior.

## Validation

- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile test -- --runInBand` (83 suites, 339 tests)
- `npm.cmd --prefix mobile run build:web` (31 static routes)
- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 tests)
- `git diff --check`