### PR TITLE
Constrain paused status to Today viewport

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.14",
+      "version": "0.12.15",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/src/components/FoodTrackingStatus.test.tsx
+++ b/mobile/src/components/FoodTrackingStatus.test.tsx
@@ -185,7 +185,7 @@ describe('food tracking day resolution', () => {
         }
     });
 
-    it('turns the expanded Today pause state into a centered status hero', async () => {
+    it('fills only the remaining Today space with a centered status hero', async () => {
         mockApi.getFoodDay.mockResolvedValue(resolvedDay('PAUSED'));
         const screen = renderWithQuery(
             <DayStatusCard
@@ -200,7 +200,7 @@ describe('food tracking day resolution', () => {
         expect(screen.getByText("Today's status")).toBeTruthy();
         expect(StyleSheet.flatten(screen.UNSAFE_getByType(AppCard).props.style)).toEqual(
             expect.objectContaining({
-                flexGrow: 1,
+                flex: 1,
                 alignItems: 'center',
                 justifyContent: 'center'
             })

--- a/mobile/src/components/FoodTrackingStatus.tsx
+++ b/mobile/src/components/FoodTrackingStatus.tsx
@@ -481,7 +481,7 @@ function createStyles(theme: AppTheme) {
             gap: theme.spacing.sm
         },
         cardExpanded: {
-            flexGrow: 1,
+            flex: 1,
             alignItems: 'center',
             justifyContent: 'center',
             paddingHorizontal: theme.spacing.xxl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.14",
+      "version": "0.12.15",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.14",
+    "version": "0.12.15",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- constrain the expanded paused status to the remaining Today viewport slot
- add regression coverage for zero-basis flex sizing
- bump server release metadata to `0.12.15` while leaving native identities unchanged

## Root cause

The expanded card used `flexGrow: 1`, which retained its intrinsic basis inside the Today scroll container. On shorter Android viewports, that intrinsic height was added before the card consumed the remaining space, making the page scroll. `flex: 1` gives the hero a zero basis so it owns only the available slot.

## Screenshots

| Before - page overflows the available viewport | After - status fills the available slot without scrolling |
| --- | --- |
| <img src="https://gist.githubusercontent.com/MChartier/db34380d185e40557ec07748b0aae57f/raw/calibrate-pr-263-before.svg" width="320" alt="Before: paused status causes the Today page to overflow"> | <img src="https://gist.githubusercontent.com/MChartier/db34380d185e40557ec07748b0aae57f/raw/calibrate-pr-263-after.svg" width="320" alt="After: paused status fills the available Today viewport without scrolling"> |

## Validation

- mobile tests: 84 suites, 356 tests passed
- mobile typecheck
- standalone Expo web build
- `npm run release:check`
- `npm run test:release`: 20 tests passed
- 394 x 853 two-card viewport: main `clientHeight` and `scrollHeight` both 724, with no overflowing elements

## Visual verification

At the reproduced mobile viewport, the paused status occupies the remaining 523 px slot, the weight card remains approximately 101 px high, and the fixed tab bar stays visible without page scrolling.
