### PR TITLE
Bump server version to 0.13.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.12.19",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.12.19",
+      "version": "0.13.0",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.12.19",
+  "version": "0.13.0",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.12.19",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.12.19",
+      "version": "0.13.0",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.12.19",
+  "version": "0.13.0",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.12.19",
+    "version": "0.13.0",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- bump the canonical server release from `0.12.19` to `0.13.0`
- align the root and backend package versions and lockfiles with `shared/release.json`
- leave the mobile and Wear versions, build numbers, API support, and minimum-client policy unchanged

## Why

PR #269 added adaptive calorie calibration but did not advance `server.version`. The manifest-release workflow therefore treated its merge as an existing release and did not publish a new server image.

Merging this follow-up makes `v0.13.0` the next stable server release, allowing the master release workflow to create the immutable tag and publish the upgraded server image.

## Validation

- `npm run release:check`
- `npm run test:release` (20 tests)
- `git diff --check`
