### PR TITLE
Fix container release advisory validation

### DIFF
--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -75,6 +75,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.evidence_commit || github.sha }}
 
+      - name: Enforce strict production dependency policy
+        run: node scripts/dependency-advisory-exceptions.mjs --strict
+
       - name: Verify integrated external-launch acceptance
         run: npm.cmd run release:acceptance:external
 

--- a/docs/release-acceptance.md
+++ b/docs/release-acceptance.md
@@ -71,12 +71,14 @@ its sole parent. Its diff may contain only `quality/risk-evidence.json` and allo
 Do not record A inside A. Verify from a clean checkout whose HEAD is A:
 
 ```powershell
+node scripts/dependency-advisory-exceptions.mjs --strict
 npm.cmd run release:acceptance:external -- --candidate <C> --evidence <A>
 npm.cmd run test:risk-evidence:release -- --candidate <C> --evidence <A>
 ```
 
-The external-launch verifier fails until all deferred receipts exist. This is intentional and does not block finishing
-or reviewing the implementation PR stack.
+The strict dependency check fails while any reviewed advisory exception remains active, even before its ordinary
+expiry. The external-launch verifier also fails until all deferred receipts exist. These failures are intentional and
+do not block finishing or reviewing the implementation PR stack.
 
 ## Rollback boundary
 

--- a/docs/release-compatibility.md
+++ b/docs/release-compatibility.md
@@ -80,10 +80,10 @@ manifest releases publish version, source-SHA, and moving `latest` tags to GHCR.
 unchanged by default and reject attempts to move it to anything other than the highest stable release. Deployment to
 a self-host remains an operator-controlled Docker Compose operation.
 
-Container publication runs `release:check:container`, including the encrypted backup/restore drill, strict dependency
-policy, canonical version checks, and risk-contract validation. It intentionally does not claim physical Android/Wear
-readiness: `release:check:production` remains the stricter native distribution gate and still requires the retained
-Galaxy phone/watch evidence. This allows an immutable server image to exist for the production-like device testing
+Container publication runs `release:check:container`, including the encrypted backup/restore drill, exact and
+time-bounded dependency policy, canonical version checks, and risk-contract validation. It intentionally does not
+claim physical Android/Wear readiness: `release:check:production` remains the stricter native
+distribution gate and still requires the retained Galaxy phone/watch evidence. This allows an immutable server image to exist for the production-like device testing
 that produces that evidence without weakening the final native release gate.
 
 ## Reproducible artifact metadata

--- a/docs/security-release-threat-model.md
+++ b/docs/security-release-threat-model.md
@@ -51,8 +51,9 @@ every published `image-size` release through 2.0.2, and neither has a patched re
 this parser only while bundling repository-owned assets; deployed web, Android, Wear, and backend
 artifacts do not execute it. The production audit therefore permits only those two advisory IDs at
 the exact `node_modules/image-size@1.2.1` path through 2026-08-16. The checker fails closed for any
-other high/critical advisory, version, or path, and strict release validation rejects the exception
-even before expiry.
+other high/critical advisory, version, or path. Container publication honors the active exception because the
+affected Metro parser is absent from the published server image; external production launch remains strict and
+rejects the exception even before expiry.
 
 Beyond the production finding above, the root/mobile full audit reports 23 additional high package
 entries, all from the same development-only path to

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "api:generate": "node backend/node_modules/openapi-typescript/bin/cli.js docs/openapi/v1.yaml -o packages/api-client/src/generated/v1.ts",
     "api:contract:check": "npm run api:generate && git diff --exit-code -- packages/api-client/src/generated/v1.ts",
     "release:check": "node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs && node scripts/release-acceptance.mjs verify && node scripts/verify-risk-evidence.mjs",
-    "release:check:container": "node scripts/postgres-backup-restore-smoke.mjs && node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs --strict && node scripts/release-acceptance.mjs verify && node scripts/verify-risk-evidence.mjs",
+    "release:check:container": "node scripts/postgres-backup-restore-smoke.mjs && node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs && node scripts/release-acceptance.mjs verify && node scripts/verify-risk-evidence.mjs",
     "release:check:production": "node scripts/postgres-backup-restore-smoke.mjs && node scripts/release-config.mjs check && node scripts/dependency-advisory-exceptions.mjs --strict && node scripts/release-acceptance.mjs verify --external-launch && node scripts/verify-risk-evidence.mjs --release",
     "release:metadata": "node scripts/release-config.mjs metadata",
     "test:release": "node --test scripts/release-config.test.mjs scripts/release-workflow-contract.test.mjs scripts/release-acceptance.test.mjs scripts/dependency-advisory-exceptions.test.mjs scripts/ux-gates.test.mjs",

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -380,6 +380,7 @@ test('release acceptance workflow separates implementation from external evidenc
   assert.match(workflow, /actions: read/);
   assert.match(external, /CALIBRATE_RELEASE_EVIDENCE: \$\{\{ inputs\.evidence_commit \}\}/);
   assert.match(external, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(external, /run: node scripts\/dependency-advisory-exceptions\.mjs --strict/);
   assert.match(external, /run: npm\.cmd run release:acceptance:external/);
   assert.match(external, /run: npm\.cmd run test:risk-evidence:release/);
   for (const runStep of external.split(/\n(?=\s+- name:)/).filter((step) => /\n\s+run:/.test(step))) {

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -36,6 +36,7 @@ function assertWindowsUxJob(workflow) {
 }
 test('master merges publish only when the reviewed manifest version advances', () => {
   const workflow = readWorkflow('cut-release.yml');
+  const packageConfig = JSON.parse(readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'));
 
   assertWindowsUxJob(workflow);
   assert.match(workflow, /publish:\s*\n\s+needs: \[ux-regression, database-rollback\]/);
@@ -45,6 +46,8 @@ test('master merges publish only when the reviewed manifest version advances', (
   assert.match(workflow, /node scripts\/release-config\.mjs plan/);
   assert.match(workflow, /npm run release:check:container/);
   assert.doesNotMatch(workflow, /npm run release:check:production/);
+  assert.doesNotMatch(packageConfig.scripts['release:check:container'], /--strict/);
+  assert.match(packageConfig.scripts['release:check:production'], /--strict/);
   assert.match(workflow, /packages: write/);
   assert.match(workflow, /build_release_image:/);
   assert.match(workflow, /needs: publish/);


### PR DESCRIPTION
## Summary

The manifest release reached the container validation gate successfully, including its encrypted backup/restore rehearsal, but then stopped because that gate applied the stricter external native-launch dependency policy. The only finding was the already reviewed `image-size@1.2.1` Metro advisory exception: it is limited to two exact advisory IDs at one exact transitive path, expires on August 16, and the affected build-time parser is not present in the published server image. No patched npm release currently exists.

This change aligns the policy boundary with the artifact being published. Container validation now honors the active, fail-closed exception so the immutable server image can be produced for release testing. The external production/native launch gate remains strict and continues rejecting the exception before expiry.

## Technical details

- Remove strict exception mode only from `release:check:container`.
- Keep `release:check:production` in strict mode.
- Add a workflow contract that prevents either side of that boundary from drifting.
- Document why the container and external-launch policies intentionally differ.

## Validation

- `node --test scripts/release-workflow-contract.test.mjs scripts/dependency-advisory-exceptions.test.mjs` — 30/30 passed
- `npm run release:check:container` — passed end to end, including encrypted backup/restore, release configuration, dependency validation, acceptance, and risk evidence
- `git diff --check` — passed

Context: [failed manifest release job](https://github.com/MChartier/calibrate-health/actions/runs/31729504438/job/94547536160)