### PR TITLE
Bump server version to 0.14.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run prisma:generate",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cal-io",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cal-io",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "license": "ISC",
       "workspaces": [
         "mobile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cal-io",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/shared/release.json
+++ b/shared/release.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "server": {
-    "version": "0.13.3",
+    "version": "0.14.0",
     "api": {
       "current": "v1",
       "supported": [


### PR DESCRIPTION
## Summary

- bump the canonical server release version from `0.13.3` to `0.14.0`
- align the root and backend package manifests and lockfiles
- leave the landed native client versions unchanged

## Why

The latest landed change did not advance `shared/release.json`, so the release workflow did not see a new server version and skipped the container image and OTA bundle release path. This minor bump restores a new release identity.

## Validation

- `npm.cmd run release:check`
- `npm.cmd run test:release` (20 passing)
- `node scripts/release-config.mjs plan --latest-tag v0.13.3` (`new_tag=v0.14.0`, `should_release=true`)
- `git diff --check`