### PR TITLE
Fix native paused Today viewport sizing

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/src/components/Screen.test.tsx
+++ b/mobile/src/components/Screen.test.tsx
@@ -19,7 +19,7 @@ describe('Screen', () => {
         expect(view.getByTestId('responsive-screen')).toHaveProp('role', 'main');
     });
 
-    it('caps wide scroll content at a readable desktop width', () => {
+    it('uses the native viewport as the flex floor for scroll content', () => {
         const view = render(
             <Screen testID="responsive-screen">
                 <AppText>Dashboard</AppText>
@@ -28,11 +28,12 @@ describe('Screen', () => {
         const contentStyle = StyleSheet.flatten(view.getByTestId('responsive-screen').props.contentContainerStyle);
 
         expect(contentStyle).toEqual(expect.objectContaining({
-            minHeight: '100%',
+            flexGrow: 1,
             width: '100%',
             maxWidth: 1040,
             alignSelf: 'center'
         }));
+        expect(contentStyle.minHeight).toBeUndefined();
     });
 
     it('uses the shared keyboard-aware scroller for form content', () => {

--- a/mobile/src/components/Screen.tsx
+++ b/mobile/src/components/Screen.tsx
@@ -11,6 +11,10 @@ type ScreenProps = ViewProps & {
 
 const DESKTOP_CONTENT_MAX_WIDTH = 1040; // Keeps forms and metrics readable on wide browser windows.
 const WIDE_LAYOUT_BREAKPOINT = 840;
+// Native ScrollViews need a flex floor; web uses its measured percentage viewport.
+const SCROLL_CONTENT_VIEWPORT_FLOOR = Platform.OS === 'web'
+    ? { minHeight: '100%' as const }
+    : { flexGrow: 1 };
 
 export const Screen: React.FC<ScreenProps> = ({
     children,
@@ -94,7 +98,7 @@ function createStyles(theme: AppTheme) {
             backgroundColor: theme.colors.background
         },
         content: {
-            minHeight: '100%',
+            ...SCROLL_CONTENT_VIEWPORT_FLOOR,
             width: '100%',
             maxWidth: DESKTOP_CONTENT_MAX_WIDTH,
             alignSelf: 'center',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.15",
+    "version": "0.12.16",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- give native `ScrollView` content a flex-based viewport floor while preserving the existing percentage floor on web
- let the expanded paused-status card consume only the genuinely available Today height
- bump the server release mirrors from `0.12.15` to `0.12.16`

## Root cause

The shared screen container used `minHeight: '100%'` for every platform. React Native does not resolve that percentage against the native `ScrollView` viewport in the same way as React Native Web, so the expanded child could size beyond the usable viewport and force the weight card below the fold. Native now uses `flexGrow: 1`; web retains `minHeight: '100%'`.

## Impact

When Today contains only the paused tracking status and today's weight, the status still fills the remaining space, but the complete weight card and bottom tabs stay visible without scrolling.

## Native evidence

Pixel 10 emulator, Android 36.1, 1080 x 2424 at 420 dpi:

- paused card bounds: `[42,479][1038,1834]`
- weight card bounds: `[42,1866][1038,2130]`
- scroll viewport: `[0,290][1080,2172]`
- a vertical swipe left both card bounds unchanged

![Pixel 10 paused Today viewport](https://raw.githubusercontent.com/MChartier/calibrate-health/86183dc611d9c38df83369c647bead763ce81a54/.github/pr-assets/264-pixel-10.png)

## Validation

- `npm.cmd --prefix mobile test -- --runInBand` - 84 suites, 356 tests
- `npm.cmd --prefix mobile run typecheck`
- `npm.cmd --prefix mobile run build:web`
- focused `Screen` and `FoodTrackingStatus` tests - 2 suites, 11 tests
- `npm.cmd run release:check`
- `npm.cmd run test:release` - 20 tests
- `git diff --check`
