### PR TITLE
Refine mobile keyboard and food search flow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -47,8 +47,13 @@ jobs:
         working-directory: ${{ matrix.directory }}
 
       - name: Audit high and critical production findings
+        if: matrix.directory != '.'
         run: npm audit --omit=dev --audit-level=high
         working-directory: ${{ matrix.directory }}
+
+      - name: Audit root production findings with time-bounded exceptions
+        if: matrix.directory == '.'
+        run: npm run audit:production
 
       - name: Validate time-bounded dependency exceptions
         if: matrix.directory == '.'

--- a/docs/security-release-threat-model.md
+++ b/docs/security-release-threat-model.md
@@ -37,29 +37,26 @@ authorize a read, update, delete, undo, or association.
 
 ## Dependency advisory resolution
 
-As of 2026-07-27, `npm audit --omit=dev` reports no production findings in either
-the root/mobile or backend lock graph. Coverage runs on `c8@12`, and compatible patched releases
-remain pinned for the production and Prisma dependency edges. API contract generation, backend
-coverage, and the full test suite exercise those overrides.
+As of 2026-08-07, the backend lock graph has no high or critical production findings. The
+root/mobile graph has no unexcepted high or critical production findings. Coverage runs on `c8@12`,
+and compatible patched releases remain pinned for the production and Prisma dependency edges. API
+contract generation, backend coverage, and the full test suite exercise those overrides.
 
-The root/mobile full audit still reports 23 high package entries, but every entry is the same
-development-only path to
-[`GHSA-mh99-v99m-4gvg`](https://github.com/advisories/GHSA-mh99-v99m-4gvg):
-React Native 0.86's Jest preset pins Babel/Jest 29, which reaches `brace-expansion@1.1.16` through
-`test-exclude@6` and `minimatch@3`. These packages only discover and instrument repository-owned
-test files; none are bundled into the server, web client, Android app, or Wear app. A forced
-`brace-expansion@5.0.8` resolution is not compatible: v5's CommonJS export is an object while
-`minimatch@3` calls the dependency as a function, causing test discovery to fail. Keep this finding
-visible until the React Native preset moves to a compatible Jest/tooling graph rather than masking
-it with an invalid lockfile override.
+The root/mobile production graph temporarily reports two no-fix `image-size` advisories:
+[`GHSA-w3rx-r6r6-pgpr`](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) and
+[`GHSA-5p2g-fcmc-qvqq`](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq). Both describe parser
+infinite loops and affect every published version through `2.0.2`; no patched release is available.
+The locked `image-size@1.2.1` copy is reached only through Expo's Metro build-tool chain, where it
+inspects repository-owned assets. User uploads and food-provider images do not pass through Metro.
+The production audit may filter only package entries whose complete advisory chain resolves to
+these two ids, only while the lock graph remains exactly `image-size@1.2.1`, and only through
+2026-08-20. A changed dependency version, another advisory, the deadline, or strict production
+release validation fails the exception.
 
-The backend development graph has the same constraint on a separate OpenAPI-only edge:
-`openapi-typescript@7.13.0` depends on Redocly `1.34.17`, which pins `minimatch@5.1.9`.
-That minimatch release requires the callable `brace-expansion@2` API, while the only version
-currently accepted by the advisory scanner is the incompatible object-exporting v5 release.
-Keep Redocly on `brace-expansion@2.1.2` until its consumer upgrades to picomatch or another
-compatible implementation. A backend regression test executes a brace-bearing pattern through
-Redocly's exact minimatch dependency, and the dependency remains development-only.
+The full root/mobile audit reports the same 15 package entries rooted in those two `image-size`
+advisories and no additional findings. A separate development-only Istanbul edge is pinned to
+patched `js-yaml@3.15.1`; keeping the override scoped to `@istanbuljs/load-nyc-config@1.1.0`
+prevents it from changing Expo's independent `js-yaml@4` dependency.
 
 The separate UUID advisory is fully resolved. The root graph pins the `xcode@3.0.1` edge to patched
 `uuid@11.1.1`, and a release test executes xcode's actual `generateUuid()` path. Android prebuild,

--- a/mobile/src/components/AddFoodSheet.test.tsx
+++ b/mobile/src/components/AddFoodSheet.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
+import type { MyFoodSummary } from '@calibrate/api-client';
+import { AddFoodSheet } from './AddFoodSheet';
+
+const mockSavedFood: MyFoodSummary = {
+    id: 12,
+    type: 'FOOD',
+    name: 'Greek yogurt',
+    serving_size_quantity: 1,
+    serving_unit_label: 'container',
+    calories_per_serving: 120,
+    is_pinned: true
+};
+const mockApi = {
+    createFoodLog: jest.fn(),
+    getMyFoods: jest.fn(async () => [mockSavedFood]),
+    getRecentFoods: jest.fn(async () => ({ items: [] })),
+    searchFood: jest.fn(async () => ({ items: [] }))
+};
+
+jest.mock('@expo/vector-icons/Ionicons', () => () => null);
+jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('../auth/AuthContext', () => ({
+    useAuth: () => ({ api: mockApi, user: { haptics_enabled: false } })
+}));
+jest.mock('../hooks/useReducedMotionPreference', () => ({
+    useReducedMotionPreference: () => true
+}));
+jest.mock('../offline/provider', () => ({
+    useOfflineOutbox: () => ({ enqueue: jest.fn() })
+}));
+jest.mock('../offline/operations', () => ({
+    executeOrQueueMutation: jest.fn(),
+    OFFLINE_MUTATION_OPERATIONS: { CREATE_FOOD_LOG: 'create-food-log' }
+}));
+jest.mock('../utils/haptics', () => ({ triggerHapticFeedback: jest.fn() }));
+jest.mock('./FoodTrackingStatus', () => ({
+    useFoodDayStatus: () => ({ data: { status: 'OPEN' } })
+}));
+jest.mock('./BottomSheetModal', () => {
+    const { View } = jest.requireActual('react-native');
+    return {
+        BottomSheetModal: ({ visible, children }: { visible: boolean; children: React.ReactNode }) => (
+            visible ? <View>{children}</View> : null
+        )
+    };
+});
+
+function renderSheet() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, gcTime: Infinity },
+            mutations: { retry: false, gcTime: Infinity }
+        }
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <AddFoodSheet visible date="2026-08-07" onClose={jest.fn()} />
+        </QueryClientProvider>
+    );
+}
+
+describe('AddFoodSheet search experience', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('expands search into the available sheet space until the user finishes', async () => {
+        const screen = renderSheet();
+        const searchInput = screen.getByLabelText('Search foods');
+        const context = screen.getByTestId('add-food-search-context');
+
+        expect(context.props.accessibilityElementsHidden).toBe(false);
+        fireEvent(searchInput, 'focus', { nativeEvent: {} });
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Done' })).toBeTruthy();
+            expect(context.props.accessibilityElementsHidden).toBe(true);
+        });
+
+        fireEvent.press(screen.getByRole('button', { name: 'Done' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Scan' })).toBeTruthy();
+            expect(context.props.accessibilityElementsHidden).toBe(false);
+        });
+    });
+
+    it('dismisses search and restores setup context when a result is chosen', async () => {
+        const dismiss = jest.spyOn(Keyboard, 'dismiss').mockImplementation(jest.fn());
+        const screen = renderSheet();
+        fireEvent(screen.getByLabelText('Search foods'), 'focus', { nativeEvent: {} });
+
+        fireEvent.press(await screen.findByRole('button', { name: 'Choose amount for Greek yogurt' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Back to food results' })).toBeTruthy();
+            expect(screen.getByTestId('add-food-search-context').props.accessibilityElementsHidden).toBe(false);
+        });
+        expect(dismiss).toHaveBeenCalled();
+    });
+});

