### PR TITLE
Stop auto-focusing weight entry

### DIFF
--- a/mobile/src/components/WeightEntrySheet.test.tsx
+++ b/mobile/src/components/WeightEntrySheet.test.tsx
@@ -168,6 +168,7 @@ describe('WeightEntrySheet', () => {
     it('allows a new weigh-in equal to the previous day but disables an unchanged same-day edit', async () => {
         const newEntry = renderSheet();
         await waitFor(() => expect(newEntry.getByLabelText('Weight in pounds')).toHaveProp('value', '170'));
+        expect(AccessibilityInfo.isScreenReaderEnabled).not.toHaveBeenCalled();
         expect(newEntry.getByRole('button', { name: 'Log weight' }).props.accessibilityState.disabled).toBe(false);
         newEntry.unmount();
 

--- a/mobile/src/components/WeightEntrySheet.tsx
+++ b/mobile/src/components/WeightEntrySheet.tsx
@@ -6,7 +6,6 @@ import {
     Platform,
     Pressable,
     StyleSheet,
-    TextInput,
     View
 } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -83,7 +82,6 @@ export const WeightEntrySheet: React.FC<WeightEntrySheetProps> = ({ visible, dat
     const queryClient = useQueryClient();
     const reduceMotion = useReducedMotionPreference();
     const isOnline = useOnlineStatus();
-    const inputRef = useRef<TextInput>(null);
     const resultHeadingRef = useRef<View>(null);
     const [phase, setPhase] = useState<SheetPhase>('loading');
     const [pendingAction, setPendingAction] = useState<'save' | 'delete'>('save');
@@ -198,20 +196,6 @@ export const WeightEntrySheet: React.FC<WeightEntrySheetProps> = ({ visible, dat
         setWeight(prefillMetric ? formatWeightInput(prefillMetric.weight) : '');
         setPhase('editing');
     }, [isOnline, metricsQuery.data, metricsQuery.isError, metricsQuery.isLoading, phase, prefillMetric, visible]);
-
-    useEffect(() => {
-        if (!visible || phase !== 'editing' || metricsQuery.isLoading) return;
-        let active = true;
-        let focusTimer: ReturnType<typeof setTimeout> | undefined;
-        void AccessibilityInfo.isScreenReaderEnabled().then((screenReaderEnabled) => {
-            if (!active || screenReaderEnabled) return;
-            focusTimer = setTimeout(() => inputRef.current?.focus(), reduceMotion ? 0 : 240);
-        });
-        return () => {
-            active = false;
-            if (focusTimer) clearTimeout(focusTimer);
-        };
-    }, [metricsQuery.isLoading, phase, reduceMotion, visible]);
 
     useEffect(() => {
         if (phase !== 'synced-result' && phase !== 'queued-result') return;
@@ -441,7 +425,6 @@ export const WeightEntrySheet: React.FC<WeightEntrySheetProps> = ({ visible, dat
                     </AppText>
                 )}
                 <WeightValueInput
-                    inputRef={inputRef}
                     value={weight}
                     unit={user?.weight_unit}
                     step={WEIGHT_INPUT_INCREMENT}


### PR DESCRIPTION
## What changed

- Removed the programmatic focus timer from the weight-entry sheet.
- Kept tap-to-focus and select-on-focus behavior for direct keyboard editing.
- Added regression coverage to ensure opening the sheet does not initiate the automatic focus path.

## Why

Opening weight entry immediately focused and selected the prefilled value, which also opened the system keyboard. That prevented users from first adjusting the weight with the increment and decrement controls.

The root cause was an editing-phase effect that called `focus()` after the sheet loaded. Removing that effect lets the controls remain immediately available while the keyboard opens only after the user taps the weight value.

## Validation

- `npm.cmd --prefix mobile test -- --runInBand src/components/WeightEntrySheet.test.tsx`
- `npm.cmd --prefix mobile run typecheck`
- `git diff --check`