### PR TITLE
Prevent Android authentication refresh races

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.17",
+      "version": "0.12.18",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/mobile/src/auth/apiClientAuth.test.ts
+++ b/mobile/src/auth/apiClientAuth.test.ts
@@ -45,6 +45,57 @@ describe('CalibrateApiClient mobile authentication recovery', () => {
         expect(refreshCount).toBe(1);
     });
 
+    it('does not rotate again for a late 401 sent with the previous access token', async () => {
+        let accessToken = 'expired-access';
+        let refreshCount = 0;
+        let unauthorizedCount = 0;
+        let expiredRequestCount = 0;
+        let releaseFirstExpiredRequest!: () => void;
+        let releaseLateExpiredRequest!: () => void;
+        const firstExpiredRequestStarted = new Promise<void>((resolve) => {
+            releaseFirstExpiredRequest = resolve;
+        });
+        const lateExpiredRequest = new Promise<void>((resolve) => {
+            releaseLateExpiredRequest = resolve;
+        });
+        const client = new CalibrateApiClient({
+            baseUrl: 'https://example.test',
+            getAccessToken: () => accessToken,
+            refreshAccessToken: async () => {
+                refreshCount += 1;
+                accessToken = 'fresh-access';
+                return true;
+            },
+            onUnauthorized: async () => {
+                unauthorizedCount += 1;
+            },
+            fetchImpl: async (_input, init) => {
+                const authorization = new Headers(init?.headers).get('authorization');
+                if (authorization === 'Bearer expired-access') {
+                    expiredRequestCount += 1;
+                    if (expiredRequestCount === 1) {
+                        await firstExpiredRequestStarted;
+                    } else {
+                        releaseFirstExpiredRequest();
+                        await lateExpiredRequest;
+                    }
+                    return jsonResponse({ message: 'expired' }, 401);
+                }
+                return jsonResponse({ user: { id: 1 } });
+            }
+        });
+
+        const firstRequest = client.getMe();
+        const lateRequest = client.getUserProfile();
+        await firstRequest;
+        releaseLateExpiredRequest();
+        await lateRequest;
+
+        expect(expiredRequestCount).toBe(2);
+        expect(refreshCount).toBe(1);
+        expect(unauthorizedCount).toBe(0);
+    });
+
     it('retries only once before clearing an unauthorized session', async () => {
         let requestCount = 0;
         let refreshCount = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.17",
+      "version": "0.12.18",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -159,6 +159,7 @@ export class CalibrateApiClient {
     private readonly requestTimeoutMs: number;
     private readonly requestCredentials?: RequestCredentials;
     private refreshPromise: Promise<boolean> | null = null;
+    private refreshGeneration = 0;
 
     constructor(options: ApiClientOptions) {
         this.baseUrl = options.baseUrl;
@@ -179,6 +180,10 @@ export class CalibrateApiClient {
 
         if (!this.refreshPromise) {
             this.refreshPromise = Promise.resolve(this.refreshAccessToken())
+                .then((refreshed) => {
+                    if (refreshed) this.refreshGeneration += 1;
+                    return refreshed;
+                })
                 .finally(() => {
                     this.refreshPromise = null;
                 });
@@ -188,6 +193,7 @@ export class CalibrateApiClient {
     }
 
     private async request<T>(path: string, options: RequestOptions = {}, allowRefresh = true): Promise<T> {
+        const requestRefreshGeneration = this.refreshGeneration;
         const {
             auth = true,
             json,
@@ -281,6 +287,11 @@ export class CalibrateApiClient {
                 await this.onClientUpgradeRequired?.(body);
             }
             if (response.status === 401 && auth && allowRefresh && this.refreshAccessToken) {
+                // A slower response may have left with the access token that another request just
+                // refreshed. Retry against that replacement instead of rotating the token pair again.
+                if (requestRefreshGeneration !== this.refreshGeneration) {
+                    return this.request<T>(path, options, false);
+                }
                 const refreshed = await this.refreshAccessTokenOnce();
                 if (refreshed) {
                     return this.request<T>(path, options, false);

--- a/packages/api-client/test/transport.test.ts
+++ b/packages/api-client/test/transport.test.ts
@@ -177,6 +177,57 @@ test('one successful refresh retries the original request with the replacement t
     assert.equal(unauthorizedCalls, 0);
 });
 
+test('a late 401 from the previous access token reuses the completed refresh', async () => {
+    let accessToken = 'expired-token';
+    let refreshCalls = 0;
+    let unauthorizedCalls = 0;
+    let expiredRequestCount = 0;
+    let releaseFirstExpiredRequest: () => void = () => undefined;
+    let releaseLateExpiredRequest: () => void = () => undefined;
+    const firstExpiredRequestStarted = new Promise<void>((resolve) => {
+        releaseFirstExpiredRequest = resolve;
+    });
+    const lateExpiredRequest = new Promise<void>((resolve) => {
+        releaseLateExpiredRequest = resolve;
+    });
+    const client = new CalibrateApiClient({
+        baseUrl: 'https://calibrate.example',
+        getAccessToken: () => accessToken,
+        refreshAccessToken: async () => {
+            refreshCalls += 1;
+            accessToken = 'replacement-token';
+            return true;
+        },
+        onUnauthorized: () => {
+            unauthorizedCalls += 1;
+        },
+        fetchImpl: (async (_input, init) => {
+            const authorization = new Headers(init?.headers).get('authorization');
+            if (authorization === 'Bearer expired-token') {
+                expiredRequestCount += 1;
+                if (expiredRequestCount === 1) {
+                    await firstExpiredRequestStarted;
+                } else {
+                    releaseFirstExpiredRequest();
+                    await lateExpiredRequest;
+                }
+                return new Response('{"message":"expired"}', { status: 401 });
+            }
+            return new Response('{"user":{"id":7}}', { status: 200 });
+        }) as typeof fetch
+    });
+
+    const firstRequest = client.getMe();
+    const lateRequest = client.getUserProfile();
+    await firstRequest;
+    releaseLateExpiredRequest();
+    await lateRequest;
+
+    assert.equal(expiredRequestCount, 2);
+    assert.equal(refreshCalls, 1);
+    assert.equal(unauthorizedCalls, 0);
+});
+
 test('a retried 401 does not start another refresh loop', async () => {
     let accessToken = 'expired-token';
     let fetchCalls = 0;

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.17",
+    "version": "0.12.18",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- keep late 401 responses from rotating an already-refreshed Android token pair
- retry staggered requests with the current refresh generation instead of clearing the local session
- add shared API-client and Android regression coverage
- advance the canonical patch release to `0.12.18`

## Root cause

Android can launch several authenticated requests together when the app wakes. The existing single-flight guard coalesced 401 responses only while a refresh promise was still pending. A slower 401 that arrived immediately after that refresh completed started a second refresh, invalidating the first replacement access token. The first request's retry could then receive another 401 and clear the credentials stored in SecureStore.

The backend already uses the intended session policy: access tokens last 15 minutes, refresh tokens last 30 days, and each successful refresh rotates the pair and extends the refresh expiry by another 30 days. Daily or semi-daily use should therefore remain signed in.

## Validation

- `npm.cmd run ci:local`
  - release and native-release contract checks
  - backend build and API-client type-check
  - Expo web build and release checks
  - 396 backend tests
  - 357 mobile tests
- `git diff --check`