--- a/mobile/src/components/AddFoodSheet.tsx
+++ b/mobile/src/components/AddFoodSheet.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { FlatList, Linking, Pressable, StyleSheet, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, Easing, FlatList, Keyboard, Linking, Pressable, StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -26,6 +26,7 @@ import { triggerHapticFeedback } from '../utils/haptics';
 import { MEAL_OPTIONS, MEAL_SELECT_OPTIONS } from '../utils/meals';
 import { selectQuickRecentFoods } from '../utils/myFoods';
 import { getFoodLogAmountText } from '../food/foodLogAmount';
+import { useReducedMotionPreference } from '../hooks/useReducedMotionPreference';
 import {
     createMyFoodSelection,
     createProviderFoodSelection,
@@ -77,6 +78,7 @@ const MINIMUM_SEARCH_LENGTH = 2;
 const DEFAULT_RECENT_LIMIT = 8;
 const DEFAULT_PINNED_LIMIT = 8;
 const ADD_FOOD_SHEET_HEIGHT = '92%';
+const SEARCH_CONTEXT_TRANSITION_MS = 180; // Collapses setup controls quickly enough for search to feel like an in-sheet navigation.
 
 function describeSearchedFood(item: SearchedFoodItem): string {
     const preferredIndex = getPreferredFoodMeasureIndex(item);
@@ -134,6 +136,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
 }) => {
     const theme = useAppTheme();
     const styles = useMemo(() => createStyles(theme), [theme]);
+    const reduceMotion = useReducedMotionPreference();
     const { api, user } = useAuth();
     const { enqueue } = useOfflineOutbox();
     const queryClient = useQueryClient();
@@ -147,7 +150,26 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     const [recipeQuery, setRecipeQuery] = useState('');
     const [selection, setSelection] = useState<FoodLogSelection | null>(null);
     const [isMealSelectorOpen, setIsMealSelectorOpen] = useState(false);
+    const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+    const [searchContextHeight, setSearchContextHeight] = useState<number | null>(null);
+    const searchContextProgress = useRef(new Animated.Value(1)).current;
+    const isSearchContextAnimating = useRef(false);
     const normalizedQuery = query.trim();
+    const isSearchExperienceExpanded = mode === 'search' && isSearchExpanded && selection === null;
+
+    useEffect(() => {
+        isSearchContextAnimating.current = true;
+        const animation = Animated.timing(searchContextProgress, {
+            toValue: isSearchExperienceExpanded ? 0 : 1,
+            duration: reduceMotion ? 0 : SEARCH_CONTEXT_TRANSITION_MS,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: false
+        });
+        animation.start(() => {
+            isSearchContextAnimating.current = false;
+        });
+        return () => animation.stop();
+    }, [isSearchExperienceExpanded, reduceMotion, searchContextProgress]);
 
     useEffect(() => {
         if (!visible || mode !== 'search' || normalizedQuery.length < MINIMUM_SEARCH_LENGTH) {
@@ -234,6 +256,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
         setRecipeQuery('');
         setSelection(null);
         setIsMealSelectorOpen(false);
+        setIsSearchExpanded(false);
         logFood.reset();
     }, [initialMeal, visible]);
 
@@ -352,6 +375,8 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
     }
 
     function selectMode(nextMode: AddFoodMode) {
+        Keyboard.dismiss();
+        setIsSearchExpanded(false);
         setMode(nextMode);
         setSelection(null);
         setIsMealSelectorOpen(false);
@@ -369,6 +394,8 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                 disabled={logFood.isPending || item.disabled}
                 disabledReason={item.disabledReason}
                 onPress={() => {
+                    Keyboard.dismiss();
+                    setIsSearchExpanded(false);
                     logFood.reset();
                     setSelection(item.selection);
                 }}
@@ -451,6 +478,12 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
         );
     }
 
+    function handleSearchContextLayout(event: LayoutChangeEvent) {
+        if (isSearchExperienceExpanded || isSearchContextAnimating.current) return;
+        const nextHeight = event.nativeEvent.layout.height;
+        if (nextHeight > 0 && nextHeight !== searchContextHeight) setSearchContextHeight(nextHeight);
+    }
+
     function renderModeContent() {
         if (mode === 'quick') {
             return (
@@ -507,6 +540,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                         <TextField
                             label="Search foods"
                             value={query}
+                            onFocus={() => setIsSearchExpanded(true)}
                             onChangeText={(value) => {
                                 setQuery(value);
                                 setSelection(null);
@@ -515,6 +549,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                             returnKeyType="search"
                             editable={!logFood.isPending}
                             onSubmitEditing={() => {
+                                Keyboard.dismiss();
                                 if (normalizedQuery.length >= MINIMUM_SEARCH_LENGTH) {
                                     setRequestedQuery(normalizedQuery);
                                 }
@@ -522,11 +557,19 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                             containerStyle={styles.searchField}
                         />
                         <AppButton
-                            title="Scan"
+                            title={isSearchExperienceExpanded ? 'Done' : 'Scan'}
                             variant="secondary"
                             disabled={logFood.isPending}
-                            leftIcon={<Ionicons name="barcode-outline" size={18} color={theme.colors.onSurface} />}
-                            onPress={openBarcodeScanner}
+                            leftIcon={(
+                                <Ionicons
+                                    name={isSearchExperienceExpanded ? 'checkmark' : 'barcode-outline'}
+                                    size={18}
+                                    color={theme.colors.onSurface}
+                                />
+                            )}
+                            onPress={isSearchExperienceExpanded
+                                ? () => setIsSearchExpanded(false)
+                                : openBarcodeScanner}
                             style={styles.scanButton}
                         />
                     </View>
@@ -538,7 +581,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                             ListEmptyComponent={renderSearchEmpty}
                             ListFooterComponent={renderSearchFooter}
                             contentContainerStyle={styles.resultsContent}
-                            keyboardDismissMode="none"
+                            keyboardDismissMode="on-drag"
                             keyboardShouldPersistTaps="always"
                             showsVerticalScrollIndicator
                             style={styles.resultsList}
@@ -559,7 +602,9 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                         logFood.reset();
                     }}
                     placeholder="e.g. chili, overnight oats"
+                    returnKeyType="search"
                     editable={!logFood.isPending}
+                    onSubmitEditing={Keyboard.dismiss}
                 />
                 {selection ? renderSelectionEditor() : (
                     <FlatList
@@ -576,7 +621,7 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
                             </AppText>
                         )}
                         contentContainerStyle={styles.resultsContent}
-                        keyboardDismissMode="none"
+                        keyboardDismissMode="on-drag"
                         keyboardShouldPersistTaps="always"
                         showsVerticalScrollIndicator
                         style={styles.resultsList}
@@ -593,22 +638,47 @@ export const AddFoodSheet: React.FC<AddFoodSheetProps> = ({
             scrollable={false}
             onRequestClose={onClose}
         >
-            <SectionHeader title="Add food" description={`${formatDateOnlyForDisplay(date)} | ${formatMealPeriod(meal)}`} />
-            <View style={styles.mealControl}>
-                <AppText variant="label">Meal</AppText>
-                <OverlaySelect
-                    accessibilityLabel="Select meal"
-                    value={meal}
-                    options={MEAL_SELECT_OPTIONS}
-                    isOpen={isMealSelectorOpen}
-                    onToggle={() => setIsMealSelectorOpen((current) => !current)}
-                    onChange={(nextMeal) => {
-                        setMeal(nextMeal);
-                        setIsMealSelectorOpen(false);
-                    }}
-                />
-            </View>
-            <SegmentedControl options={ADD_FOOD_MODES} value={mode} onChange={selectMode} />
+            <Animated.View
+                testID="add-food-search-context"
+                accessibilityElementsHidden={isSearchExperienceExpanded}
+                importantForAccessibility={isSearchExperienceExpanded ? 'no-hide-descendants' : 'auto'}
+                pointerEvents={isSearchExperienceExpanded ? 'none' : 'auto'}
+                onLayout={handleSearchContextLayout}
+                style={[
+                    styles.searchContext,
+                    searchContextHeight !== null && {
+                        height: searchContextProgress.interpolate({
+                            inputRange: [0, 1],
+                            outputRange: [0, searchContextHeight]
+                        }),
+                        opacity: searchContextProgress,
+                        transform: [{
+                            translateY: searchContextProgress.interpolate({
+                                inputRange: [0, 1],
+                                outputRange: [-spacing.sm, 0]
+                            })
+                        }]
+                    },
+                    searchContextHeight === null && isSearchExperienceExpanded && styles.searchContextHidden
+                ]}
+            >
+                <SectionHeader title="Add food" description={`${formatDateOnlyForDisplay(date)} | ${formatMealPeriod(meal)}`} />
+                <View style={styles.mealControl}>
+                    <AppText variant="label">Meal</AppText>
+                    <OverlaySelect
+                        accessibilityLabel="Select meal"
+                        value={meal}
+                        options={MEAL_SELECT_OPTIONS}
+                        isOpen={isMealSelectorOpen}
+                        onToggle={() => setIsMealSelectorOpen((current) => !current)}
+                        onChange={(nextMeal) => {
+                            setMeal(nextMeal);
+                            setIsMealSelectorOpen(false);
+                        }}
+                    />
+                </View>
+                <SegmentedControl options={ADD_FOOD_MODES} value={mode} onChange={selectMode} />
+            </Animated.View>
             <View style={styles.modeContent}>{renderModeContent()}</View>
         </BottomSheetModal>
     );
@@ -659,6 +729,14 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     },
     mealControl: {
         gap: spacing.sm
+    },
+    searchContext: {
+        gap: spacing.md,
+        overflow: 'hidden'
+    },
+    searchContextHidden: {
+        height: 0,
+        opacity: 0
     },
     modeContent: {
         flex: 1,

--- a/mobile/src/components/AppButton.tsx
+++ b/mobile/src/components/AppButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, StyleSheet, View, type PressableProps, type StyleProp, type TextStyle } from 'react-native';
+import { Keyboard, Pressable, StyleSheet, View, type PressableProps, type StyleProp, type TextStyle } from 'react-native';
 import { type AppTheme, useAppTheme } from '../theme';
 import { AppText } from './AppText';
 
@@ -7,16 +7,20 @@ type AppButtonProps = Omit<PressableProps, 'android_ripple'> & {
     title: string;
     variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
     leftIcon?: React.ReactNode;
+    /** App actions finish current text entry unless they explicitly operate in place. */
+    dismissKeyboardOnPress?: boolean;
 };
 
 export const AppButton: React.FC<AppButtonProps> = ({
     title,
     variant = 'primary',
     leftIcon,
+    dismissKeyboardOnPress = true,
     disabled,
     accessibilityLabel,
     accessibilityRole,
     accessibilityState,
+    onPress,
     style,
     ...props
 }) => {
@@ -35,6 +39,10 @@ export const AppButton: React.FC<AppButtonProps> = ({
         accessibilityLabel={accessibilityLabel ?? title}
         accessibilityRole={accessibilityRole ?? 'button'}
         accessibilityState={{ ...accessibilityState, disabled: Boolean(disabled) }}
+        onPress={(event) => {
+            if (dismissKeyboardOnPress) Keyboard.dismiss();
+            onPress?.(event);
+        }}
         style={({ pressed }) => [
             styles.base,
             styles[variant],

--- a/mobile/src/components/FoodSelectionEditor.test.tsx
+++ b/mobile/src/components/FoodSelectionEditor.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
+import type { MyFoodSummary } from '@calibrate/api-client';
+import { MEAL_PERIODS } from '@calibrate/shared';
+import { createMyFoodSelection } from '../food/foodLogSelection';
+import { FoodSelectionEditor } from './FoodSelectionEditor';
+
+jest.mock('@expo/vector-icons/Ionicons', () => () => null);
+
+const savedFood: MyFoodSummary = {
+    id: 12,
+    type: 'FOOD',
+    name: 'Greek yogurt',
+    serving_size_quantity: 1,
+    serving_unit_label: 'container',
+    calories_per_serving: 120,
+    is_pinned: true
+};
+
+describe('FoodSelectionEditor', () => {
+    it('dismisses quantity input before returning to search results', () => {
+        const dismiss = jest.spyOn(Keyboard, 'dismiss').mockImplementation(jest.fn());
+        const onCancel = jest.fn();
+        const screen = render(
+            <FoodSelectionEditor
+                selection={createMyFoodSelection(savedFood)}
+                date="2026-08-07"
+                meal={MEAL_PERIODS.BREAKFAST}
+                onCancel={onCancel}
+                onSubmit={jest.fn()}
+            />
+        );
+
+        fireEvent.press(screen.getByRole('button', { name: 'Back to food results' }));
+
+        expect(dismiss).toHaveBeenCalledTimes(1);
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        dismiss.mockRestore();
+    });
+});

--- a/mobile/src/components/FoodSelectionEditor.tsx
+++ b/mobile/src/components/FoodSelectionEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Keyboard, Pressable, StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import type { FoodLogCreatePayload } from '@calibrate/api-client';
 import type { MealPeriod } from '@calibrate/shared';
@@ -81,7 +81,10 @@ export const FoodSelectionEditor: React.FC<FoodSelectionEditorProps> = ({
                     accessibilityRole="button"
                     accessibilityLabel="Back to food results"
                     disabled={isSubmitting}
-                    onPress={onCancel}
+                    onPress={() => {
+                        Keyboard.dismiss();
+                        onCancel();
+                    }}
                     style={({ pressed }) => [styles.backButton, pressed && styles.pressed]}
                 >
                     <Ionicons name="arrow-back" size={20} color={theme.colors.onSurface} />

--- a/mobile/src/components/KeyboardAwareScrollView.test.tsx
+++ b/mobile/src/components/KeyboardAwareScrollView.test.tsx
@@ -69,6 +69,24 @@ describe('KeyboardAwareScrollView', () => {
         expect(contentStyle.paddingBottom).toBe(220);
     });
 
+    it('uses compact default context spacing above the software keyboard', () => {
+        const view = render(
+            <KeyboardAwareScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+                <AppText>Form content</AppText>
+            </KeyboardAwareScrollView>
+        );
+
+        act(() => {
+            const showKeyboard = keyboardListeners.keyboardDidShow ?? keyboardListeners.keyboardWillShow;
+            showKeyboard?.();
+        });
+
+        const contentStyle = StyleSheet.flatten(
+            view.UNSAFE_getByType(ScrollView).props.contentContainerStyle
+        );
+        expect(contentStyle.paddingBottom).toBe(72);
+    });
+
     it('preserves larger configured bottom padding when the keyboard opens', () => {
         const view = render(
             <KeyboardAwareScrollView

--- a/mobile/src/components/KeyboardAwareScrollView.tsx
+++ b/mobile/src/components/KeyboardAwareScrollView.tsx
@@ -13,7 +13,7 @@ type KeyboardAwareScrollViewProps = ScrollViewProps & {
     keyboardContextHeight?: number;
 };
 
-const DEFAULT_KEYBOARD_CONTEXT_HEIGHT = 192; // Keeps validation, actions, or the first search result visible below the active field.
+const DEFAULT_KEYBOARD_CONTEXT_HEIGHT = 72; // Keeps one compact validation or action row visible without floating the input far above the keyboard.
 const WEB_KEYBOARD_OVERLAY_THRESHOLD = 80; // Ignores small visual-viewport changes caused by mobile browser chrome.
 
 /**

--- a/mobile/src/components/OverlaySelect.tsx
+++ b/mobile/src/components/OverlaySelect.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import {
+    Keyboard,
     Modal,
     Pressable,
     ScrollView,
@@ -67,6 +68,7 @@ export function OverlaySelect<T extends string>({
     }
 
     function openMenu() {
+        Keyboard.dismiss();
         anchorRef.current?.measureInWindow((x, y, width, height) => {
             setAnchorFrame({ x, y, width, height });
             onToggle();

--- a/mobile/src/components/TimeZonePickerField.test.tsx
+++ b/mobile/src/components/TimeZonePickerField.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
 import { TimeZonePickerField } from './TimeZonePickerField';
 
 jest.mock('@expo/vector-icons/Ionicons', () => () => null);
@@ -12,6 +13,16 @@ jest.mock('../utils/timezones', () => {
 });
 
 describe('TimeZonePickerField', () => {
+    it('dismisses active text input before opening an overlay selector', () => {
+        const dismiss = jest.spyOn(Keyboard, 'dismiss').mockImplementation(jest.fn());
+        const screen = render(<TimeZonePickerField value="America/New_York" onChange={jest.fn()} />);
+
+        fireEvent.press(screen.getByLabelText('Select time zone'));
+
+        expect(dismiss).toHaveBeenCalledTimes(1);
+        dismiss.mockRestore();
+    });
+
     it('offers the permission-free device timezone as a clear action', () => {
         const onChange = jest.fn();
         const screen = render(<TimeZonePickerField value="America/New_York" onChange={onChange} />);

--- a/mobile/src/components/accessibilityPrimitives.test.tsx
+++ b/mobile/src/components/accessibilityPrimitives.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react-native';
-import { StyleSheet, Text } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import { Keyboard, StyleSheet, Text } from 'react-native';
 import { AppButton } from './AppButton';
 import { AppChip } from './AppChip';
 import { SectionHeader } from './SectionHeader';
@@ -28,6 +28,39 @@ describe('mobile accessibility primitives', () => {
         const { getByRole } = render(<AppButton title="Create account" />);
 
         expect(getByRole('button', { name: 'Create account' }).props.android_ripple).toBeUndefined();
+    });
+
+    it('dismisses the keyboard before running a completed action by default', () => {
+        const calls: string[] = [];
+        const dismiss = jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => {
+            calls.push('dismiss');
+        });
+        const { getByRole } = render(
+            <AppButton title="Save meal" onPress={() => calls.push('press')} />
+        );
+
+        fireEvent.press(getByRole('button', { name: 'Save meal' }));
+
+        expect(calls).toEqual(['dismiss', 'press']);
+        dismiss.mockRestore();
+    });
+
+    it('allows an in-place button action to preserve the keyboard', () => {
+        const dismiss = jest.spyOn(Keyboard, 'dismiss').mockImplementation(jest.fn());
+        const onPress = jest.fn();
+        const { getByRole } = render(
+            <AppButton
+                title="Keep editing"
+                dismissKeyboardOnPress={false}
+                onPress={onPress}
+            />
+        );
+
+        fireEvent.press(getByRole('button', { name: 'Keep editing' }));
+
+        expect(dismiss).not.toHaveBeenCalled();
+        expect(onPress).toHaveBeenCalledTimes(1);
+        dismiss.mockRestore();
     });
 
     it('uses a text field label as its accessible name even when the visual label is hidden', () => {

--- a/mobile/src/utils/keyboard.test.ts
+++ b/mobile/src/utils/keyboard.test.ts
@@ -1,8 +1,8 @@
 import { getKeyboardAvoidingBehavior } from './keyboard';
 
 describe('keyboard avoidance', () => {
-    it('shrinks Android layouts and pads iOS layouts around the system keyboard', () => {
-        expect(getKeyboardAvoidingBehavior('android')).toBe('height');
+    it('lets Android resize its window once and pads iOS layouts around the keyboard', () => {
+        expect(getKeyboardAvoidingBehavior('android')).toBeUndefined();
         expect(getKeyboardAvoidingBehavior('ios')).toBe('padding');
         expect(getKeyboardAvoidingBehavior('web')).toBeUndefined();
     });

--- a/mobile/src/utils/keyboard.ts
+++ b/mobile/src/utils/keyboard.ts
@@ -1,8 +1,7 @@
 export type KeyboardAvoidingBehavior = 'height' | 'padding' | undefined;
 
-/** Keeps form content visible above the native keyboard on each supported platform. */
+/** Keeps form content visible without duplicating Android's window-resize handling. */
 export function getKeyboardAvoidingBehavior(platform: string): KeyboardAvoidingBehavior {
     if (platform === 'ios') return 'padding';
-    if (platform === 'android') return 'height';
     return undefined;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2700,9 +2700,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:mobile-build-tools": "node --test scripts/xcode-uuid-compatibility.test.mjs",
     "test:native:upgrade": "node scripts/native-upgrade-rehearsal.mjs",
     "test:native:upgrade:unit": "node --test scripts/native-upgrade-rehearsal.test.mjs",
+    "audit:production": "node scripts/production-dependency-audit.mjs",
     "audit:exceptions:check": "node scripts/dependency-advisory-exceptions.mjs",
     "lint": "npm run lint:backend && npm run lint:shared && npm run lint:api-client && npm run lint:mobile",
     "lint:backend": "npm --prefix backend run typecheck",
@@ -90,6 +91,9 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "overrides": {
+    "@istanbuljs/load-nyc-config@1.1.0": {
+      "js-yaml": "3.15.1"
+    },
     "xcode@3.0.1": {
       "uuid": "11.1.1"
     }

--- a/scripts/dependency-advisory-exceptions.mjs
+++ b/scripts/dependency-advisory-exceptions.mjs
@@ -15,6 +15,19 @@ export const UUID_ADVISORY_EXCEPTION = Object.freeze({
   tracker: 'https://github.com/MChartier/calibrate-health/issues/222'
 });
 
+export const IMAGE_SIZE_ADVISORY_EXCEPTION = Object.freeze({
+  advisories: Object.freeze([
+    'GHSA-w3rx-r6r6-pgpr',
+    'GHSA-5p2g-fcmc-qvqq'
+  ]),
+  allowedVersion: '1.2.1',
+  expiresAt: '2026-08-21T00:00:00.000Z',
+  references: Object.freeze([
+    'https://github.com/advisories/GHSA-w3rx-r6r6-pgpr',
+    'https://github.com/advisories/GHSA-5p2g-fcmc-qvqq'
+  ])
+});
+
 /** Match every affected range published for GHSA-w5hq-g745-h8pq, including UUID 12 and 13. */
 export function isUuidVersionAffected(uuidVersion) {
   return compareSemver(uuidVersion, '11.1.1') < 0 ||
@@ -59,10 +72,66 @@ export function evaluateUuidAdvisoryException(uuidVersions, options = {}) {
   };
 }
 
+/** Keep the no-fix image-size exception bound to Metro's currently reviewed lockfile edge. */
+export function evaluateImageSizeAdvisoryException(imageSizeVersions, options = {}) {
+  const versions = [...new Set(imageSizeVersions ?? [])].sort(compareSemver);
+  const advisoryLabel = IMAGE_SIZE_ADVISORY_EXCEPTION.advisories.join(', ');
+  if (versions.length === 0) {
+    return { ok: true, message: `${advisoryLabel} are not present in the locked graph.` };
+  }
+
+  if (versions.length !== 1 || versions[0] !== IMAGE_SIZE_ADVISORY_EXCEPTION.allowedVersion) {
+    return {
+      ok: false,
+      message:
+        `${advisoryLabel} exception only covers image-size@${IMAGE_SIZE_ADVISORY_EXCEPTION.allowedVersion}; ` +
+        `the locked graph now contains ${versions.map((version) => `image-size@${version}`).join(', ')}. ` +
+        `Re-evaluate the dependency and advisory status before changing the exception.`
+    };
+  }
+
+  const versionLabel = `image-size@${versions[0]}`;
+  if (options.strict) {
+    return {
+      ok: false,
+      message:
+        `${advisoryLabel} remain active through ${versionLabel}; production release validation ` +
+        `requires resolution. See ${IMAGE_SIZE_ADVISORY_EXCEPTION.references.join(' and ')}.`
+    };
+  }
+
+  const now = options.now ?? new Date();
+  const expiresAt = new Date(IMAGE_SIZE_ADVISORY_EXCEPTION.expiresAt);
+  if (now.getTime() >= expiresAt.getTime()) {
+    return {
+      ok: false,
+      message:
+        `${advisoryLabel} exception expired with ${versionLabel}. Upgrade Metro's dependency or ` +
+        `renew the evidence and deadline using ${IMAGE_SIZE_ADVISORY_EXCEPTION.references.join(' and ')}.`
+    };
+  }
+
+  return {
+    ok: true,
+    message:
+      `${advisoryLabel} remain temporarily accepted for ${versionLabel}; the exception expires ` +
+      `${IMAGE_SIZE_ADVISORY_EXCEPTION.expiresAt}. See ${IMAGE_SIZE_ADVISORY_EXCEPTION.references.join(' and ')}.`
+  };
+}
+
 /** Collect root and nested UUID installs so a future npm layout cannot hide an affected copy. */
 export function getLockedUuidVersions(lockfile) {
   const versions = Object.entries(lockfile.packages ?? {})
     .filter(([packagePath]) => /(^|\/)node_modules\/uuid$/.test(packagePath))
+    .map(([, metadata]) => metadata?.version)
+    .filter((version) => typeof version === 'string');
+  return [...new Set(versions)].sort(compareSemver);
+}
+
+/** Collect every image-size install so a changed Metro graph invalidates the reviewed exception. */
+export function getLockedImageSizeVersions(lockfile) {
+  const versions = Object.entries(lockfile.packages ?? {})
+    .filter(([packagePath]) => /(^|\/)node_modules\/image-size$/.test(packagePath))
     .map(([, metadata]) => metadata?.version)
     .filter((version) => typeof version === 'string');
   return [...new Set(versions)].sort(compareSemver);
@@ -73,11 +142,23 @@ export async function readLockedUuidVersions(lockfilePath = PACKAGE_LOCK_PATH) {
   return getLockedUuidVersions(JSON.parse(await readFile(lockfilePath, 'utf8')));
 }
 
+export async function readLockedImageSizeVersions(lockfilePath = PACKAGE_LOCK_PATH) {
+  return getLockedImageSizeVersions(JSON.parse(await readFile(lockfilePath, 'utf8')));
+}
+
 export async function checkDependencyAdvisoryExceptions(options = {}) {
-  const uuidVersions = options.uuidVersions ?? await readLockedUuidVersions(options.lockfilePath);
-  const result = evaluateUuidAdvisoryException(uuidVersions, options);
-  if (!result.ok) throw new Error(result.message);
-  return result.message;
+  const lockfile = options.lockfilePath
+    ? JSON.parse(await readFile(options.lockfilePath, 'utf8'))
+    : JSON.parse(await readFile(PACKAGE_LOCK_PATH, 'utf8'));
+  const uuidVersions = options.uuidVersions ?? getLockedUuidVersions(lockfile);
+  const imageSizeVersions = options.imageSizeVersions ?? getLockedImageSizeVersions(lockfile);
+  const results = [
+    evaluateUuidAdvisoryException(uuidVersions, options),
+    evaluateImageSizeAdvisoryException(imageSizeVersions, options)
+  ];
+  const failure = results.find((result) => !result.ok);
+  if (failure) throw new Error(failure.message);
+  return results.map((result) => result.message).join('\n');
 }
 
 async function main() {

--- a/scripts/dependency-advisory-exceptions.test.mjs
+++ b/scripts/dependency-advisory-exceptions.test.mjs
@@ -2,12 +2,20 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  IMAGE_SIZE_ADVISORY_EXCEPTION,
   UUID_ADVISORY_EXCEPTION,
+  evaluateImageSizeAdvisoryException,
   evaluateUuidAdvisoryException,
+  getLockedImageSizeVersions,
   getLockedUuidVersions,
   isUuidVersionAffected,
+  readLockedImageSizeVersions,
   readLockedUuidVersions
 } from './dependency-advisory-exceptions.mjs';
+import {
+  collectAuditAdvisories,
+  evaluateProductionAuditReport
+} from './production-dependency-audit.mjs';
 
 test('accepts the affected UUID version only before the exception deadline', () => {
   const result = evaluateUuidAdvisoryException(['7.0.3'], {
@@ -74,4 +82,88 @@ test('collects root and nested UUID versions from a lock graph', () => {
 
 test('reads every UUID version from the production lock graph', async () => {
   assert.deepEqual(await readLockedUuidVersions(), ['11.1.1']);
+});
+
+test('accepts only the reviewed image-size lock version before its deadline', () => {
+  const accepted = evaluateImageSizeAdvisoryException(['1.2.1'], {
+    now: new Date('2026-08-20T23:59:59.999Z')
+  });
+  const changed = evaluateImageSizeAdvisoryException(['1.2.1', '2.0.2'], {
+    now: new Date('2026-08-08T00:00:00.000Z')
+  });
+
+  assert.equal(accepted.ok, true);
+  assert.match(accepted.message, /temporarily accepted/);
+  assert.equal(changed.ok, false);
+  assert.match(changed.message, /only covers image-size@1\.2\.1/);
+});
+
+test('rejects the image-size exception at its deadline and in strict release mode', () => {
+  const expired = evaluateImageSizeAdvisoryException(['1.2.1'], {
+    now: new Date(IMAGE_SIZE_ADVISORY_EXCEPTION.expiresAt)
+  });
+  const strict = evaluateImageSizeAdvisoryException(['1.2.1'], {
+    now: new Date('2026-08-08T00:00:00.000Z'),
+    strict: true
+  });
+
+  assert.equal(expired.ok, false);
+  assert.match(expired.message, /expired/);
+  assert.equal(strict.ok, false);
+  assert.match(strict.message, /production release validation requires resolution/);
+});
+
+test('collects every locked image-size version', async () => {
+  assert.deepEqual(getLockedImageSizeVersions({
+    packages: {
+      'node_modules/image-size': { version: '1.2.1' },
+      'node_modules/other/node_modules/image-size': { version: '2.0.2' }
+    }
+  }), ['1.2.1', '2.0.2']);
+  assert.deepEqual(await readLockedImageSizeVersions(), ['1.2.1']);
+});
+
+test('resolves cyclic npm audit entries to their leaf advisories', () => {
+  const resolved = collectAuditAdvisories({
+    metro: { via: ['image-size', 'metro-config'] },
+    'metro-config': { via: ['metro'] },
+    'image-size': {
+      via: IMAGE_SIZE_ADVISORY_EXCEPTION.advisories.map((advisory) => ({
+        url: `https://github.com/advisories/${advisory}`
+      }))
+    }
+  });
+
+  assert.deepEqual(resolved.metro.advisories, [...IMAGE_SIZE_ADVISORY_EXCEPTION.advisories].sort());
+  assert.deepEqual(resolved['metro-config'].advisories, [...IMAGE_SIZE_ADVISORY_EXCEPTION.advisories].sort());
+  assert.deepEqual(resolved.metro.unresolved, []);
+});
+
+test('filters only high findings fully rooted in the reviewed image-size advisories', () => {
+  const report = {
+    vulnerabilities: {
+      metro: { severity: 'high', via: ['image-size'] },
+      'image-size': {
+        severity: 'high',
+        via: IMAGE_SIZE_ADVISORY_EXCEPTION.advisories.map((advisory) => ({
+          url: `https://github.com/advisories/${advisory}`
+        }))
+      },
+      unrelated: {
+        severity: 'high',
+        via: [{ url: 'https://github.com/advisories/GHSA-xxxx-yyyy-zzzz' }]
+      },
+      moderate: {
+        severity: 'moderate',
+        via: [{ url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc' }]
+      }
+    }
+  };
+  const result = evaluateProductionAuditReport(report, ['1.2.1'], {
+    now: new Date('2026-08-08T00:00:00.000Z')
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.exempted.map((finding) => finding.package), ['metro', 'image-size']);
+  assert.deepEqual(result.remaining.map((finding) => finding.package), ['unrelated']);
 });

--- a/scripts/production-dependency-audit.mjs
+++ b/scripts/production-dependency-audit.mjs
@@ -1,0 +1,166 @@
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  IMAGE_SIZE_ADVISORY_EXCEPTION,
+  evaluateImageSizeAdvisoryException,
+  getLockedImageSizeVersions
+} from './dependency-advisory-exceptions.mjs';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIR, '..');
+const PACKAGE_LOCK_PATH = path.join(REPOSITORY_ROOT, 'package-lock.json');
+const AUDITED_SEVERITIES = new Set(['high', 'critical']);
+
+function extractAdvisoryId(via) {
+  if (!via || typeof via !== 'object') return undefined;
+  return via.url?.match(/GHSA-[a-z0-9-]+/i)?.[0];
+}
+
+/** Resolve npm's cyclic vulnerability graph to the leaf advisories behind each package entry. */
+export function collectAuditAdvisories(vulnerabilities) {
+  const entries = vulnerabilities ?? {};
+  const advisoriesByPackage = new Map(
+    Object.entries(entries).map(([packageName, vulnerability]) => [
+      packageName,
+      new Set((vulnerability.via ?? []).map(extractAdvisoryId).filter(Boolean))
+    ])
+  );
+  const unresolvedByPackage = new Map(
+    Object.entries(entries).map(([packageName, vulnerability]) => [
+      packageName,
+      new Set(
+        (vulnerability.via ?? [])
+          .filter((via) => typeof via === 'string' && !(via in entries))
+          .map(String)
+      )
+    ])
+  );
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [packageName, vulnerability] of Object.entries(entries)) {
+      const packageAdvisories = advisoriesByPackage.get(packageName);
+      const unresolved = unresolvedByPackage.get(packageName);
+      for (const via of vulnerability.via ?? []) {
+        if (typeof via !== 'string' || !(via in entries)) continue;
+        for (const advisory of advisoriesByPackage.get(via)) {
+          if (!packageAdvisories.has(advisory)) {
+            packageAdvisories.add(advisory);
+            changed = true;
+          }
+        }
+        for (const dependency of unresolvedByPackage.get(via)) {
+          if (!unresolved.has(dependency)) {
+            unresolved.add(dependency);
+            changed = true;
+          }
+        }
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.keys(entries).map((packageName) => [packageName, {
+      advisories: [...advisoriesByPackage.get(packageName)].sort(),
+      unresolved: [...unresolvedByPackage.get(packageName)].sort()
+    }])
+  );
+}
+
+/** Exempt only high/critical entries whose complete npm dependency chain ends at the reviewed advisories. */
+export function evaluateProductionAuditReport(report, imageSizeVersions, options = {}) {
+  const exception = evaluateImageSizeAdvisoryException(imageSizeVersions, options);
+  const vulnerabilities = report?.vulnerabilities ?? {};
+  const resolved = collectAuditAdvisories(vulnerabilities);
+  const allowedAdvisories = new Set(IMAGE_SIZE_ADVISORY_EXCEPTION.advisories);
+  const exempted = [];
+  const remaining = [];
+
+  for (const [packageName, vulnerability] of Object.entries(vulnerabilities)) {
+    if (!AUDITED_SEVERITIES.has(vulnerability.severity)) continue;
+    const roots = resolved[packageName];
+    const isFullyExplainedByException =
+      exception.ok &&
+      roots.advisories.length > 0 &&
+      roots.unresolved.length === 0 &&
+      roots.advisories.every((advisory) => allowedAdvisories.has(advisory));
+    (isFullyExplainedByException ? exempted : remaining).push({
+      package: packageName,
+      advisories: roots.advisories,
+      unresolved: roots.unresolved
+    });
+  }
+
+  return {
+    ok: exception.ok && remaining.length === 0,
+    exception,
+    exempted,
+    remaining
+  };
+}
+
+function runNpmAudit() {
+  const npmExecPath = process.env.npm_execpath;
+  const command = npmExecPath ? process.execPath : process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const args = npmExecPath
+    ? [npmExecPath, 'audit', '--omit=dev', '--audit-level=high', '--json']
+    : ['audit', '--omit=dev', '--audit-level=high', '--json'];
+  return spawnSync(command, args, {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'utf8',
+    windowsHide: true
+  });
+}
+
+function describeFinding(finding) {
+  const roots = finding.advisories.length > 0
+    ? finding.advisories.join(', ')
+    : `unresolved dependencies: ${finding.unresolved.join(', ') || 'none reported'}`;
+  return `${finding.package} (${roots})`;
+}
+
+async function main() {
+  const audit = runNpmAudit();
+  if (audit.error) throw audit.error;
+
+  let report;
+  try {
+    report = JSON.parse(audit.stdout);
+  } catch {
+    throw new Error(`npm audit did not return JSON. ${audit.stderr.trim()}`.trim());
+  }
+  if (!report.vulnerabilities) {
+    throw new Error(`npm audit did not return a vulnerability report. ${report.message ?? audit.stderr}`.trim());
+  }
+
+  const lockfile = JSON.parse(await readFile(PACKAGE_LOCK_PATH, 'utf8'));
+  const result = evaluateProductionAuditReport(report, getLockedImageSizeVersions(lockfile));
+  console.log(result.exception.message);
+  if (!result.ok) {
+    if (!result.exception.ok) console.error(result.exception.message);
+    if (result.remaining.length > 0) {
+      console.error(`Unexcepted high/critical production findings: ${result.remaining.map(describeFinding).join('; ')}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Production audit has no unexcepted high/critical findings; ` +
+    `${result.exempted.length} package entries resolve only to the temporary image-size advisories.`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## What changed

- dismiss the software keyboard when users complete food search, choose a result, submit quick-add actions, open an overlay selector, or move between add-food steps
- make shared app buttons dismiss active text entry by default, with an explicit opt-out for in-place editing actions
- stop applying a second Android `KeyboardAvoidingView` resize on top of the app's configured `softwareKeyboardLayoutMode: resize`
- reduce shared focused-input context spacing from 192dp to 72dp
- collapse the add-food title, meal selector, and mode tabs while live search is active so the search field and results use the visible sheet area
- restore setup controls when the user taps Done or chooses a food, with a reduced-motion-aware transition
- add regression coverage for keyboard dismissal, compact spacing, Android avoidance, and expanded search state
- upgrade the fixable Istanbul-only `js-yaml` edge to patched `3.15.1`
- add a fail-closed production audit wrapper for the two new no-fix `image-size` advisories, limited to the reviewed `1.2.1` lock graph and expiring on 2026-08-21
- keep strict production release checks failing while the temporary exception is active, and keep unrelated or newly introduced advisories blocking CI
- rebase the branch onto current remote `master` (`190e55c`)

## Why

Food search taps preserved the system keyboard even after the user had clearly finished entering a query, forcing a separate dismissal before quantity entry. Android layouts also combined activity-level window resizing with `KeyboardAvoidingView` height adjustment and a large 192dp context offset, creating excess empty space above the keyboard. The static setup controls then consumed much of the already reduced viewport while live results were being reviewed.

The dependency audit also began reporting [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) and [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) through Expo's Metro build-tool chain. Every published `image-size` release is currently affected, so no compatible patched version exists. The temporary policy exception is restricted to Metro's locked `image-size@1.2.1`, repository-owned build assets, those exact advisory IDs, and a short deadline.

## User impact

Food search and quick entry now move cleanly between query, selection, quantity, and submission. On Android, content should sit substantially closer to the keyboard, and active search behaves like a focused in-sheet destination with more room for results.

The production audit is actionable again: the separate fixable advisory is resolved, the two upstream no-fix advisories are visible and time-bounded, and any unrelated high or critical finding still fails the workflow.

## Validation

- clean `npm.cmd ci --ignore-scripts --fund=false --no-audit`
- `npm.cmd run audit:production` (15 package entries, all rooted only in the two reviewed `image-size` advisories)
- `npm.cmd audit --json` (15 high, zero additional findings)
- `npm.cmd --prefix backend audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `npm.cmd run test:release` (25 tests)
- `npm.cmd --prefix mobile test -- --runInBand` (103 suites, 462 tests)
- `npm.cmd run lint`
- `npm.cmd run build:expo-web`
- `git diff --check`

Android emulator QA could not be run on this host because no Android SDK or `adb` installation is available.