### PR TITLE
Bump server version to 0.13.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.13.1",
+    "version": "0.13.2",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- bump the canonical server release from `0.13.1` to `0.13.2`
- update the matching root and backend package manifests and lockfiles
- leave native phone and Wear versions unchanged

## Why

PR #273 introduced server version `0.13.1`. PR #272 was then rebased on top and merged without advancing the release identity for its shipped weight-logging experience. This follow-up restores the repository's one-version-per-shipped-change convention.

## Impact

The next server/PWA release is uniquely identified as `0.13.2`. There are no runtime behavior or native artifact changes in this PR.

## Validation

- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 passed)
- `git diff --check`