### PR TITLE
Add axes to weight trend preview

### DIFF
--- a/mobile/src/components/progress/WeightTrendPreviewCard.test.tsx
+++ b/mobile/src/components/progress/WeightTrendPreviewCard.test.tsx
@@ -50,8 +50,13 @@ describe('WeightTrendPreviewCard', () => {
 
         expect(screen.getByText('Last four weeks at a glance.')).toBeTruthy();
         expect(screen.getByLabelText('Four-week weight trend preview')).toBeTruthy();
+        expect(screen.getByLabelText('169 lb weight axis label')).toBeTruthy();
+        expect(screen.getByLabelText('168 lb weight axis label')).toBeTruthy();
+        expect(screen.getByLabelText('Jul 19 date axis label')).toBeTruthy();
+        expect(screen.getByLabelText('Jul 20 date axis label')).toBeTruthy();
         expect(screen.getByText('Trend line: down 0.6 lb over 1 day.')).toBeTruthy();
         expect(screen.queryByText(/-0\.35|volatility/)).toBeNull();
+        expect(screen.queryByText(/^(Week|Month|Year|All)$/)).toBeNull();
 
         fireEvent.press(screen.getByLabelText('Open full weight trend'));
         expect(onPress).toHaveBeenCalledTimes(1);
@@ -103,8 +108,8 @@ describe('WeightTrendPreviewCard', () => {
 
         const screen = render(<WeightTrendPreviewCard onPress={jest.fn()} />);
 
-        expect(screen.getByTestId('weight-trend-preview-measurement-path').props.d).toMatch(/^M 8\.00 /);
-        expect(screen.getByTestId('weight-trend-preview-smoothed-path').props.d).toMatch(/^M 170\.00 /);
+        expect(screen.getByTestId('weight-trend-preview-measurement-path').props.d).toMatch(/^M 48\.00 /);
+        expect(screen.getByTestId('weight-trend-preview-smoothed-path').props.d).toMatch(/^M 190\.00 /);
         expect(screen.getByText('Trend line: down 0.6 lb over 1 day.')).toBeTruthy();
     });
 

--- a/mobile/src/components/progress/WeightTrendPreviewCard.tsx
+++ b/mobile/src/components/progress/WeightTrendPreviewCard.tsx
@@ -41,11 +41,11 @@ const MIN_PREVIEW_WIDTH = 240;
 const PREVIEW_HEIGHT = 112; // Keeps the Progress card glanceable while preserving a meaningful trend shape.
 const PREVIEW_CARD_MIN_HEIGHT = 240; // Preserves the compact chart and summary before free space is distributed.
 const PREVIEW_PADDING_LEFT = 48; // Reserves a compact gutter for weight labels without widening the card.
-const PREVIEW_PADDING_RIGHT = 8;
-const PREVIEW_PADDING_TOP = 10;
+const PREVIEW_PADDING_RIGHT = 8; // Keeps the final point and end-date label clear of the rounded chart edge.
+const PREVIEW_PADDING_TOP = 10; // Leaves headroom for the top gridline and measurement markers.
 const PREVIEW_PADDING_BOTTOM = 24; // Keeps endpoint dates inside the existing preview canvas.
-const PREVIEW_AXIS_FONT_SIZE = 10;
-const PREVIEW_AXIS_TICK_SIZE = 4;
+const PREVIEW_AXIS_FONT_SIZE = 10; // Keeps preview labels legible without competing with the trend lines.
+const PREVIEW_AXIS_TICK_SIZE = 4; // Marks the date endpoints without adding interactive chart controls.
 const MIN_PREVIEW_WEIGHT_SPAN = 0.4;
 
 function buildPath(points: PreviewPoint[], key: 'measurementY' | 'trendY'): string {

--- a/mobile/src/components/progress/WeightTrendPreviewCard.tsx
+++ b/mobile/src/components/progress/WeightTrendPreviewCard.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import Svg, { Circle, Line, Path } from 'react-native-svg';
+import Svg, { Circle, Line, Path, Text as SvgText } from 'react-native-svg';
 import { useQuery } from '@tanstack/react-query';
 import type { TrendMetricEntry } from '@calibrate/api-client';
 import { AppCard } from '../AppCard';
@@ -9,6 +9,8 @@ import { AppText } from '../AppText';
 import { SectionHeader } from '../SectionHeader';
 import { useAuth } from '../../auth/AuthContext';
 import { radius, spacing, useAppTheme, type AppTheme } from '../../theme';
+import { dateOnlyToLocalDate } from '../../utils/dates';
+import { formatWeight } from '../../utils/format';
 import { describeVisibleWeightTrend, isVisibleWeightTrendPoint } from '../../weightTrend/presentation';
 
 type WeightTrendPreviewCardProps = {
@@ -28,12 +30,22 @@ type PreviewCanvasSize = {
     height: number;
 };
 
+type PreviewLayout = PreviewCanvasSize & {
+    points: PreviewPoint[];
+    xTicks: Array<{ key: string; label: string; x: number; textAnchor: 'start' | 'end' }>;
+    yTicks: Array<{ value: number; y: number }>;
+};
+
 const DEFAULT_PREVIEW_WIDTH = 340;
 const MIN_PREVIEW_WIDTH = 240;
 const PREVIEW_HEIGHT = 112; // Keeps the Progress card glanceable while preserving a meaningful trend shape.
 const PREVIEW_CARD_MIN_HEIGHT = 240; // Preserves the compact chart and summary before free space is distributed.
-const PREVIEW_HORIZONTAL_PADDING = 8;
-const PREVIEW_VERTICAL_PADDING = 12;
+const PREVIEW_PADDING_LEFT = 48; // Reserves a compact gutter for weight labels without widening the card.
+const PREVIEW_PADDING_RIGHT = 8;
+const PREVIEW_PADDING_TOP = 10;
+const PREVIEW_PADDING_BOTTOM = 24; // Keeps endpoint dates inside the existing preview canvas.
+const PREVIEW_AXIS_FONT_SIZE = 10;
+const PREVIEW_AXIS_TICK_SIZE = 4;
 const MIN_PREVIEW_WEIGHT_SPAN = 0.4;
 
 function buildPath(points: PreviewPoint[], key: 'measurementY' | 'trendY'): string {
@@ -42,15 +54,22 @@ function buildPath(points: PreviewPoint[], key: 'measurementY' | 'trendY'): stri
         .join(' ');
 }
 
-function getPreviewPoints(metrics: TrendMetricEntry[], canvasSize: PreviewCanvasSize): PreviewPoint[] {
+function formatPreviewDate(value: string): string {
+    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' })
+        .format(dateOnlyToLocalDate(value.split('T')[0] ?? value));
+}
+
+function getPreviewLayout(metrics: TrendMetricEntry[], canvasSize: PreviewCanvasSize): PreviewLayout {
     const chronologicalMetrics = metrics
         .slice()
         .filter((metric) => Number.isFinite(metric.weight))
         .reverse();
-    if (chronologicalMetrics.length === 0) return [];
-
     const width = Math.max(canvasSize.width, MIN_PREVIEW_WIDTH);
     const height = Math.max(canvasSize.height, PREVIEW_HEIGHT);
+    if (chronologicalMetrics.length === 0) {
+        return { width, height, points: [], xTicks: [], yTicks: [] };
+    }
+
     const values = chronologicalMetrics.flatMap((metric) => (
         isVisibleWeightTrendPoint(metric)
             ? [metric.weight, metric.trend_weight]
@@ -61,23 +80,49 @@ function getPreviewPoints(metrics: TrendMetricEntry[], canvasSize: PreviewCanvas
     const range = Math.max(maximum - minimum, MIN_PREVIEW_WEIGHT_SPAN);
     const axisMiddle = (maximum + minimum) / 2;
     const axisMinimum = axisMiddle - range / 2;
-    const drawableWidth = width - (PREVIEW_HORIZONTAL_PADDING * 2);
-    const drawableHeight = height - (PREVIEW_VERTICAL_PADDING * 2);
+    const axisMaximum = axisMiddle + range / 2;
+    const drawableWidth = width - PREVIEW_PADDING_LEFT - PREVIEW_PADDING_RIGHT;
+    const drawableHeight = height - PREVIEW_PADDING_TOP - PREVIEW_PADDING_BOTTOM;
     const lastIndex = Math.max(chronologicalMetrics.length - 1, 1);
     const yForValue = (value: number) =>
-        PREVIEW_VERTICAL_PADDING + drawableHeight - ((value - axisMinimum) / range) * drawableHeight;
+        PREVIEW_PADDING_TOP + drawableHeight - ((value - axisMinimum) / range) * drawableHeight;
 
-    return chronologicalMetrics.map((metric, index) => {
+    const points = chronologicalMetrics.map((metric, index) => {
         const measurementY = yForValue(metric.weight);
         const hasVisibleTrend = isVisibleWeightTrendPoint(metric);
         return {
             key: `${metric.id}-${metric.date}`,
             hasVisibleTrend,
-            x: PREVIEW_HORIZONTAL_PADDING + (drawableWidth * index) / lastIndex,
+            x: PREVIEW_PADDING_LEFT + (drawableWidth * index) / lastIndex,
             measurementY,
             trendY: hasVisibleTrend ? yForValue(metric.trend_weight) : measurementY
         };
     });
+
+    const lastMetric = chronologicalMetrics[chronologicalMetrics.length - 1];
+    return {
+        width,
+        height,
+        points,
+        yTicks: [
+            { value: axisMaximum, y: PREVIEW_PADDING_TOP },
+            { value: axisMinimum, y: height - PREVIEW_PADDING_BOTTOM }
+        ],
+        xTicks: [
+            {
+                key: `start-${chronologicalMetrics[0].date}`,
+                label: formatPreviewDate(chronologicalMetrics[0].date),
+                x: PREVIEW_PADDING_LEFT,
+                textAnchor: 'start'
+            },
+            {
+                key: `end-${lastMetric.date}`,
+                label: formatPreviewDate(lastMetric.date),
+                x: width - PREVIEW_PADDING_RIGHT,
+                textAnchor: 'end'
+            }
+        ]
+    };
 }
 
 export const WeightTrendPreviewCard: React.FC<WeightTrendPreviewCardProps> = ({ onPress }) => {
@@ -92,10 +137,11 @@ export const WeightTrendPreviewCard: React.FC<WeightTrendPreviewCardProps> = ({ 
         queryKey: ['mobile-metrics-trend', 'month'],
         queryFn: () => api.getTrendMetrics({ range: 'month' })
     });
-    const points = useMemo(
-        () => getPreviewPoints(trendQuery.data?.metrics ?? [], canvasSize),
+    const chartLayout = useMemo(
+        () => getPreviewLayout(trendQuery.data?.metrics ?? [], canvasSize),
         [canvasSize, trendQuery.data?.metrics]
     );
+    const points = chartLayout.points;
     const measurementPath = buildPath(points, 'measurementY');
     const trendPath = buildPath(points.filter((point) => point.hasVisibleTrend), 'trendY');
     const hasWeightHistory = (trendQuery.data?.meta.total_points ?? 0) > 0;
@@ -157,17 +203,53 @@ export const WeightTrendPreviewCard: React.FC<WeightTrendPreviewCardProps> = ({ 
                                     accessibilityLabel="Four-week weight trend preview"
                                     width="100%"
                                     height="100%"
-                                    viewBox={`0 0 ${Math.max(canvasSize.width, MIN_PREVIEW_WIDTH)} ${Math.max(canvasSize.height, PREVIEW_HEIGHT)}`}
+                                    viewBox={`0 0 ${chartLayout.width} ${chartLayout.height}`}
                                 >
-                                    <Line
-                                        x1={PREVIEW_HORIZONTAL_PADDING}
-                                        y1={Math.max(canvasSize.height, PREVIEW_HEIGHT) / 2}
-                                        x2={Math.max(canvasSize.width, MIN_PREVIEW_WIDTH) - PREVIEW_HORIZONTAL_PADDING}
-                                        y2={Math.max(canvasSize.height, PREVIEW_HEIGHT) / 2}
-                                        stroke={theme.colors.outlineVariant}
-                                        strokeWidth={1}
-                                        strokeDasharray="3 4"
-                                    />
+                                    {chartLayout.yTicks.map((tick) => (
+                                        <React.Fragment key={tick.value}>
+                                            <Line
+                                                x1={PREVIEW_PADDING_LEFT}
+                                                y1={tick.y}
+                                                x2={chartLayout.width - PREVIEW_PADDING_RIGHT}
+                                                y2={tick.y}
+                                                stroke={theme.colors.outlineVariant}
+                                                strokeWidth={1}
+                                                strokeDasharray="3 4"
+                                            />
+                                            <SvgText
+                                                accessibilityLabel={`${formatWeight(tick.value, user?.weight_unit)} weight axis label`}
+                                                x={PREVIEW_PADDING_LEFT - 6}
+                                                y={tick.y + 3}
+                                                fill={theme.colors.onSurfaceVariant}
+                                                fontSize={PREVIEW_AXIS_FONT_SIZE}
+                                                textAnchor="end"
+                                            >
+                                                {formatWeight(tick.value, user?.weight_unit)}
+                                            </SvgText>
+                                        </React.Fragment>
+                                    ))}
+                                    {chartLayout.xTicks.map((tick) => (
+                                        <React.Fragment key={tick.key}>
+                                            <Line
+                                                x1={tick.x}
+                                                y1={chartLayout.height - PREVIEW_PADDING_BOTTOM}
+                                                x2={tick.x}
+                                                y2={chartLayout.height - PREVIEW_PADDING_BOTTOM + PREVIEW_AXIS_TICK_SIZE}
+                                                stroke={theme.colors.outlineVariant}
+                                                strokeWidth={1}
+                                            />
+                                            <SvgText
+                                                accessibilityLabel={`${tick.label} date axis label`}
+                                                x={tick.x}
+                                                y={chartLayout.height - 5}
+                                                fill={theme.colors.onSurfaceVariant}
+                                                fontSize={PREVIEW_AXIS_FONT_SIZE}
+                                                textAnchor={tick.textAnchor}
+                                            >
+                                                {tick.label}
+                                            </SvgText>
+                                        </React.Fragment>
+                                    ))}
                                     <Path
                                         testID="weight-trend-preview-measurement-path"
                                         d={measurementPath}


### PR DESCRIPTION
## Summary

- Rebase the change onto the current Expo client after the legacy Vite client was removed.
- Add two compact weight labels and start/end date labels inside the existing Progress-tab trend preview.
- Preserve the current Progress card design and its single tap target; range controls remain exclusive to Trend details.

## Screenshot

![Current Expo Progress tab with labeled weight trend preview](https://raw.githubusercontent.com/MChartier/calibrate-health/6c69b6e92a1c9eba4dd1ba1a7b134802e86440e9/.github/pr-assets/weight-trend-progress-current.jpg)

## Validation

- `npm.cmd --prefix mobile test -- --runInBand src/components/progress/WeightTrendPreviewCard.test.tsx`
- `npm.cmd --prefix mobile run typecheck`
- Current Expo web runtime at 390 x 844: the Progress preview remains one button and shows no range controls; tapping it opens Trend details with Week/Month/Year/All.
